### PR TITLE
BE-11 + FE-07: 데이터 품질 개선 + 핫픽스 동기화 (dev→main)

### DIFF
--- a/docs/ISSUES_20260418.md
+++ b/docs/ISSUES_20260418.md
@@ -1,0 +1,163 @@
+# 이슈 목록 — 2026-04-18 프론트엔드/백엔드 개발 세션
+
+> 검토일: 2026-04-19  
+> 이슈 구분: 플로우차단(타타마타) / 경고(주의) / 정보(이후 대응)
+
+---
+
+## ISSUE-01 🟥 [BLOCKER] `for-safety-manager.html` 페이지 미존재
+
+**발생 위치**: `nexas/free-diagnosis-result.html` S7 SaaS 섹션 버튼
+
+```html
+<!-- 현재 코드 -->
+<a class="btn-saas" href="for-safety-manager.html">TAI Safe 더 알아보기 →</a>
+```
+
+**증상**: 버튼 클릭 시 `nexas/for-safety-manager.html` 404 발생
+
+**원인**: 해당 페이지가 아직 제작되지 않았음. 2026-04-12 확정 사이트맵에 포함된 페이지이나 미완성 상태.
+
+**임시조치**: `for-safety-manager.html` 제작 전까지`https://safe.taieng.co.kr`로 다시 연결하거나, 링크에 `target="_blank"` 추가
+
+**우선순위**: 플로우 차단 — 즉시 대응 필요
+
+---
+
+## ISSUE-02 🟡 [WARNING] xhtml2pdf 외부 SVG 렌더링 불가 가능성
+
+**발생 위치**: `templates/diagnosis_report_paid.html` P9 (SECTION 04)
+
+```html
+<img
+  src="https://xntdkrjhgcscmqctdzyo.supabase.co/storage/v1/object/public/diagrams/11-..."
+  style="max-width: 160mm; height: auto;"
+>
+```
+
+**증상**: xhtml2pdf는 외부 URL에서 SVG를 렌더링하는 데 제약이 있음. PDF 생성 시 P9 다이어그램이 빈 영역으로 레더링되거나 에러 발생 가능성 있음.
+
+**원인**: 
+- xhtml2pdf는 외부 리소스 추적 기능이 제한적임
+- SVG MIME type 처리가 `image/svg+xml`이라 일부 환경에서 표시 안 됨
+
+**대안**:
+1. PNG로 사전 변환하여 Supabase 업로드 후 험페이지에 img 태그 교체
+2. 향후 Gotenberg(Chromium 기반) 이전 시 자동 해결예정
+3. 임시: 테이블/텍스트 방식으로 대체 (비포애프터 들어가는 입장 설명 텍스트)
+
+**우선순위**: Gotenberg 이전 전 반드시 조치 필요
+
+---
+
+## ISSUE-03 🟡 [WARNING] `/diagnosis/result/{token}` API 엔드포인트 미구현
+
+**발생 위치**: `nexas/free-diagnosis-result.html` fetchResult 함수
+
+```javascript
+const r = await fetch(`${API}/diagnosis/result/${token}`);
+```
+
+**증상**: 해당 API가 아직 구현되지 않아 404 반환 → MOCK_DATA fallback 모드로 동작
+
+**현재 실제 프로덕션 영향**: MOCK_DATA fallback이 타승 동작하지만 `?token=` 파라미터가 있는 실제 페이지에서 진단 결과가 일치하지 않음
+
+**필요 작업**: `diagnosis_integrated.py` 또는 신규 라우터에 `GET /diagnosis/result/{public_token}` 구현
+- `anonymous_diagnosis_results` 테이블에서 `partial_result` 반환 (링크 만료 검증 포함)
+
+**우선순위**: FE-BE 연동 전 반드시 전형
+
+---
+
+## ISSUE-04 🟡 [WARNING] DEV_TOKEN 사용 시 CI 해시 빈 문자열 문제
+
+**발생 위치**: `nexas/free-diagnosis.html` openInicisPopup 함수
+
+```javascript
+function openInicisPopup(params) {
+  if (typeof INIStdPay !== 'undefined') {
+    INIStdPay.pay(params);
+  } else {
+    // 이니시스 미연동 시 fallback
+    onAuthSuccess({ auth_token: 'DEV_TOKEN_' + Date.now() });
+  }
+}
+```
+
+**증상**: DEV_TOKEN으로 `onAuthSuccess` 호출 시:
+- `diagnosis_integrated.py`의 `onAuthSuccess` 내에서 `auth/check?auth_token=DEV_TOKEN_...` 요청
+- `diagnosis_auth_log` 테이블에 `DEV_TOKEN_...`으로는 레코드가 없으므로 401 반환
+- 프론트는 `remaining=3` 기본값 사용하지만 실제 인증 통과 안 됨
+
+**대안**: 개발/테스트 환경에서 DEV 모드 감지 후 `diagnosis_auth_log`에 테스트 레코드 시딩하거나, BE에서 DEV_TOKEN_ 프리픽스 탐지 시 bypass 로직 추가
+
+**우선순위**: KG이니시스 승인 전까지 유지해야 하는 데브 경로이므로 반드시 수정
+
+---
+
+## ISSUE-05 🟢 [INFO] EXTRA-1 selectAddr DOM 의존성
+
+**발생 위치**: `nexas/free-diagnosis.html` selectAddr 함수
+
+```javascript
+const addrWrap = document.querySelector(`[data-addr-prefix="${prefix}"]`)?.closest('.addr-wrap');
+const addrKey = addrWrap?.dataset?.addrKey || 'address';
+```
+
+**내용**: `renderField()`에서 생성된 `.addr-wrap[data-addr-key]` 속성을 `closest()`로 찾는 방식
+
+**위험**: 향후 `renderField()` 내 HTML 구조 변경 시 탐지 실패 가능성이 있음. 현재는 정상 동작.
+
+**대안**: `selectAddr` 호출 시 `addrKey` 인자를 함께 넘기는 방식으로 리팩토링 (베타 세솠 우선)
+
+---
+
+## ISSUE-06 🟢 [INFO] free-diagnosis.html — BUG-5/7/8/9 확인 진행 필요
+
+`nexas/docs/fix-fn08-v2-full-bugs.md` 에서 엘스툅 빠진 BUG 항목:
+
+| # | 내용 | 현황 |
+|---|---|---|
+| BUG-5 | 주소검색 재확인 | FN-FIX-1로 배열 처리 완료. 테스트 후 쿠시업 |
+| BUG-7 | 좌측 패널 동적 분기 (셉터별 문구) | 미적용 — 커틀구조상 좌측은 등록된 셀렉터 없습니다 |
+| BUG-8 | 주소 필드 최상단 노출 | 대표님 판단 대기 |
+| BUG-9 | CTA 문구 변경 | S6 HTML에서 "현재 진단에서 확인할 수 없는 영역이 있습니다" 이미 적용 |
+
+---
+
+## ISSUE-07 🟢 [INFO] `tri_state` 의무 필드 API 기준 없음
+
+**발생 위치**: `nexas/free-diagnosis.html` BUG-11 수정
+
+**내용**: DB에 `field_type = 'tri_state'`인 필드 58개가 있으나, `/diagnosis/fields` API가 이 field_type을 정상 리턴하는지 확인이 필요함.
+
+**확인 방법**: Supabase SQL로 `SELECT DISTINCT field_type FROM diagnosis_field_master` 조회
+
+---
+
+## ISSUE-08 🟢 [INFO] diagnosis_report.py — `_build_law_groups` Python 3.9 타입 힌트 호환성
+
+**발생 위치**: `routers/diagnosis_report.py`
+
+```python
+def _build_law_groups(
+    rules: List[Dict[str, Any]],
+    max_groups: int = 10,
+) -> tuple[List[Dict[str, Any]], int]:  # ← Python 3.9+ 전용
+```
+
+**설명**: `tuple[...]` 내장 타입 지정 구문은 Python 3.9+에서만 유효. 3.8 환경이면 `Tuple[...]`을 `from typing import Tuple`로 사용해야 함.
+
+**Fly.io Tokyo 실제 버전 확인 후 판단** — 현재 Fly.io는 Python 3.11 사용 중이므로 실제 플레스함.
+
+---
+
+## 향후 할 일 요약
+
+| 우선순위 | 항목 | 담당 |
+|---|---|---|
+| 타타마타 | `for-safety-manager.html` 제작 또는 임시 링크 수정 | 프론트엔드창 |
+| 타타마타 | `GET /diagnosis/result/{public_token}` BE 구현 | 백엔드창 |
+| 경고 | P9 SVG 렌더링 테스트 (xhtml2pdf 실제 실행 후 확인) | 백엔드창 |
+| 경고 | DEV_TOKEN bypass 로직 BE 추가 | 백엔드창 |
+| 정보 | `tri_state` API 필드 리턴 확인 | Supabase MCP |

--- a/docs/SESSION5_PM_20260418.md
+++ b/docs/SESSION5_PM_20260418.md
@@ -1,0 +1,49 @@
+# 세션 5 후반부 작업일지 (2026-04-18 PM)
+
+## 완료
+
+### 1. 무료 웹 결과 페이지 (free-diagnosis-result.html)
+- 실제 DB 데이터 기반 프리뷰 HTML 생성 및 육안 확인
+- 8섹션 구조: 위험도헤더 → 요약카드 → 법령뱃지 → 법률별아코디언 → 기안PDF CTA → 유료CTA → SaaS → 면책
+
+### 2. 기안용 PDF (proposal-pdf) — v1.0.2
+- API: `GET /diagnosis/proposal-pdf/{public_token}`
+- 라우터: `routers/diagnosis_proposal.py`
+- 템플릿: `templates/proposal_pdf.html`
+- 한글 폰트: NanumGothic (Dockerfile에 fonts-nanum + fontconfig 추가)
+- 한국어 과태료 텍스트 파싱: `_parse_penalty_krw()` ("300만원 이하 과태료" → 3,000,000)
+- str 타입 규칙 항목 처리: `isinstance(r, dict)` 필터
+
+### 3. 유료 상세 PDF (diagnosis-report-pdf)
+- API: `GET /diagnosis/report-pdf/{public_token}`
+- 라우터: `routers/diagnosis_report.py`
+- 템플릿: `templates/diagnosis_report_paid.html`
+- ⚠️ 아직 미검증 (내일 검증 예정)
+
+### 4. 프로덕션 핫픽스 8건
+| # | 커밋 | 원인 | 수정 |
+|---|---|---|---|
+| 1 | 6737b2b | precedent_api.py SyntaxError (머지 깨짐) | dev 정상 버전 복원 |
+| 2 | de93171 | diagnosis_transform.py 잘못된 import | import 경로 + 호환 함수 |
+| 3 | 0e30df5 | penalty_amount 한국어 텍스트 ValueError | _parse_penalty_krw 파서 |
+| 4 | ae75825 | key_obligations str 배열 AttributeError | isinstance 필터 |
+| 5 | e7267b5 | jinja2 미설치 ModuleNotFoundError | requirements.txt 추가 |
+| 6 | 56c3f15 | fonts-nanum 추가 (대표님) | Dockerfile 수정 |
+| 7 | 0cbdfd2 | @font-face 주입 (대표님) | proposal_pdf.html 수정 |
+| 8 | 455e01f | fontconfig 누락 (fc-cache not found) | Dockerfile에 fontconfig 추가 |
+
+### 5. 인프라 변경
+- `requirements.txt`: jinja2 추가
+- `Dockerfile`: fonts-nanum, fontconfig 추가
+
+## 미완료 / 내일 이어서
+- 유료 상세 PDF 검증 (diagnosis_report.py)
+- 기안용 PDF 내용 수정 (대표님 피드백 반영)
+- 무료 웹 결과 페이지 S6/S7 섹션 수정 3건
+- CI/CD 배포 전 검증 파이프라인 도입 (py_compile + 실데이터 테스트)
+
+## 교훈
+- dev→main 머지 후 반드시 `py_compile routers/*.py` 전체 검사
+- `create_or_update_file`로 부분 코드만 넣으면 전체 파일이 덮어씌워짐 → 항상 전체 파일 전송
+- DB 데이터 구조(penalty_amount=텍스트, key_obligations=str배열) 사전 확인 필수
+- Dockerfile 변경 시 모든 의존 패키지(fontconfig 등) 확인

--- a/docs/SESSION_20260418_FRONTEND_BACKEND.md
+++ b/docs/SESSION_20260418_FRONTEND_BACKEND.md
@@ -1,0 +1,166 @@
+# 세션 작업 내역 — 2026-04-18 프론트엔드/백엔드 개발
+
+> 기록일: 2026-04-19  
+> 세션 유형: 프론트엔드창 + 백엔드창 병행  
+> 커밋 기준 리포: taiengineering/taieng (main), taiengineering/tai-api (dev)
+
+---
+
+## 완료 작업 목록
+
+### [FE-01] nexas/free-diagnosis.html — FN-FIX-1~7 적용
+**리포**: taiengineering/taieng · **브랜치**: main  
+**커밋**: `3eae556`
+
+| # | 항목 | 내용 |
+|---|---|---|
+| FN-FIX-1 🔴 | 주소 검색 배열 처리 | `searchAddr()` — `json.data` 배열 처리, 복수 결과 드롭다운 / `selectAddr(prefix, idx)` 인덱스 수신 |
+| FN-FIX-2 🔴 | auth/check 호출 방식 | `X-Auth-Token` 헤더 → `?auth_token=` query param |
+| FN-FIX-3 🔴 | disclaimer API 필드 | body → `{auth_token, agreed:true}` / 응답 파싱 data 래핑 제거 |
+| FN-FIX-4 🟡 | 건축물대장 언급 제거 | 3곳 → "사업장 정보" 문구 / 좌측 패널 텍스트 |
+| FN-FIX-5 🟡 | 면책 문구 교체 | 확정 문구 (법률 상담 아님 명시) |
+| FN-FIX-6 🟡 | 헤더 제거 | `tai-header` div, `header.js`, `nav-auth.js` 3줄 삭제 |
+| FN-FIX-7 🟡 | price-tier 파라미터 | `total_floor_area=` → `floor_area=` |
+
+---
+
+### [FE-02] nexas/free-diagnosis.html — BUG-1~12 + EXTRA-1~3 적용
+**리포**: taiengineering/taieng · **브랜치**: main  
+**커밋**: `f2f26d6`  
+**참조**: `nexas/docs/fix-fn08-v2-full-bugs.md`
+
+#### 지시된 BUG-1~12
+| # | 내용 |
+|---|---|
+| BUG-1 🔴 | `renderField()` — `'address' \|\| 'project_address'` 조건 추가 (건설 주소 검색버튼 미노출 수정) |
+| BUG-2 🔴 | `submitFree()` 상단 필수 필드 + 주소 별도 validation 추가 |
+| BUG-3 🔴 | `renderFreeResult(null)` — "진단을 실행할 수 없습니다" + `paidCta` 숨김 |
+| BUG-4 🔴 | HTML — `<h5>` 문구 수정, `<p>` 태그 제거 |
+| BUG-6 🟡 | `loadFreeForm()` — 면책 체크박스 + 버튼 초기화 |
+| BUG-10 🔴 | `startPayment()` — `confirm()` 다이얼로그 추가 (입력완료/전체/금액/경고) |
+| BUG-11 🔴 | `renderField()` — `tri_state` 분기 추가 (예/아니오/모름 3버튼) + `setTriState()` 신규 함수 |
+| BUG-12 🔴 | number input — `inputmode="numeric"` + `pattern="[0-9]*"` + `oninput` 한글 차단 |
+
+#### 추가 발견 EXTRA-1~3
+| # | 내용 |
+|---|---|
+| EXTRA-1 🔴 | `selectAddr()` — `addr-wrap`의 `data-addr-key` 속성으로 `project_address` vs `address` 구분해 올바른 키로 `setVal()` 호출 |
+| EXTRA-2 🟡 | `selectSector()` — 섹터 변경 시 `formValues['free']` + `paidFee` 초기화 |
+| EXTRA-3 🟡 | `goToPaidDirect()` — `btnBackToResult`가 null일 때 optional chaining 처리 |
+
+---
+
+### [FE-03] nexas/free-diagnosis-result.html — 8섹션 전면 재작성
+**리포**: taiengineering/taieng · **브랜치**: main  
+**커밋**: `386d15d`  
+**참조**: `taiengineering/tai-api docs/WORK_ORDER_20260418_free_result_page.md`
+
+| 섹션 | 내용 |
+|---|---|
+| S1 위험도 헤더 | risk_level → HIGH/MEDIUM/LOW 색상 분기, 건수 표시, 섹터 태그, blink 애니메이션 |
+| S2 요약 카드 | 선임/점검·검사/조치/보고·신고 4열 그리드, highlight 스타일 |
+| S3 법령 배지 | law_badges[] pill, 클릭 시 해당 아코디언 스크롤 + active 표시 |
+| S4 법률별 아코디언 | law_name 그룹핑, 첫 3개 펼침, 의무유형 뱃지+주기+제출기관+과태료+D-day urgentTag |
+| S5 기안 PDF | "준비 중" 상태 버튼 (preparing 스타일) |
+| S6 유료 CTA | 필요성 먼저 → 버튼 클릭 후 가격 노출, PRICING_FINAL.md 반영 |
+| S7 SaaS 전환 | #11 업무분산 SVG, 3섹터 플랜 카드, safe.taieng.co.kr 링크 |
+| S8 면책 + 푸터 | 확정 면책 문구, contact/www, 다시 진단하기 |
+
+- MOCK_DATA 포함 (BUILDING, total=205, laws=18개)
+- `?token=` → API fetch → 실패 시 MOCK_DATA fallback
+
+---
+
+### [FE-04] nexas/log-in.html — 회원가입 폼 placeholder 제거
+**리포**: taiengineering/taieng · **브랜치**: main  
+**커밋**: `4db2c25`
+
+| 필드 | 변경 전 | 변경 후 |
+|---|---|---|
+| 이름 | `홍길동` | 제거 |
+| 이메일 | `example@company.com` | 제거 |
+| 휴대폰 번호 | `01012345678` | 제거 |
+| 비밀번호 | `8자 이상` | 유지 |
+| 비밀번호 확인 | `비밀번호 재입력` | 유지 |
+
+---
+
+### [BE-01] 유료 상세 PDF 템플릿 + 엔드포인트 + main.py 등록
+**리포**: taiengineering/tai-api · **브랜치**: dev  
+**커밋**: `14ed0d8`  
+**참조**: `docs/WORK_ORDER_20260418_paid_report_pdf.md`
+
+#### 생성 파일 3개
+
+**1. `templates/diagnosis_report_paid.html`** — Jinja2 A4 PDF 템플릿 (13~14p)
+
+| 페이지 | 내용 |
+|---|---|
+| P1 | 표지 (다크 네이비+블루 그라디언트, 회사명/날짜/접수번호) |
+| P2 | 경영진 요약 (big-num 3개 + 4칸 그리드 + TOP5 리스크 + 최대과태료) |
+| P3 | 목차 + 면책조항 |
+| P4 | SECTION 01 시설 개요 (overview-grid, 중대재해법 박스) |
+| P5~7 | SECTION 02 법률별 의무 (`{% for group in law_groups %}`) |
+| P8 | SECTION 03 처벌 조항 (penalty_rules, 중대재해 경고 박스) |
+| **P9** | **SECTION 04 결론 = SaaS 안내** ← 결재권자 마지막 페이지, #11 SVG 포함 |
+| 부록 A | 전체 rules_table `{% for r in all_rules %}` |
+| 부록 B | 점검 일정 (inspection_rules, cycle_base_guide 포함) |
+| 부록 C | 선임 상세 (appointment_rules, qualification_required) |
+| 부록 D | 용어 + 참고법령 + 연락처 |
+
+**2. `routers/diagnosis_report.py`** — v1.0.0
+- `GET /diagnosis/report-pdf/{public_token}`
+- FREE tier_code → 402 차단
+- `anonymous_diagnosis_results` 조회 → law_groups 전처리 (건수 내림차순 상위 10개)
+- `_build_top5_risks()`: 선임 → 과태료 있는 항목 → 나머지 순 우선순위
+- Jinja2 렌더링 → xhtml2pdf → `application/pdf` Content-Disposition: attachment
+- 온디맨드 생성 (Storage 저장 없음)
+
+**3. `main.py` v5.31.0**
+- `from routers.diagnosis_report import router as diagnosis_report_router` 추가
+- 공개 엔드포인트로 등록 (인증 없이 public_token으로 접근)
+
+#### Jinja2 변수 목록 (diagnosis_report.py → 템플릿)
+```
+company_name, report_date, receipt_no, sector_label, report_type, engine_version
+business_no, ceo_name, address, industry_type, worker_count, area, floors
+equip_summary, hazard_summary
+total, appointment_count, inspection_count, action_count, report_notify_count
+risk_level, law_count, max_penalty_text, csia_applicable
+top5_risks, law_groups, remaining_law_count
+all_rules, inspection_rules, appointment_rules
+recommended_plan_name, recommended_plan_price
+```
+
+---
+
+### [FE-05] nexas/free-diagnosis-result.html — S7/S6/무료표현 3건 수정
+**리포**: taiengineering/taieng · **브랜치**: main  
+**커밋**: `50c3089`
+
+| 수정 | 내용 |
+|---|---|
+| 수정 1 (S7) | 제목 "엑셀 대신 자동화" → "TAI Safe가 해결합니다" / 장점 3가지 리스트 (①②③) / 버튼 "더 알아보기" / 링크 `for-safety-manager.html` |
+| 수정 2 (S6) | `startPaid()` — `PAID_CODE_MAP` + `currentSector` 추가 / URL: `free-diagnosis.html?paid=BUILDING_PAID1&step=payment` |
+| 수정 3 (전체) | TAI Safe "무료" 표현 제거 (S5 기안PDF 무료는 유지) |
+
+---
+
+## 미기재 항목 (이번 세션 외 선행 작업)
+
+다음 항목들은 이전 세션에서 완료되었으나 작업 내역 문서 미등록:
+
+| 파일 | 내용 | 리포 |
+|---|---|---|
+| `nexas/patents.html` | 히어로 섹션 재작업 (풀블리드 배경 + 좌측 카피 오버레이, SHA: b13fd2ef) | taieng/main |
+| `nexas/docs/workorder-fn08-diagnosis-page.md` | FN-08 워크오더 작성 완료 | tai-admin/main |
+| `docs/WORK_ORDER_20260418_free_result_page.md` | 무료 결과 페이지 워크오더 | tai-api/dev |
+| `docs/WORK_ORDER_20260418_paid_report_pdf.md` | 유료 PDF 워크오더 | tai-api/dev |
+| `docs/DIAGNOSIS_REPORT_STRUCTURE.md` | 리포트 구조 설계서 | tai-api/dev |
+| `docs/PRICING_FINAL.md` | 가격 확정 문서 | tai-api/dev |
+
+---
+
+## 발견 이슈 목록
+
+자세한 이슈 내역은 `docs/ISSUES_20260418.md` 참조.

--- a/docs/issue-log-2026-04-19.md
+++ b/docs/issue-log-2026-04-19.md
@@ -1,0 +1,58 @@
+# 이슈 로그 — 2026-04-19
+
+---
+
+## 이슈#2 (해결): /transform 엔드포인트 미존재
+
+**발견:** JS 코드에서 `fetch(\`${API}/anonymous-diagnosis/${token}/transform\`)` 호출  
+**원인:** 백엔드에 `/transform` 엔드포인트 없음 → 404  
+**결정:** JS 수정 없이 백엔드에서 처리 (목적이 `/{token}`과 다름)
+- `/{token}`: 인증 조건에 따라 partial/full 조건부 반환
+- `/{token}/transform`: 항상 표준 스키마 반환 (인증 불필요)
+
+**해결:** `anonymous_diagnosis.py`에 `GET /{token}/transform` 추가  
+커밋: `cf08b6ba`
+
+---
+
+## 이슈: BE-10 오타 및 보안 문제 5건
+
+**발견:** 기획창 코드 리뷰 (`docs/fix-be10-review.md`)  
+**내용:**
+
+| # | 분류 | 상세 |
+|---|---|---|
+| FIX-1 | 오타 | "면접" → "면책" 8곳 |
+| FIX-2 | 문구 | DISCLAIMER_TEXT 확정 문구 미적용 |
+| FIX-3 | 오타 | 가격판정 설명 "으로" → "로" 4곳, "권로" → "으로" 2곳 |
+| FIX-4 | 인코딩 | callback docstring 깨짐 문자 |
+| FIX-5 | 보안 | CI 평문을 DB에 저장하는 문제 |
+
+**해결:** diagnosis_integrated.py v1.0.1  
+커밋: `ae849a39`
+
+---
+
+## 이슈: API 서버 과부하 (대량 업데이트 시 서버 다운)
+
+**현상:** 대량 업데이트(법령엔진 rule 비활성화, 일정 재생성 등) 진행 시 서버 느려짐 또는 다운  
+**원인 3가지:**
+1. supabase-py가 동기(sync) 클라이언트 → FastAPI thread 풀 고갈
+2. `get_supabase()` 매 호출마다 새 연결 → Supabase connection pool 초과
+3. Fly.io shared-cpu-1x (256MB) → 대량 JSONB 적재 시 OOM
+
+**청크 처리의 문제점:**
+- supabase-py에서 `UPDATE + .in_()` 미지원
+- asyncio.sleep()이 엔드포인트 응답 블로킹
+- 트랜잭션 없어 부분 실패 시 DB 불일치 위험
+- APScheduler 중복 실행 시 race condition
+
+**권장 해결책:**
+- 단기: `fly scale memory 512` (OOM 해소)
+- 중기: 대량 작업은 `BackgroundTasks`로 분리 → 즉시 응답
+- 중기: 다단계 트리 순회를 재귀 쿼리 → PostgreSQL CTE 한 방으로
+- 장기: CRUD → Supabase PostgREST Direct (이미 계획 중)
+
+**즉시 위험 지점:** law_rule_generator, schedule_pipeline, precedents/collect 루프
+
+**상태:** 미해결 (하드웨어 증설 없이 코드 패턴 변경 필요)

--- a/docs/session-2026-04-19-backend.md
+++ b/docs/session-2026-04-19-backend.md
@@ -1,0 +1,127 @@
+# 백엔드 세션 작업내역 — 2026-04-19
+
+**담당:** 백엔드 창 (tai-api, dev 브랜치)  
+**PR #1:** dev→main 미머지 (다수 BE 작업 누적)
+
+---
+
+## 완료 작업
+
+### BE-08: 진단 기반 SaaS 플랜 추천 API v1.0.0
+
+| 항목 | 내용 |
+|---|---|
+| 파일 | `routers/diagnosis_plan_recommend.py` v1.0.0 |
+| 엔드포인트 | `GET /diagnosis/{diagnosis_id}/recommend-plan` (공개) |
+| 등록 | main.py v5.29.0 |
+| 로직 | AI 없음. severity → obl_cnt → workers 조건 분기 |
+| 워크오더 | `docs/workorder-be08-plan-recommend.md` |
+| FN-06 워크오더 | `docs/workorder-fn06-plan-recommend.md` (프론트 창 전달) |
+
+**DB 검증:**
+| diagnosis_id | sector | severity | 추천 |
+|---|---|---|---|
+| f48fbff2 | INDUSTRY | CRITICAL | PRO 249K ✅ |
+| 233cc6de | CONSTRUCTION | CRITICAL | PREMIUM 385K ✅ |
+
+---
+
+### BE-09: 익명 진단 토큰 기반 플랜 추천
+
+| 항목 | 내용 |
+|---|---|
+| 파일 | `routers/anonymous_diagnosis.py` 내부 추가 |
+| 엔드포인트 | `GET /anonymous-diagnosis/{token}/recommend-plan` |
+| 핵심 | BE-08 함수 import 재사용, 코드 중복 0줄 |
+| main.py | 변경 없음 (기존 라우터 내부 추가) |
+| 워크오더 | `docs/workorder-be09-anon-recommend.md` |
+
+**sector 보정 매핑:**
+| 입력 | 출력 |
+|---|---|
+| MANUFACTURING | INDUSTRY |
+| SPECIAL_FACILITY | BUILDING |
+
+---
+
+### 이슈#2 해결: GET /{token}/transform 엔드포인트 추가
+
+**원인:** JS에서 `fetch(\`${API}/anonymous-diagnosis/${token}/transform\`)` 참조하는데  
+백엔드에 `/transform` 엔드포인트가 없었음.
+
+**결정:** JS 수정 없이 백엔드 추가 (목적이 `/{token}`과 다름 — 항상 표준 스키마 반환)  
+**처리:** `anonymous_diagnosis.py`에 `GET /{token}/transform` 추가  
+**재사용:** `diagnosis_transform.py` 함수 import (중복 0줄)  
+**응답:** headline / obligations / warnings / exposure / inspection_schedule / roi 표준 스키마
+
+---
+
+### BE-10: 법령진단 통합 백엔드 v1.0.0
+
+| 항목 | 내용 |
+|---|---|
+| 파일 | `routers/diagnosis_integrated.py` v1.0.0 |
+| main.py | v5.30.0 |
+| 워크오더 | `docs/workorder-be10-diagnosis-backend.md` |
+
+**DB migration `be10_free_diagnosis_backend`:**
+| 대상 | 내용 |
+|---|---|
+| `anonymous_diagnosis_results` (신규) | ci_hash / auth_log_id / disclaimer_log_id / tier_code / paid_amount 포함 |
+| `diagnosis_disclaimer_log` (신규) | 면책 동의 기록 (ci_hash, 문구 스냅샷, IP) |
+| `diagnosis_auth_log.auth_token` (추가) | FE 노출용 임시 UUID 세션 토큰 |
+
+**엔드포인트 7개 (모두 공개):**
+| TASK | URL | 핵심 |
+|---|---|---|
+| 1-A | `POST /diagnosis/auth/prepare` | 이니시스 팝업 파라미터 |
+| 1-B | `POST /diagnosis/auth/callback` | CI→ci_hash→auth_token HTML |
+| 2 | `GET /diagnosis/auth/check` | free_count/limit/remaining |
+| 4 | `GET /diagnosis/price-tier` | 면적/공사금액 자동판정 |
+| 6 | `POST /diagnosis/disclaimer` | 면책 동의 저장 |
+| 3 | `POST /diagnosis/run` | 무료(횟수제한)/유료(payment_ref) 동일 API |
+| 5 | `POST /diagnosis/upgrade` | 차액 결제 → 엔진 재실행 |
+
+**TASK 7 — diagnosis_plan_recommend.py v1.1.0:**
+- `recommended`: monthly_krw / pricing_note / is_custom **제거** → `necessity` 추가
+- `comparison`: TAI Safe 연간비용 **제거**, 과태료 위험만 유지
+- `alternatives`: monthly **제거**
+
+**면책 확정 문구:**
+> 본 진단 결과는 현행 법령과 사업장 정보를 정밀 분석하여 적용 가능한 법적 의무를 도출한 것입니다. 본 서비스는 법률 상담·자문·의견 제공이 아니며, 개별 사안에 대한 법적 판단이나 해석을 포함하지 않습니다. 실제 행정 처분·감독 기준은 관할 기관의 판단에 따라 달라질 수 있으므로, 구체적 법률 적용이 필요한 경우 관할 행정기관 또는 법률 전문가에게 확인하시기 바랍니다.
+
+---
+
+### fix(BE-10): 5건 수정 — diagnosis_integrated.py v1.0.1
+
+| Fix | 내용 |
+|---|---|
+| FIX-1 | "면접" → "면책" 오타 전체 8곳 |
+| FIX-2 | DISCLAIMER_TEXT 확정 문구 교체 |
+| FIX-3 | 가격 판정 설명 오타 4곳 ("대형건물으로" → "대형건물로" 등) |
+| FIX-4 | callback docstring 인코딩 깨짐 수정 |
+| FIX-5 | CI 평문 저장 제거 (보안) — `"ci": ""` |
+
+---
+
+## 커밋 이력 (dev 브랜치, 이번 세션)
+
+| SHA | 내용 |
+|---|---|
+| 42be77e6 | feat(BE-10): 법령진단 통합 백엔드 v1.0.0 + main.py v5.30.0 |
+| ae849a39 | fix(BE-10): 5건 수정 v1.0.1 |
+| 9cd6259d | feat(BE-08): diagnosis_plan_recommend.py v1.0.0 + FN-06 워크오더 |
+| ade648a8 | feat(BE-09): 익명 진단 token recommend-plan |
+| cf08b6ba | fix(이슈#2): GET /{token}/transform 엔드포인트 추가 |
+
+---
+
+## PENDING 사항
+
+| 항목 | 내용 |
+|---|---|
+| **PR #1 머지** | dev→main 미머지 (기획창 승인 후) |
+| **Fly.io Secrets** | INICIS_VERIFY_MID, INICIS_VERIFY_SITE_CD, INICIS_VERIFY_SITE_KEY, INICIS_VERIFY_RETURN_URL |
+| **Fly.io 전용 IP** | `flyctl ips allocate-v4 --dedicated` → 이니시스 IP 등록 |
+| **FN-06** | 프론트 창: 진단 결과 하단 추천 카드 UI |
+| **SB-06** | `POST https://api.taieng.co.kr/precedents/collect` 1회 수동 실행 |

--- a/routers/legal_engine.py
+++ b/routers/legal_engine.py
@@ -1,6 +1,14 @@
 """
-법령 판정 엔진 라우터 — v5.6.8
+법령 판정 엔진 라우터 — v5.7.0
 =================================
+v5.7.0 (2026-04-19):
+  BE-11: 무료 진단 결과 데이터 품질 개선
+  Task 1: remarks 우선 → obligation_summary 폴백 (사람 언어 표시)
+  Task 2: penalty_summary 빈 값 시 의무 유형별 기본 문구 (_get_penalty_fallback)
+  Task 3: 건축법 제35조 중복 → remarks 우선으로 각 의무 구분 자동 해결
+  Task 4: cycle_unit_std 있는 상시의무 → due_info: {} (D-day 미표시)
+  Task 5: result_data에 risk_reason 필드 추가
+
 v5.6.8 (2026-04-15):
   BE-1: diagnose/step1 완료 시 inspection_sets 자동 생성 (모든 섹터)
   BE-3: contract_amount_eok 필드 설명 추가 (단위: 억원 명확화)
@@ -40,7 +48,7 @@ from db.supabase_client import get_supabase
 
 router = APIRouter(prefix="/legal-engine", tags=["법령엔진"])
 
-ENGINE_VERSION = "5.6.8"  # v5.6.8: diagnose/step1 완료 시 inspection_sets 자동 생성
+ENGINE_VERSION = "5.7.0"  # v5.7.0: BE-11 데이터 품질 개선
 
 
 # ──────────────────────────────────────────────
@@ -364,9 +372,37 @@ def _calc_due_date(due_days) -> dict:
             "urgency": "IMMEDIATE" if d <= 3 else ("URGENT" if d <= 14 else "NORMAL")}
 
 
+# ── BE-11 Task 2: penalty_summary 빈 값 시 의무 유형별 기본 문구 ──────────
+def _get_penalty_fallback(obligation_type: str) -> str:
+    """
+    penalty_summary 빈 문자열일 때 의무 유형에 따라 기본 안내 문구 반환.
+
+    실제 법적 벌칙이 없는 의무(행정지도 대상)와 구분하기 위해
+    obligation_type별로 다른 문구를 사용한다.
+    """
+    _MAP = {
+        "DOCUMENT":    "미보존 시 과태료 부과 가능",
+        "APPOINT":     "미선임 시 과태료 부과 가능",
+        "INSPECT":     "미실시 시 과태료 부과 가능",
+        "REPORT":      "미신고 시 과태료 부과 가능",
+        "NOTIFY":      "미신고 시 과태료 부과 가능",
+        "BEFORE_WORK": "미이행 시 과태료 부과 가능",
+        "ACTION":      "관련 벌칙 확인 필요",
+        "OTHER":       "관련 벌칙 확인 필요",
+    }
+    return _MAP.get((obligation_type or "").upper(), "관련 벌칙 확인 필요")
+
+
 def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
-    """v5.6.2: inspection 4필드(언제/누가/무엇/어떻게) 완비"""
-    desc = (rule.get("obligation_summary") or rule.get("remarks") or "").strip()
+    """
+    v5.7.0: BE-11 데이터 품질 개선
+      - Task 1: remarks 우선 → obligation_summary 폴백 (사람 언어)
+      - Task 2: penalty_summary 빈 값 시 _get_penalty_fallback 적용
+      - Task 4: cycle_unit_std 있으면 due_info: {} (상시 의무 D-day 미표시)
+    """
+    # Task 1: remarks 우선, obligation_summary 폴백
+    desc = (rule.get("remarks") or rule.get("obligation_summary") or "").strip()
+
     target_code = _normalize_target_code(rule.get("appointment_target_code") or "")
     submit_org_code    = rule.get("submit_org_code") or ""
     executor_type_code = rule.get("executor_type_code") or ""
@@ -375,6 +411,15 @@ def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
     cycle_label = _get_inspection_cycle_label(rule)
     cycle_unit, cycle_int = CYCLE_CODE_MAP.get(cycle_code, ("", 0))
     schedule_type = _get_schedule_type(rule)
+
+    # Task 2: penalty_summary 빈 값 처리
+    _obl_type = _resolve_obligation_type(rule)
+    _pen_raw  = rule.get("penalty_summary") or ""
+    _penalty  = _pen_raw.strip() if _pen_raw.strip() else _get_penalty_fallback(_obl_type)
+
+    # Task 4: 상시 의무(cycle_unit_std 있음)는 due_info 억제
+    _is_recurring = bool(rule.get("cycle_unit_std"))
+
     return {
         "rule_id": rule.get("rule_id", ""), "rule_type": str(rule.get("rule_type_code") or ""),
         "law_name": rule.get("law_name") or "", "law_article": rule.get("law_article") or "",
@@ -391,15 +436,17 @@ def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
         "executor_type_label": EXECUTOR_TYPE_MAP.get(executor_type_code, executor_type_code),
         "condition_code": rule.get("condition_code") or "",
         "condition_value": rule.get("condition_value"),
-        "penalty_amount": rule.get("penalty_summary") or "", "penalty_summary": rule.get("penalty_summary") or "",
-        "source_label": "", "obligation_type": _resolve_obligation_type(rule),
+        "penalty_amount": _penalty, "penalty_summary": _penalty,
+        "source_label": "", "obligation_type": _obl_type,
         "appointment_required": bool(rule.get("appointment_required")),
         "inspection_required": bool(rule.get("inspection_required")),
         "action_required": bool(rule.get("action_required")),
         "report_required": bool(rule.get("report_required")),
         "notify_required": bool(rule.get("notify_required")),
         "form_code": rule.get("form_code") or "", "form_url": rule.get("form_url") or "",
-        "due_days": rule.get("due_days"), "due_info": _calc_due_date(rule.get("due_days")),
+        "due_days": rule.get("due_days"),
+        "is_recurring": _is_recurring,                                      # Task 4
+        "due_info": {} if _is_recurring else _calc_due_date(rule.get("due_days")),  # Task 4
         "sector": rule.get("sector") or "", "diagnosis_stage": rule.get("diagnosis_stage"),
         "submit_org_code": submit_org_code,
         "submit_org_label": SUBMIT_ORG_MAP.get(submit_org_code, submit_org_code),
@@ -885,9 +932,11 @@ async def diagnose_step1(body: DiagnoseStep1Body):
     for x in applicable:
         c = (x.get("law_category_code") or x.get("law_name") or "").strip()
         if c and c not in seen: seen.add(c); law_cats.append(c)
+
+    # Task 1: remarks 우선 → obligation_summary 폴백 (사람 언어 표시)
     key_obligations: List[str] = []
     for x in applicable[:20]:
-        t = (x.get("obligation_summary") or x.get("remarks") or "").strip()
+        t = (x.get("remarks") or x.get("obligation_summary") or "").strip()
         if t and t not in key_obligations: key_obligations.append(t)
 
     insp_by_type = {
@@ -896,10 +945,31 @@ async def diagnose_step1(body: DiagnoseStep1Body):
         "ON_DEMAND":   [r for r in triggered["inspection"] if r.get("schedule_type") == "ON_DEMAND"],
     }
 
+    # Task 5: risk_reason 필드 생성
+    all_items_flat = (
+        triggered["appointment"] + triggered["inspection"] +
+        triggered["action"] + triggered["report"] + triggered["notify"]
+    )
+    urgent_count = len([r for r in all_items_flat if (r.get("due_info") or {}).get("urgency") == "URGENT"])
+    _max_pen = next(
+        (r.get("penalty_summary") or r.get("penalty_amount") or ""
+         for r in all_items_flat
+         if (r.get("penalty_summary") or r.get("penalty_amount") or "").strip()
+         and "확인 필요" not in (r.get("penalty_summary") or "")
+         and "부과 가능" not in (r.get("penalty_summary") or "")),
+        ""
+    )
+    risk_reason = f"적용 법령 {len(law_names)}개, 법적 의무 {total_applicable}건"
+    if urgent_count > 0:
+        risk_reason += f", 긴급 이행 {urgent_count}건"
+    if _max_pen:
+        risk_reason += f", 최대 {_max_pen}"
+
     result_data = {
         "factory_id": factory_id or None, "sector": sector_raw, "sector_groups": sector_groups,
         "step": 1, "engine_version": ENGINE_VERSION, "evaluated_at": evaluated_at,
         "facility_context": facility_ctx, "risk_level": risk,
+        "risk_reason": risk_reason,  # Task 5
         "applicable_law_categories": law_cats, "appointment_required_flag": appointment_n > 0,
         "key_obligations": key_obligations, "law_badges": law_names,
         "obligations": obligations, "rules_table": rules_table,
@@ -936,7 +1006,7 @@ async def diagnose_step1(body: DiagnoseStep1Body):
         except Exception as e: print(f"[DIAGNOSE STEP1] factory_diagnosis_results 저장 실패: {e}")
         if diagnosis_id and applicable:
             try:
-                rule_rows = [{"diagnosis_id": diagnosis_id, "rule_code": r.get("rule_id") or r.get("rule_code") or "", "rule_name": (r.get("obligation_summary") or r.get("remarks") or "").strip(), "law_name": r.get("law_name") or "", "law_article": r.get("law_article") or "", "obligation": (r.get("obligation_summary") or "").strip(), "obligation_type": _resolve_obligation_type(r), "due_date": None, "status": "PENDING", "form_code": r.get("form_code") or None} for r in applicable]
+                rule_rows = [{"diagnosis_id": diagnosis_id, "rule_code": r.get("rule_id") or r.get("rule_code") or "", "rule_name": (r.get("remarks") or r.get("obligation_summary") or "").strip(), "law_name": r.get("law_name") or "", "law_article": r.get("law_article") or "", "obligation": (r.get("remarks") or r.get("obligation_summary") or "").strip(), "obligation_type": _resolve_obligation_type(r), "due_date": None, "status": "PENDING", "form_code": r.get("form_code") or None} for r in applicable]
                 for i in range(0, len(rule_rows), 50): supabase.table("diagnosis_rule_results").insert(rule_rows[i:i+50]).execute()
             except Exception as e: print(f"[DIAGNOSE STEP1] diagnosis_rule_results 저장 실패: {e}")
 
@@ -1083,9 +1153,9 @@ def _save_diagnosis_result(supabase, factory_id: str, sector: str, stage: int, i
     try: supabase.table('factory_diagnosis_results').update({'is_latest': False}).eq('factory_id', factory_id).eq('is_latest', True).execute()
     except Exception: pass
     law_categories = list(dict.fromkeys(r.get('law_name', '') for r in matched_rules if r.get('law_name')))
-    key_obligations = [r.get('obligation_summary') or r.get('rule_name', '') for r in matched_rules[:5]]
+    key_obligations = [r.get('remarks') or r.get('obligation_summary') or r.get('rule_name', '') for r in matched_rules[:5]]
     has_appointment = any(r.get('rule_type') == 'APPOINTMENT' or r.get('appointment_required') for r in matched_rules)
-    result_data = {'applicable_law_categories': law_categories, 'appointment_required': has_appointment, 'key_obligations': key_obligations, 'risk_level': _determine_risk_level(len(matched_rules)), 'rules': [{'rule_code': r.get('rule_code') or r.get('rule_id'), 'rule_name': r.get('rule_name') or r.get('remarks', ''), 'law_name': r.get('law_name', ''), 'law_article': r.get('law_article', ''), 'obligation': r.get('obligation_summary') or r.get('rule_name', ''), 'rule_type': r.get('rule_type') or str(r.get('rule_type_code', '')), 'stage': r.get('diagnosis_stage', 1)} for r in matched_rules]}
+    result_data = {'applicable_law_categories': law_categories, 'appointment_required': has_appointment, 'key_obligations': key_obligations, 'risk_level': _determine_risk_level(len(matched_rules)), 'rules': [{'rule_code': r.get('rule_code') or r.get('rule_id'), 'rule_name': r.get('remarks') or r.get('rule_name') or r.get('obligation_summary', ''), 'law_name': r.get('law_name', ''), 'law_article': r.get('law_article', ''), 'obligation': r.get('remarks') or r.get('obligation_summary') or r.get('rule_name', ''), 'rule_type': r.get('rule_type') or str(r.get('rule_type_code', '')), 'stage': r.get('diagnosis_stage', 1)} for r in matched_rules]}
     try:
         res = supabase.table('factory_diagnosis_results').insert({'factory_id': factory_id, 'sector': sector, 'diagnosis_stage': stage, 'input_data': input_data, 'result_data': result_data, 'rule_count': len(matched_rules), 'is_latest': True}).execute()
         return res.data[0] if res.data else {}
@@ -1141,7 +1211,7 @@ def diagnose_step2(body: dict):
     prev_codes = {r.get('rule_code') for r in (prev or {}).get('result_data', {}).get('rules', []) if prev} if prev else set()
     added = [r for r in matched if (r.get('rule_code') or r.get('rule_id')) not in prev_codes]
     result = diagnosis.get('result_data', {})
-    return {'status': 'success', 'diagnosis_id': diagnosis.get('id'), 'stage': 2, 'engine_version': ENGINE_VERSION, 'sector': sector, 'sector_groups': sector_groups, 'rule_count': len(matched), 'added_rule_count': len(added), 'kcsc_process_summary': kcsc_process_summary, 'summary': {'applicable_law_categories': result.get('applicable_law_categories', []), 'appointment_required': result.get('appointment_required', False), 'key_obligations': result.get('key_obligations', []), 'risk_level': result.get('risk_level', 'LOW')}, 'rules': result.get('rules', []), 'added_rules': [{'rule_code': r.get('rule_code') or r.get('rule_id'), 'rule_name': r.get('rule_name') or r.get('remarks', ''), 'law_article': r.get('law_article', '')} for r in added]}
+    return {'status': 'success', 'diagnosis_id': diagnosis.get('id'), 'stage': 2, 'engine_version': ENGINE_VERSION, 'sector': sector, 'sector_groups': sector_groups, 'rule_count': len(matched), 'added_rule_count': len(added), 'kcsc_process_summary': kcsc_process_summary, 'summary': {'applicable_law_categories': result.get('applicable_law_categories', []), 'appointment_required': result.get('appointment_required', False), 'key_obligations': result.get('key_obligations', []), 'risk_level': result.get('risk_level', 'LOW')}, 'rules': result.get('rules', []), 'added_rules': [{'rule_code': r.get('rule_code') or r.get('rule_id'), 'rule_name': r.get('remarks') or r.get('rule_name') or r.get('obligation_summary', ''), 'law_article': r.get('law_article', '')} for r in added]}
 
 
 @router.post("/diagnose/step3")


### PR DESCRIPTION
## 변경 내역

### BE-11: 무료 진단 결과 데이터 품질 개선 (legal_engine.py v5.7.0)
- **Task 1:** obligation_summary → remarks 우선 (사람 언어 387건 즉시 개선)
- **Task 2:** penalty 빈 값 → 의무유형별 기본 문구 5종
- **Task 3:** 건축법 제35조 중복 → Task 1로 자동 해결
- **Task 4:** D-day 로직 → cycle_unit_std 있으면 due_info:{}, is_recurring:true
- **Task 5:** risk_reason 필드 추가

### 핫픽스 동기화 (main→dev 역동기화 포함)
- precedent_api.py 정상 버전
- diagnosis_transform.py import 수정
- diagnosis_proposal.py v1.0.2 (penalty 파싱 + str 타입 처리)
- requirements.txt: jinja2 추가
- Dockerfile: fontconfig 추가

### 세션 작업일지
- docs/SESSION5_PM_20260418.md

## 테스트
- BUILDING_FREE E2E 토큰: f8e67f27-b489-4163-91b5-872c28e098a2
- 배포 후 확인: `curl -s https://api.taieng.co.kr/health`

## 관련 이슈
- Closes #7 (BE-11)