### PR TITLE
기안 PDF v2.0.0 — v6 콘텐츠 + Storage 캐싱 (백엔드)

### DIFF
--- a/docs/SESSION6_20260419.md
+++ b/docs/SESSION6_20260419.md
@@ -1,0 +1,76 @@
+# 세션 6 작업일지 (2026-04-19)
+
+## 완료
+
+### 1. BE-11 + FE-07 dev→main 머지
+- PR #8 생성 → 법령엔진 무결성 검증 4건 통과 → main 머지 (커밋 1ea85ae)
+- BE-11: legal_engine.py v5.7.0 (obligation_summary remarks 우선, penalty 기본 문구, risk_reason)
+- FE-07: free-diagnosis-result.html (긴급 섹션, 위험도 근거, 배지 축약, S5/S6/S7)
+- GitHub Actions #68 배포 성공
+
+### 2. 이슈 정리
+- tai-api #6 closed (BE-11 기획 → #7 이관)
+- tai-api #7 closed (BE-11 실행 완료)
+- tai-api #8 merged (PR)
+- taieng #2 closed (S5/S6/S7 수정)
+- taieng #3 closed (FE-07 UI 개선)
+
+### 3. 유료 PDF E2E 테스트 시작
+- INDUSTRY PAID 테스트 레코드 생성
+  - id: 8ccb9fbf-3c83-483d-a6e0-bdca49c0e1ee
+  - token: e2e-ind-paid-c1269589a61e61091c8d
+  - tier: INDUSTRY_V2
+  - 실데이터: (주)대성정밀 안산공장, 45명, 2800㎡, 금속절삭가공
+  - 공정 6개, 설비 6종 포함
+  - full_result: INDUSTRY_FREE 131건 복사
+
+### 4. 유료 PDF 에러 발견 + 수정
+- 에러: `Invalid color value '<css function: var(--border)>'`
+- 원인: xhtml2pdf가 CSS 변수(var()) 미지원
+- 수정: diagnosis_report.py v1.0.1
+  - `_CSS_VAR_MAP` 딕셔너리 (13개 변수→색상 매핑)
+  - `_replace_css_vars()` 함수 추가
+  - `_html_to_pdf()` 내부에서 자동 치환
+  - `isinstance(r, dict)` 필터 추가 (str 배열 방어)
+- 커밋: eec59c1 (main 직접 핫픽스)
+
+### 5. 외부 리뷰 기반 데이터 품질 분류
+- 수용 6건: obligation_summary 사람 언어, 긴급 최상단, HIGH 근거, penalty 빈 값, 제35조, D-day
+- 거절 3건: 아코디언 모법 통합, ACTION 129건 줄이기, 무료/유료 차별화
+- 부분 수용 1건: 배지만 모법 축약
+
+## 미해결 / 에러
+
+### GitHub Actions #69 배포 실패 🔴
+- 커밋: eec59c1 (diagnosis_report.py v1.0.1)
+- 에러: Fly.io health check timeout (앱이 0.0.0.0:8080에서 리슨 안 함)
+- API 다운 가능성
+- 원인 후보:
+  1. push_files로 전달한 코드에 \n 리터럴 저장 SyntaxError
+  2. Fly.io rolling deployment 타이밍 문제
+  3. Railway 삭제 후 환경변수 누락
+
+### Railway 참조 잔존 코드 발견
+- 5개 라우터 파일에 Railway 참조:
+  - routers/biz_verify.py
+  - routers/kosha_apis.py
+  - routers/law_collector.py
+  - routers/precedent_api.py
+  - routers/identity.py
+- 주석인지 런타임 참조인지 확인 필요
+- Dockerfile 주석 (무해)
+
+## 다음 세션
+1. 서버 복구 (fly deploy 수동 실행)
+2. diagnosis_report.py 구문 검증 (py_compile)
+3. Railway 참조 확인 + 제거
+4. 유료 PDF E2E 테스트 완료
+5. CI/CD fly-deploy.yml 검증 파이프라인 (Issue #3)
+6. 기안 PDF 내용 수정 (Issue #4)
+
+## 교훈
+- push_files로 200줄+ 파일 전달 시 \n이 리터럴로 저장되어 SyntaxError 유발 사례 발생
+  → Claude Code로 로컬 직접 수정 후 git push 권장
+  → 불가피하게 MCP 쓰면 grep -c '' 와 py_compile 이중검증 필수
+- Fly.io rolling deployment 실패 시 양쪽 머신 모두 불안정 상태 가능
+- Railway 삭제 전 코드베이스 전체 검색으로 참조 제거 선행 필수

--- a/docs/proposal_pdf_v6/01_backend_task.md
+++ b/docs/proposal_pdf_v6/01_backend_task.md
@@ -1,0 +1,623 @@
+# 01. 백엔드 작업 지시서 — 기안 PDF v6 개편
+
+> **담당 창:** 백엔드 창 (tai-api 레포 · Fly.io 배포)
+> **작업 브랜치:** `dev`
+> **예상 시간:** 2~3시간
+> **관련 문서:** `./README.md` (종합 핸드오프), `./mockup.html` (시각 기준)
+
+---
+
+## 🎯 담당 범위
+
+### ✅ 이 문서에서 작업하는 것
+1. **DB 마이그레이션** — `anonymous_diagnosis_results` 컬럼 추가
+2. **Supabase Storage 버킷** — `proposals` 신설 + RLS
+3. **Python 로직** — `routers/diagnosis_proposal.py` v1.0.3 → v2.0.0 재작성
+
+### ❌ 이 문서에서 작업하지 않는 것
+- `templates/proposal_pdf.html` → **02_frontend_task.md** 창이 담당
+- 마케팅 사이트 / safe.taieng.co.kr UI 변경 → 별도 작업
+
+---
+
+## 🔗 프론트(템플릿) 창과의 계약 (중요)
+
+백엔드가 `_build_context`에서 반환하는 딕셔너리 = 템플릿이 받는 컨텍스트. 아래 **변수 이름·구조를 정확히 맞춰야** 프론트 작업창과 충돌이 없음.
+
+### 계약 스펙 (v2.0.0 `_build_context` 반환)
+
+```python
+{
+    # 기본 정보 (기존 유지)
+    "company_name": str,          # "귀 사업장" (input 없을 시 fallback)
+    "report_date": str,           # "2026년 04월 19일"
+    "sector": str,                # "INDUSTRY" | "BUILDING" | "CONSTRUCTION"
+    "sector_label": str,          # "산업(제조)" | "건물·시설" | "건설"
+    "risk_level": str,            # "LOW" | "MEDIUM" | "HIGH"
+    "workers": int,               # 45
+    "report_no": str,             # "A1B2C3D4" (public_token 앞 8자)
+
+    # 요약 수치 (기존 유지)
+    "total": int,                 # 131
+    "appointment": int,           # 8
+    "inspection": int,            # 37
+    "action": int,                # 55
+    "report_notify": int,         # 31
+    "law_count": int,             # 46
+
+    # ⭐ 신규: 과태료 합산 (중대재해법 제외)
+    "penalty_sum": float,         # 245000000
+    "penalty_sum_text": str,      # "약 2억 4,500만원"
+
+    # TOP 5 리스크 (기존 유지)
+    "top5": list[dict],           # [{"title", "law", "penalty", "amount"}, ...]
+
+    # 중대재해법 (기존 유지)
+    "csia_applicable": bool,      # workers >= 50
+
+    # ⭐ 신규: 섹터별 유료 티어
+    "paid_tiers": dict,           # 아래 상세 참조
+
+    # ❌ 이전 필드 중 삭제된 것들 (템플릿에서도 더 이상 사용 안 함)
+    # - max_penalty_text (→ penalty_sum_text로 대체)
+    # - recommended_plan_name
+    # - recommended_plan_price
+    # - recommended_plan_monthly
+    # - plan_code
+    # - annual_savings_low
+    # - annual_savings_high
+}
+```
+
+### `paid_tiers` 구조 (가장 중요)
+
+**INDUSTRY 섹터 (mode = "select"):**
+```python
+{
+    "mode": "select",
+    "tiers": [
+        {"badge_class": "basic",    "code": "INDUSTRY_V2",       "name": "제조·산업 기본", "price": 79000,  "pages": 20},
+        {"badge_class": "standard", "code": "INDUSTRY_STANDARD", "name": "제조·산업 정밀", "price": 149000, "pages": 24},
+        {"badge_class": "premium",  "code": "INDUSTRY_PREMIUM",  "name": "제조·산업 종합", "price": 249000, "pages": 28},
+    ],
+}
+```
+
+**BUILDING 섹터 (mode = "determined") — 면적 자동판정:**
+```python
+# 2,800㎡ 입력 케이스
+{
+    "mode": "determined",
+    "determined": {
+        "code": "BUILDING_V2",
+        "name": "소형건물 (5,000㎡ 미만)",
+        "price": 99000,
+        "pages": 20,
+    },
+    "upper": {  # 상위 등급 힌트 (이미 대형이면 None)
+        "name": "대형건물 등급",
+        "price": 249000,
+        "threshold": "연면적 5,000㎡ 이상",
+    },
+    "basis": "입력 연면적 2,800㎡ 기준 자동 판정",
+}
+```
+
+**CONSTRUCTION 섹터 (mode = "determined") — 공사금액 자동판정:**
+```python
+# 30억원 입력 케이스
+{
+    "mode": "determined",
+    "determined": {
+        "code": "CONSTRUCTION",
+        "name": "건설 기본 등급 (50억원 미만)",
+        "price": 145000,
+        "pages": 22,
+    },
+    "upper": {
+        "name": "건설 종합 등급",
+        "price": 299000,
+        "threshold": "공사금액 50억원 이상",
+    },
+    "basis": "입력 공사금액 30억원 기준 자동 판정",
+}
+```
+
+---
+
+## 🛠️ Phase 1: DB + Storage 준비
+
+### Step 1.1: DB 마이그레이션
+
+**Supabase MCP 사용:**
+```
+tool: supabase:apply_migration
+name: add_proposal_pdf_url_to_anonymous_diagnosis_results
+query:
+  ALTER TABLE anonymous_diagnosis_results
+  ADD COLUMN IF NOT EXISTS proposal_pdf_url TEXT,
+  ADD COLUMN IF NOT EXISTS proposal_pdf_generated_at TIMESTAMPTZ;
+
+  CREATE INDEX IF NOT EXISTS idx_anon_diag_proposal_cache
+  ON anonymous_diagnosis_results(public_token)
+  WHERE proposal_pdf_url IS NOT NULL;
+```
+
+### Step 1.2: Storage 버킷 생성
+
+```sql
+-- supabase:execute_sql
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'proposals', 'proposals', true, 5242880,
+  ARRAY['application/pdf']::text[]
+)
+ON CONFLICT (id) DO NOTHING;
+```
+
+**참고:** `public: true`로 설정 — PDF URL을 고객이 품의서 첨부 시 열어야 하므로. 단 URL은 `public_token` 기반이라 외부 노출 위험은 제한적.
+
+### Step 1.3: RLS 정책 (Storage)
+
+```sql
+-- anon이 업로드할 수 있도록 (Fly에서 service role key 사용하지만 안전장치)
+CREATE POLICY "anon_upload_proposals" ON storage.objects
+FOR INSERT TO anon
+WITH CHECK (bucket_id = 'proposals');
+
+CREATE POLICY "public_read_proposals" ON storage.objects
+FOR SELECT TO anon, authenticated
+USING (bucket_id = 'proposals');
+
+CREATE POLICY "service_role_all_proposals" ON storage.objects
+FOR ALL TO service_role
+USING (bucket_id = 'proposals');
+```
+
+### Step 1.4: 검증
+```sql
+-- 컬럼 확인
+SELECT column_name, data_type FROM information_schema.columns
+WHERE table_name = 'anonymous_diagnosis_results'
+  AND column_name LIKE 'proposal%';
+
+-- 버킷 확인
+SELECT id, name, public, allowed_mime_types FROM storage.buckets
+WHERE name = 'proposals';
+```
+
+---
+
+## 🐍 Phase 2: Python 수정 (`routers/diagnosis_proposal.py`)
+
+### 중요: 파일 수정 방식
+- **현재 크기:** 12,278 bytes, 약 280 라인
+- **수정 후 예상:** 350~400 라인
+- **권장:** Claude Code 로컬 편집 + `git push` (메모리 #1)
+- MCP push_files 사용 시: 커밋 후 raw URL에서 리터럴 `\n` 확인 + `py_compile` 이중검증
+
+### Step 2.1: 삭제할 요소
+
+```python
+# 상수 삭제
+_PLANS                         # SaaS 플랜 딕셔너리
+_AGENCY_MONTHLY_LOW            # 대행 월비용
+_AGENCY_MONTHLY_HIGH
+
+# 함수 삭제
+_recommend_plan()              # SaaS 플랜 추천 (이 PDF에서 안 씀)
+
+# _build_context 내부에서 삭제
+max_penalty = max(...)
+max_penalty_text = _format_penalty(max_penalty)
+plan_code, plan_info = _recommend_plan(...)
+monthly = plan_info.get("monthly")
+plan_price = ...
+annual_savings_low = ...
+annual_savings_high = ...
+
+# 반환 딕셔너리에서 삭제 (아래 키들)
+"max_penalty_text"
+"recommended_plan_name"
+"recommended_plan_price"
+"recommended_plan_monthly"
+"plan_code"
+"annual_savings_low"
+"annual_savings_high"
+```
+
+### Step 2.2: 추가할 함수
+
+```python
+def _compute_penalty_sum(rules_flat: List[Dict]) -> float:
+    """전체 규칙의 과태료를 합산. 중대재해처벌법 항목은 제외."""
+    total = 0.0
+    for r in rules_flat:
+        if not isinstance(r, dict):
+            continue
+        law_name = str(r.get("law_name") or r.get("law") or "").strip()
+        if "중대재해" in law_name:
+            continue
+        total += _get_penalty_from_rule(r)
+    return total
+
+
+def _build_paid_tiers(sector: str, input_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    섹터별 유료 티어 구성을 생성.
+    - INDUSTRY: 3개 티어 리스트 (사용자 선택형)
+    - BUILDING: 면적 기준 자동 판정 (단일 + 상위 힌트)
+    - CONSTRUCTION: 공사금액 기준 자동 판정 (단일 + 상위 힌트)
+    """
+    if sector == "INDUSTRY":
+        return {
+            "mode": "select",
+            "tiers": [
+                {"badge_class": "basic",    "code": "INDUSTRY_V2",       "name": "제조·산업 기본", "price": 79000,  "pages": 20},
+                {"badge_class": "standard", "code": "INDUSTRY_STANDARD", "name": "제조·산업 정밀", "price": 149000, "pages": 24},
+                {"badge_class": "premium",  "code": "INDUSTRY_PREMIUM",  "name": "제조·산업 종합", "price": 249000, "pages": 28},
+            ],
+        }
+
+    if sector == "BUILDING":
+        try:
+            area = float(input_data.get("total_floor_area") or 0)
+        except (TypeError, ValueError):
+            area = 0.0
+
+        if area < 5000:
+            determined = {
+                "code": "BUILDING_V2",
+                "name": "소형건물 (5,000㎡ 미만)",
+                "price": 99000,
+                "pages": 20,
+            }
+            upper = {
+                "name": "대형건물 등급",
+                "price": 249000,
+                "threshold": "연면적 5,000㎡ 이상",
+            }
+        else:
+            determined = {
+                "code": "BUILDING_LARGE_V2",
+                "name": "대형건물 (5,000㎡ 이상)",
+                "price": 249000,
+                "pages": 25,
+            }
+            upper = None
+
+        return {
+            "mode": "determined",
+            "determined": determined,
+            "upper": upper,
+            "basis": f"입력 연면적 {int(area):,}㎡ 기준 자동 판정",
+        }
+
+    if sector == "CONSTRUCTION":
+        try:
+            # 공사금액: 원 단위로 들어오면 억원 변환, 이미 억원이면 그대로
+            raw_amount = input_data.get("project_amount") or 0
+            amount_won = float(raw_amount)
+            # 10억 이상이면 원 단위로 가정, 아니면 억원 단위로 가정
+            amount_eok = amount_won / 100_000_000 if amount_won >= 1_000_000_000 else amount_won
+        except (TypeError, ValueError):
+            amount_eok = 0.0
+
+        if amount_eok < 50:
+            determined = {
+                "code": "CONSTRUCTION",
+                "name": "건설 기본 등급 (50억원 미만)",
+                "price": 145000,
+                "pages": 22,
+            }
+            upper = {
+                "name": "건설 종합 등급",
+                "price": 299000,
+                "threshold": "공사금액 50억원 이상",
+            }
+        else:
+            determined = {
+                "code": "CONSTRUCTION_PREMIUM",
+                "name": "건설 종합 등급 (50억원 이상)",
+                "price": 299000,
+                "pages": 28,
+            }
+            upper = None
+
+        return {
+            "mode": "determined",
+            "determined": determined,
+            "upper": upper,
+            "basis": f"입력 공사금액 {int(amount_eok):,}억원 기준 자동 판정",
+        }
+
+    # fallback
+    return {"mode": "select", "tiers": []}
+```
+
+### Step 2.3: `_build_context` 리팩토링
+
+기존 코드 중 아래 블록을 교체:
+
+```python
+# 기존 (삭제)
+max_penalty = max((_get_penalty_from_rule(r) for r in all_rules_flat), default=0.0)
+max_penalty_text = _format_penalty(max_penalty)
+top5 = _get_top5(full)
+csia_applicable = workers >= 50
+plan_code, plan_info = _recommend_plan(sector, risk_level, total, workers)
+monthly = plan_info.get("monthly")
+plan_price = f"월 {monthly:,}원" if monthly else "맞춤 견적"
+monthly_plan = monthly or 149_000
+annual_savings_low  = max(0, int((_AGENCY_MONTHLY_LOW  - monthly_plan) * 12 / 10_000))
+annual_savings_high = max(0, int((_AGENCY_MONTHLY_HIGH - monthly_plan) * 12 / 10_000))
+```
+
+로 바꿔서:
+
+```python
+# 신규
+penalty_sum = _compute_penalty_sum(all_rules_flat)
+penalty_sum_text = _format_penalty(penalty_sum)
+top5 = _get_top5(full)
+csia_applicable = workers >= 50
+paid_tiers = _build_paid_tiers(sector, input_data)
+```
+
+그리고 return 딕셔너리를 아래처럼:
+
+```python
+return {
+    "company_name": company_name,
+    "report_date": report_date,
+    "sector_label": sector_label,
+    "sector": sector,
+    "risk_level": risk_level,
+    "workers": workers,
+    "report_no": str(row.get("public_token", ""))[:8].upper(),
+    "total": total,
+    "appointment": appointment,
+    "inspection": inspection,
+    "action": action,
+    "report_notify": report_notify,
+    "law_count": law_count,
+    "penalty_sum": penalty_sum,
+    "penalty_sum_text": penalty_sum_text,
+    "top5": top5,
+    "csia_applicable": csia_applicable,
+    "paid_tiers": paid_tiers,
+}
+```
+
+### Step 2.4: 엔드포인트 캐싱 로직
+
+```python
+from fastapi.responses import RedirectResponse, StreamingResponse
+
+@router.get("/proposal-pdf/{public_token}")
+def get_proposal_pdf(public_token: str):
+    """기안용 PDF — 품의서 첨부 근거자료 (공개 엔드포인트, 캐싱 적용)."""
+    row = _fetch_row(public_token)
+
+    # Cache hit check
+    cached_url = row.get("proposal_pdf_url")
+    if cached_url:
+        log.info(f"[proposal-pdf] cache hit: {public_token}")
+        return RedirectResponse(url=cached_url, status_code=302)
+
+    # 생성
+    context = _build_context(row)
+    html    = _render_html(context)
+    pdf     = _generate_pdf(html)
+    filename = f"TAI_proposal_{context['report_no']}.pdf"
+
+    # Storage 업로드 (실패 시 직접 스트리밍 fallback)
+    try:
+        sb = get_supabase()
+        storage_path = f"{public_token}/{filename}"
+
+        sb.storage.from_("proposals").upload(
+            path=storage_path,
+            file=pdf,
+            file_options={
+                "content-type": "application/pdf",
+                "upsert": "true",
+            },
+        )
+        public_url = sb.storage.from_("proposals").get_public_url(storage_path)
+
+        sb.table("anonymous_diagnosis_results").update({
+            "proposal_pdf_url": public_url,
+            "proposal_pdf_generated_at": _now().isoformat(),
+        }).eq("public_token", public_token).execute()
+
+        log.info(f"[proposal-pdf] generated+cached: {public_token}")
+        return RedirectResponse(url=public_url, status_code=302)
+
+    except Exception as e:
+        log.error(f"[proposal-pdf] storage upload failed, streaming: {e}")
+        return StreamingResponse(
+            io.BytesIO(pdf),
+            media_type="application/pdf",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(len(pdf)),
+                "Cache-Control": "no-store",
+            },
+        )
+```
+
+### Step 2.5: 버전 + import 정리
+
+```python
+VERSION = "2.0.0"
+
+# 파일 맨 위 docstring 업데이트
+"""
+routers/diagnosis_proposal.py — v2.0.0
+기안 PDF — 품의서 첨부용 분석보고서 (v6 콘텐츠 + Storage 캐싱)
+
+v2.0.0 (2026-04-19): v6 콘텐츠 개편, Storage 캐싱, penalty_sum/paid_tiers 신규
+v1.0.3 (2026-04-18): xhtml2pdf 한글 폰트 주입
+v1.0.2 (2026-04-18): str 규칙 처리 수정
+v1.0.1 (2026-04-18): penalty 파싱 수정
+v1.0.0 (2026-04-18): 최초 생성
+"""
+
+# import 추가
+from fastapi.responses import RedirectResponse, StreamingResponse
+```
+
+---
+
+## ✅ Phase 3: 로컬 검증
+
+```bash
+# Python 문법 검증
+python -m py_compile routers/diagnosis_proposal.py
+
+# import 정상 여부
+python -c "from routers import diagnosis_proposal; print(diagnosis_proposal.VERSION)"
+# 출력: 2.0.0
+```
+
+단위 테스트 (선택):
+```python
+# _build_paid_tiers 테스트
+assert _build_paid_tiers("INDUSTRY", {})["mode"] == "select"
+assert len(_build_paid_tiers("INDUSTRY", {})["tiers"]) == 3
+
+assert _build_paid_tiers("BUILDING", {"total_floor_area": 2800})["determined"]["code"] == "BUILDING_V2"
+assert _build_paid_tiers("BUILDING", {"total_floor_area": 6000})["determined"]["code"] == "BUILDING_LARGE_V2"
+
+assert _build_paid_tiers("CONSTRUCTION", {"project_amount": 30})["determined"]["code"] == "CONSTRUCTION"
+assert _build_paid_tiers("CONSTRUCTION", {"project_amount": 80})["determined"]["code"] == "CONSTRUCTION_PREMIUM"
+```
+
+---
+
+## 🚀 Phase 4: 배포
+
+```bash
+# dev 브랜치 커밋
+git checkout dev
+git add routers/diagnosis_proposal.py
+git commit -m "feat(proposal-pdf): v2.0.0 — v6 콘텐츠 + Storage 캐싱
+
+- _build_context 리팩토링 (penalty_sum, paid_tiers 신규)
+- _recommend_plan, annual_savings 제거 (SaaS 영업 내용 배제)
+- RedirectResponse 캐싱: 첫 생성 → Storage 업로드 → 302
+- 재요청: proposal_pdf_url DB 확인 → 즉시 302 redirect
+
+Refs: tai-api #4"
+git push origin dev
+
+# PR 생성 (dev → main)
+# GitHub에서 수동 또는 gh CLI 사용
+gh pr create --base main --head dev \
+  --title "기안 PDF v2.0.0 — v6 콘텐츠 + Storage 캐싱" \
+  --body "proposal_pdf_v6_handoff 참조. 프론트 템플릿 작업과 동시 머지 필요."
+```
+
+**중요:** 템플릿(`proposal_pdf.html`) 작업과 **같은 PR 또는 연속 머지 필수**. 템플릿만 있고 context가 부재하면 Jinja2가 UndefinedError 발생.
+
+---
+
+## 🔍 Phase 5: E2E 검증
+
+```bash
+# 3개 섹터 샘플 토큰으로 호출
+curl -I "https://api.taieng.co.kr/diagnosis/proposal-pdf/${TOKEN_INDUSTRY}"
+# 첫 호출: HTTP/1.1 302 Found, location: https://xntdkrjhgcscmqctdzyo.supabase.co/storage/v1/object/public/proposals/...
+# 재호출: HTTP/1.1 302 Found (DB 캐시 히트)
+
+# Storage에 파일 존재 확인
+```
+
+Supabase MCP로 확인:
+```sql
+SELECT public_token, proposal_pdf_url, proposal_pdf_generated_at
+FROM anonymous_diagnosis_results
+WHERE proposal_pdf_url IS NOT NULL
+ORDER BY proposal_pdf_generated_at DESC
+LIMIT 5;
+```
+
+```sql
+-- Storage 파일 목록
+SELECT name, bucket_id, created_at, metadata->>'size' as size_bytes
+FROM storage.objects
+WHERE bucket_id = 'proposals'
+ORDER BY created_at DESC
+LIMIT 10;
+```
+
+---
+
+## ⚠️ 주의사항
+
+### dev 브랜치 원칙 (메모리 #14, #28)
+- 모든 커밋 → `dev` 브랜치
+- `main` 직접 커밋 금지
+
+### Fly.io 배포 (메모리 #1)
+- 앱명: `tai-api-prod`
+- dev → main PR 머지 → Actions 자동 배포
+- 배포 후 `/health` + `/diagnosis/proposal-pdf/{token}` 양쪽 확인
+- Fly lease 충돌 주의: Actions 중 재배포 금지
+
+### 프론트 창과의 동기화
+- 백엔드 v2.0.0만 배포되면 템플릿(기존 v1.0.3)과 불일치 → 500 에러 발생 가능
+  - `max_penalty_text` 템플릿에서 참조하는데 context에 없으므로
+- **템플릿 작업(02_frontend_task.md)과 동시 머지** 필수
+
+### CONSTRUCTION.process_fee vs total_report_fee (메모리 #21)
+- DB 실제 값: `process_fee = 385000`, `total_report_fee = 299000` 불일치
+- **표시 가격은 `total_report_fee`의 299,000원** 확정
+- 본 작업에서 하드코딩된 `299000` 사용 (DB 조회 안 함)
+
+---
+
+## 📋 최종 체크리스트
+
+### Phase 1 — DB/Storage
+- [ ] `apply_migration` PASS
+- [ ] `proposal_pdf_url` 컬럼 확인
+- [ ] `proposals` 버킷 확인 (public, 5MB, application/pdf)
+- [ ] RLS 정책 3개 확인
+
+### Phase 2 — Python
+- [ ] `_PLANS`, `_recommend_plan` 등 삭제
+- [ ] `_compute_penalty_sum`, `_build_paid_tiers` 추가
+- [ ] `_build_context` 리팩토링 (반환 딕셔너리 키 정확히 일치)
+- [ ] 엔드포인트에 캐싱 로직 추가
+- [ ] `VERSION = "2.0.0"`
+- [ ] Docstring 업데이트
+
+### Phase 3 — 로컬 검증
+- [ ] `py_compile` PASS
+- [ ] 모듈 import 정상
+- [ ] 단위 테스트 3개 섹터 PASS
+
+### Phase 4 — 배포
+- [ ] dev 커밋 + 푸시
+- [ ] PR 생성 (프론트 PR과 연계)
+- [ ] main 머지
+- [ ] Fly 자동 배포 성공 확인
+- [ ] `/health` 200
+
+### Phase 5 — E2E
+- [ ] INDUSTRY 샘플 토큰: 첫 302 → redirected URL 접근 시 PDF 정상
+- [ ] BUILDING 샘플 토큰: 동일
+- [ ] CONSTRUCTION 샘플 토큰: 동일
+- [ ] 재호출 시 즉시 302 (캐시 히트)
+- [ ] Storage에 PDF 3개 존재
+- [ ] DB에 `proposal_pdf_url` 3건 기록
+
+---
+
+## 🔗 다음 단계
+
+본 작업 완료 후:
+- **tai-api #5 유료 PDF 개편** — 티어별 상세 분석 범위(시설/공정/설비) 유료 PDF에 이전
+- **tai-api #3 CI/CD 파이프라인** — Actions에 `py_compile` 검증 스텝 추가

--- a/docs/proposal_pdf_v6/02_frontend_task.md
+++ b/docs/proposal_pdf_v6/02_frontend_task.md
@@ -1,0 +1,663 @@
+# 02. 프론트(템플릿) 작업 지시서 — 기안 PDF v6 개편
+
+> **담당 창:** 프론트(템플릿) 창 (tai-api 레포의 `templates/` 디렉토리)
+> **작업 브랜치:** `dev`
+> **예상 시간:** 2시간
+> **관련 문서:** `./README.md` (종합 핸드오프), `./mockup.html` (시각 기준), `./01_backend_task.md` (백엔드 계약)
+
+---
+
+## 🎯 담당 범위
+
+### ✅ 이 문서에서 작업하는 것
+- **`templates/proposal_pdf.html` 전면 재작성**
+  - v6 mockup (`./mockup.html`) 기반으로 CSS/HTML 구조 이전
+  - 하드코딩 값을 Jinja2 변수로 치환
+  - 섹터별 분기 (`{% if sector == "INDUSTRY" %}`)
+
+### ❌ 이 문서에서 작업하지 않는 것
+- `routers/diagnosis_proposal.py` → **01_backend_task.md** 창이 담당
+- DB 마이그레이션 / Storage 버킷 → 백엔드 담당
+- 마케팅 사이트·프론트엔드 앱의 다운로드 버튼 → 별도 작업
+
+---
+
+## 🔗 백엔드 창과의 계약 (중요)
+
+백엔드가 제공하는 Jinja2 컨텍스트:
+
+| 변수 | 타입 | 예시 | 비고 |
+|---|---|---|---|
+| `company_name` | str | "귀 사업장" | |
+| `report_date` | str | "2026년 04월 19일" | |
+| `sector` | str | `"INDUSTRY"` \| `"BUILDING"` \| `"CONSTRUCTION"` | **분기 기준** |
+| `sector_label` | str | "산업(제조)" | 표시용 한글 |
+| `risk_level` | str | `"LOW"` \| `"MEDIUM"` \| `"HIGH"` | 배지 색상 결정 |
+| `workers` | int | 45 | |
+| `report_no` | str | "A1B2C3D4" | 문서번호 suffix |
+| `total` | int | 131 | 법적 의무 총계 |
+| `appointment` | int | 8 | 선임 |
+| `inspection` | int | 37 | 점검·검사 |
+| `action` | int | 55 | 조치 |
+| `report_notify` | int | 31 | 보고·신고 |
+| `law_count` | int | 46 | 적용 법령 수 |
+| **`penalty_sum_text`** ⭐ | str | "약 2억 4,500만원" | **신규 — 합산·중대재해 제외** |
+| `top5` | list[dict] | `[{title, law, penalty, amount}, ...]` | |
+| `csia_applicable` | bool | workers ≥ 50 | 중대재해법 적용 여부 |
+| **`paid_tiers`** ⭐ | dict | 아래 참조 | **신규 — 섹터별 구조 다름** |
+
+### `paid_tiers` 구조 (섹터별 상이)
+
+**INDUSTRY (mode="select"):**
+```python
+{
+    "mode": "select",
+    "tiers": [
+        {"badge_class": "basic",    "name": "제조·산업 기본", "price": 79000,  "pages": 20},
+        {"badge_class": "standard", "name": "제조·산업 정밀", "price": 149000, "pages": 24},
+        {"badge_class": "premium",  "name": "제조·산업 종합", "price": 249000, "pages": 28},
+    ],
+}
+```
+
+**BUILDING / CONSTRUCTION (mode="determined"):**
+```python
+{
+    "mode": "determined",
+    "determined": {"code": "...", "name": "소형건물 (5,000㎡ 미만)", "price": 99000, "pages": 20},
+    "upper": {"name": "대형건물 등급", "price": 249000, "threshold": "연면적 5,000㎡ 이상"} or None,
+    "basis": "입력 연면적 2,800㎡ 기준 자동 판정",
+}
+```
+
+### ⚠️ 삭제되는 변수 (기존 템플릿에서 참조하지 말 것)
+- `max_penalty_text` → `penalty_sum_text` 로 교체
+- `recommended_plan_name`, `recommended_plan_price`, `recommended_plan_monthly`, `plan_code`
+- `annual_savings_low`, `annual_savings_high`
+
+---
+
+## 📄 작업 순서
+
+### Step 1: Mockup 구조 파악
+
+`./mockup.html` 을 브라우저에서 열어 5페이지 구조 확인:
+- 페이지 1: 표지 + 진단 요약 (공통)
+- 페이지 2: 중대재해법 + 관리방법 비교 + 분석 요지 (공통)
+- 페이지 3: INDUSTRY P3 (3개 티어)
+- 페이지 4: BUILDING P3 (단일 + 상위 힌트)
+- 페이지 5: CONSTRUCTION P3 (단일 + 상위 힌트)
+
+### Step 2: Jinja 템플릿 골격
+
+```jinja2
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>산업안전 법령진단 분석 보고서</title>
+<style>
+/* mockup의 <style>을 그대로 이전 */
+/* .page, .sh, .exec-box, .tier-card, .single-tier-box, .safety-value-box, .company-info 등 */
+/* ⚠️ .viewer-note, .sector-switch 는 제거 (mockup 전용) */
+/* ⚠️ body { background: #e2e8f0; padding: 20px; } 는 제거 (PDF는 background white) */
+/* ⚠️ .page { box-shadow, margin, border-radius } 는 제거 (PDF 한 장씩 렌더) */
+</style>
+</head>
+<body>
+
+{# ========== PAGE 1: 표지 + 진단 요약 ========== #}
+<div class="page">
+  {# 헤더 #}
+  <table style="width:100%; border-bottom: 3px solid #1A5FD4; ...">
+    <tr>
+      <td>
+        <span style="font-size:17pt; font-weight:bold; color:#1A5FD4;">TAI</span>
+        <span style="font-size:9pt; color:#64748b;">Engineering · taieng.co.kr</span>
+      </td>
+      <td style="text-align:right;">
+        <span style="font-size:13.5pt; font-weight:bold;">산업안전 법령진단 분석 보고서</span><br/>
+        <span style="font-size:7.5pt; color:#64748b;">Legal Compliance Analysis Report</span>
+      </td>
+    </tr>
+  </table>
+
+  {# 진단 정보 (좌/우 2열) #}
+  <table style="width:100%; ...">
+    <tr>
+      <td style="width:49%; ...">
+        <table>
+          <tr><td>진단 대상</td><td>{{ company_name }}</td></tr>
+          <tr><td>작성일</td><td>{{ report_date }}</td></tr>
+          <tr><td>사업장 유형</td><td>{{ sector_label }}</td></tr>
+        </table>
+      </td>
+      <td style="width:49%; ...">
+        <table>
+          <tr><td>문서번호</td><td>TAI-2026-DR-{{ report_no }}</td></tr>
+          <tr>
+            <td>상시 인원</td>
+            <td>
+              {{ workers }}명
+              {% if csia_applicable %}
+                <span style="color:#dc2626;">(중대재해법 적용)</span>
+              {% else %}
+                <span style="color:#64748b;">(중대재해법 미적용 · 50인 기준)</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <td>위험도</td>
+            <td>
+              {% if risk_level == "HIGH" %}
+                <span class="badge b-high">높음 (HIGH)</span>
+              {% elif risk_level == "LOW" %}
+                <span class="badge b-low">낮음 (LOW)</span>
+              {% else %}
+                <span class="badge b-med">보통 (MEDIUM)</span>
+              {% endif %}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+
+  {# 경영진 요약 박스 (⭐ penalty_sum_text 사용) #}
+  <div class="exec-box">
+    <div class="exec-main">
+      귀 사업장은 <span style="color:#f59e0b;">{{ total }}건</span>의 법적 의무를 이행해야 하며,
+      미이행 시 <span style="color:#f59e0b;">{{ penalty_sum_text }}</span> 규모의 과태료에 노출되어 있습니다.
+    </div>
+    <table style="width:100%;">
+      <tr>
+        <td style="text-align:center; ...">
+          <div class="exec-num-val">{{ law_count }}</div>
+          <div class="exec-num-label">적용 법령 수</div>
+        </td>
+        <td style="text-align:center; ...">
+          <div class="exec-num-val">{{ total }}</div>
+          <div class="exec-num-label">법적 의무 총계</div>
+        </td>
+        <td style="text-align:center; ...">
+          <div class="exec-num-val" style="color:#f87171;">{{ penalty_sum_text }}</div>
+          <div class="exec-num-label">과태료 노출 총액</div>
+          <div class="exec-num-sub">(합산 · 중대재해법 제외)</div>
+        </td>
+      </tr>
+    </table>
+  </div>
+
+  {# 법적 의무 유형별 요약 4카드 #}
+  <div class="sh"><h2>법적 의무 유형별 요약</h2></div>
+  <table style="width:100%;">
+    <tr>
+      <td style="width:25%; padding:3px;"><div class="sc"><div class="k">선임 의무</div><div class="v">{{ appointment }}</div><div class="k">건</div></div></td>
+      <td style="width:25%; padding:3px;"><div class="sc"><div class="k">점검·검사</div><div class="v">{{ inspection }}</div><div class="k">건</div></div></td>
+      <td style="width:25%; padding:3px;"><div class="sc"><div class="k">조치 의무</div><div class="v">{{ action }}</div><div class="k">건</div></div></td>
+      <td style="width:25%; padding:3px;"><div class="sc"><div class="k">보고·신고</div><div class="v">{{ report_notify }}</div><div class="k">건</div></div></td>
+    </tr>
+  </table>
+
+  {# TOP 5 리스크 #}
+  <div class="sh" style="margin-top:13px;">
+    <h2>주요 리스크 TOP 5</h2>
+    <p>과태료 금액 기준 상위 5건 — 법령을 정밀 분석하여 도출</p>
+  </div>
+  <table class="top5-table">
+    <thead>
+      <tr>
+        <th style="width:6%;">순위</th>
+        <th style="width:42%;">위반 사항</th>
+        <th style="width:31%;">근거 법령</th>
+        <th style="width:21%;">처벌 내용</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in top5 %}
+      <tr>
+        <td style="text-align:center; font-weight:bold; color:#1A5FD4;">{{ loop.index }}위</td>
+        <td>{{ item.title }}</td>
+        <td style="color:#64748b; font-size:8pt;">{{ item.law }}</td>
+        <td style="color:#dc2626; font-weight:bold;">{{ item.penalty }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {# 푸터 #}
+  <div class="pf">
+    <table style="width:100%;">
+      <tr>
+        <td>TAI Engineering · taieng.co.kr · contact@taieng.co.kr</td>
+        <td style="text-align:right;">1 / 3</td>
+      </tr>
+    </table>
+  </div>
+</div>{# /page 1 #}
+
+
+{# ========== PAGE 2: 중대재해법 + 관리방법 + 분석 요지 ========== #}
+<div class="page" style="page-break-before: always;">
+  {# 간략 헤더 #}
+  <table style="border-bottom:2px solid #1A5FD4; ...">
+    <tr>
+      <td>
+        <span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span>
+        <span style="font-size:7.5pt; color:#64748b;">산업안전 법령진단 분석 보고서</span>
+      </td>
+      <td style="text-align:right;">{{ company_name }} · {{ report_date }}</td>
+    </tr>
+  </table>
+
+  {# 중대재해법 박스 #}
+  <div class="sh"><h2>중대재해처벌법 적용 여부</h2></div>
+  {% if csia_applicable %}
+    <div style="background:#fef2f2; border:1px solid #dc2626; ...">
+      <strong style="color:#dc2626; font-size:10.5pt;">⚠️ 즉시 적용 대상입니다 (상시 {{ workers }}명)</strong><br/>
+      <span style="font-size:8.8pt;">
+        중대재해처벌법에 따라 경영책임자는 산재 발생 시 1년 이상 징역 또는 10억원 이하 벌금에 처해질 수 있습니다.
+        즉시 안전보건관리체계 구축 및 이행이 필요합니다.
+      </span>
+    </div>
+  {% else %}
+    <div style="background:#fffbeb; border:1px solid #fcd34d; ...">
+      <strong style="color:#b45309; font-size:10.5pt;">현재 상시 {{ workers }}인 — 즉시 적용 대상은 아닙니다</strong><br/>
+      <span style="font-size:8.8pt;">
+        상시 근로자 50인 이상 사업장에 중대재해처벌법이 적용됩니다.
+        {% set remaining = 50 - workers %}
+        {% if remaining > 0 and remaining <= 10 %}
+          현재 {{ workers }}명으로 {{ remaining }}명 증가 시 즉시 적용되며,
+        {% endif %}
+        5인 이상 사업장은 이미 산업안전보건법 처벌 대상이므로 사전 대비가 필요합니다.
+      </span>
+    </div>
+  {% endif %}
+
+  {# 안전관리 방법별 비용·리스크 비교 #}
+  {# mockup P2의 cost-table + risk-bar-table 그대로 이전 #}
+  {# 변수 없이 정적 테이블 (모든 섹터 공통) #}
+
+  {# 분석 요지 #}
+  <div class="sh" style="margin-top:13px;"><h2>분석 요지</h2></div>
+  <div style="background:#f1f5f9; ...">
+    본 무료 진단 결과, 귀 사업장은
+    <strong class="text-blue">{{ total }}건</strong>의 법적 의무에 대하여
+    <strong class="text-red">{{ penalty_sum_text }}</strong> 규모의 과태료 노출(합산, 중대재해법 제외)이 확인되었으며,
+    {% if csia_applicable %}
+      중대재해처벌법이 적용되므로 경영책임자의 형사처벌 리스크까지 존재합니다.
+    {% else %}
+      중대재해처벌법 위반 시에는 별도로 경영책임자의 형사처벌이 가능합니다.
+    {% endif %}
+    <br/>
+    본 진단은 사업장 기본 정보만으로 도출된 일반 분석이며,
+    설비·공정·작업 단위의 개별 의무는 <strong>정밀 진단</strong>을 통해서만 확인할 수 있습니다.
+    다음 페이지에서 정밀 진단의 상세 구성과 예상 비용을 안내합니다.
+  </div>
+
+  <div class="pf">
+    <table style="width:100%;">
+      <tr>
+        <td>TAI Engineering · taieng.co.kr · contact@taieng.co.kr</td>
+        <td style="text-align:right;">2 / 3</td>
+      </tr>
+    </table>
+  </div>
+</div>{# /page 2 #}
+
+
+{# ========== PAGE 3: 섹터별 분기 ========== #}
+<div class="page" style="page-break-before: always;">
+  {# 간략 헤더 — 섹터별 제목 변경 #}
+  <table style="border-bottom:2px solid #1A5FD4; ...">
+    <tr>
+      <td>
+        <span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span>
+        <span style="font-size:7.5pt; color:#64748b;">
+          산업안전 법령진단 분석 보고서
+          {% if sector == "BUILDING" %} — 건물
+          {% elif sector == "CONSTRUCTION" %} — 건설
+          {% endif %}
+        </span>
+      </td>
+      <td style="text-align:right;">{{ company_name }} · {{ report_date }}</td>
+    </tr>
+  </table>
+
+  {# 1. 확인된 영역 (섹터별 멘트 다름) #}
+  <div class="sh"><h2>1. 본 무료 진단에서 확인된 영역</h2></div>
+  <div class="area-box area-confirmed">
+    <div class="area-title">분석 완료된 항목</div>
+    {% if sector == "INDUSTRY" %}
+      <div class="area-item">· 사업장 기본 정보 기반 법령 매칭 (업종·규모·위치)</div>
+      <div class="area-item">· 일반 법령 의무 {{ total }}건 도출</div>
+      <div class="area-item">· 주요 리스크 TOP 5 식별 및 근거 법령 제시</div>
+      <div class="area-item">· 중대재해처벌법 적용 여부 자동 판정</div>
+    {% elif sector == "BUILDING" %}
+      <div class="area-item">· 건축물대장 기반 법령 매칭 (용도·규모·층수)</div>
+      <div class="area-item">· 건물 일반 법령 의무 {{ total }}건 도출</div>
+      <div class="area-item">· 소방·승강기·전기안전 선임 의무</div>
+      <div class="area-item">· 중대재해처벌법 적용 여부 자동 판정</div>
+    {% elif sector == "CONSTRUCTION" %}
+      <div class="area-item">· 현장 기본 정보 기반 법령 매칭 (공사금액·기간·인원)</div>
+      <div class="area-item">· 건설업 일반 법령 의무 {{ total }}건 도출</div>
+      <div class="area-item">· 안전관리자·보건관리자 선임 요건 판정</div>
+      <div class="area-item">· 중대재해처벌법 적용 여부 자동 판정</div>
+    {% endif %}
+  </div>
+
+  {# 2. 확인되지 않은 영역 (섹터별 멘트 다름) #}
+  <div class="sh" style="margin-top:10px;"><h2>2. 본 무료 진단에서 확인되지 않은 영역</h2></div>
+  <div class="area-box area-unconfirmed">
+    <div class="area-title">정밀 진단을 통해서만 확인 가능한 항목</div>
+    {% if sector == "INDUSTRY" %}
+      <div class="area-item">· <strong>시설별 상세 법령</strong> — 건축물·부속시설 개별 의무</div>
+      <div class="area-item">· <strong>위험물 취급 규정</strong> — 보유 위험물 종류·수량 기반 의무</div>
+      <div class="area-item">· <strong>공정 단위 안전의무</strong> — 작업 공정별 규정 (정밀 등급 이상)</div>
+      <div class="area-item">· <strong>설비별 개별 의무</strong> — 보유 설비 개별 점검·검사 규정 (종합 등급)</div>
+    {% elif sector == "BUILDING" %}
+      <div class="area-item">· 건물 규모 기반 적용 법령 세부 매핑</div>
+      <div class="area-item">· 용도별 특수 규정 (근린·의료·판매 등)</div>
+      <div class="area-item">· 관리 주체·임차인 책임 구분</div>
+      <div class="area-item">· 세부 점검 주기 및 담당자 지정 기준</div>
+    {% elif sector == "CONSTRUCTION" %}
+      <div class="area-item">· 공사금액 기반 적용 법령 세부 매핑</div>
+      <div class="area-item">· 안전관리비 산정 기준 및 요율</div>
+      <div class="area-item">· 원청·하청 안전 책임 분배 상세</div>
+      <div class="area-item">· 세부 점검 주기 및 담당자 지정 기준</div>
+    {% endif %}
+  </div>
+
+  {# 3. 정밀 진단 안내 — 섹터별 분기 (핵심!) #}
+  {% if paid_tiers.mode == "select" %}
+    {# === INDUSTRY: 3개 티어 === #}
+    <div class="sh" style="margin-top:11px;">
+      <h2>3. 정밀 진단 (유료) — 3개 등급 안내</h2>
+      <p>사업장 특성에 맞는 등급을 선택하실 수 있습니다</p>
+    </div>
+    <div class="tier-grid">
+      {% for tier in paid_tiers.tiers %}
+      <div class="tier-card">
+        <div class="tier-badge {{ tier.badge_class }}">
+          {% if tier.badge_class == "basic" %}기본
+          {% elif tier.badge_class == "standard" %}정밀
+          {% elif tier.badge_class == "premium" %}종합
+          {% endif %}
+        </div>
+        <div class="tier-name">{{ tier.name }}</div>
+        <div class="tier-price">{{ "{:,}".format(tier.price) }}원</div>
+        <div class="tier-price-note">VAT 별도 · 1회성</div>
+        <div class="tier-output-title">산출물</div>
+        <div class="tier-output-item">상세 PDF 리포트</div>
+        <div class="tier-output-pages">약 {{ tier.pages }}페이지</div>
+      </div>
+      {% endfor %}
+    </div>
+    <div style="font-size:8pt; color:#64748b; margin-top:6px;">
+      ※ 공통 산출물: 전체 적용 법령 테이블 · 점검 일정 캘린더 · 선임 의무 양식 · 조항별 과태료 시뮬레이션<br>
+      ※ 등급별 상세 분석 범위는 safe.taieng.co.kr 신청 페이지에서 확인하실 수 있습니다.
+    </div>
+
+  {% else %}
+    {# === BUILDING / CONSTRUCTION: 단일 티어 + 상위 힌트 === #}
+    <div class="sh" style="margin-top:11px;">
+      <h2>
+        3. 귀 {% if sector == "BUILDING" %}사업장{% else %}현장{% endif %} 해당 정밀 진단
+      </h2>
+      <p>
+        {% if sector == "BUILDING" %}연면적{% else %}공사금액{% endif %} 자동 판정 결과에 따라 아래 등급이 적용됩니다
+      </p>
+    </div>
+
+    <div class="single-tier-box">
+      <span class="single-tier-badge">
+        귀 {% if sector == "BUILDING" %}사업장{% else %}현장{% endif %} 해당
+      </span>
+      <div style="font-size:12pt; font-weight:bold; color:#0f172a; margin-bottom:4px;">
+        {{ paid_tiers.determined.name }}
+      </div>
+      <div style="font-size:8.5pt; color:#64748b;">{{ paid_tiers.basis }}</div>
+
+      <div class="single-tier-row">
+        <div class="single-tier-cell">
+          <div class="dlabel">비용</div>
+          <div class="dval">{{ "{:,}".format(paid_tiers.determined.price) }}원</div>
+          <div style="font-size:7.5pt; color:#64748b;">VAT 별도 · 1회성</div>
+        </div>
+        <div class="single-tier-cell">
+          <div class="dlabel">소요 시간</div>
+          <div class="dval">즉시</div>
+          <div style="font-size:7.5pt; color:#64748b;">결제 후 자동 분석</div>
+        </div>
+        <div class="single-tier-cell">
+          <div class="dlabel">산출물</div>
+          <div class="dval">상세 PDF</div>
+          <div style="font-size:7.5pt; color:#64748b;">약 {{ paid_tiers.determined.pages }}페이지</div>
+        </div>
+      </div>
+
+      <div style="margin-top:10px; padding-top:9px; border-top:1px dashed #cbd5e1;">
+        {% if sector == "BUILDING" %}
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 전체 적용 법령 테이블</div>
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 층별·용도별 의무 매핑</div>
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 선임 의무자 양식 (소방·전기·승강기)</div>
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 건축물 정기점검 일정 캘린더</div>
+        {% else %}
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 공종별 적용 법령 상세</div>
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 안전관리비 산정 가이드</div>
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· TBM·위험성평가 일정 캘린더</div>
+          <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 원청·하청 안전 책임 구분표</div>
+        {% endif %}
+      </div>
+    </div>
+
+    {# 상위 등급 힌트 (이미 최상위면 표시 안 함) #}
+    {% if paid_tiers.upper %}
+    <div style="background:#f8fafc; border:1px solid #e2e8f0; ...">
+      ※ {{ paid_tiers.upper.threshold }}은 <strong>{{ paid_tiers.upper.name }}({{ "{:,}".format(paid_tiers.upper.price) }}원)</strong>이 적용됩니다.
+      입력 항목은 동일하나, 규모 기준에 따라 적용 법령 세트와 분석 결과가 달라집니다.
+    </div>
+    {% endif %}
+  {% endif %}
+
+  {# 활용 포인트 박스 (전 섹터 공통) #}
+  <div class="safety-value-box">
+    <strong>활용 포인트</strong><br>
+    본 유료 리포트는 <strong>관공서 안전감독 시</strong> 법적 의무 이행을 입증하는 근거자료로 활용하실 수 있습니다.
+  </div>
+
+  {# TAI 회사 정보 #}
+  <div class="company-info">
+    <div class="company-info-title">TAI Engineering</div>
+    <div class="company-info-row">
+      <div class="company-info-cell">
+        <div><span class="cil">사업자</span><span class="civ">723-39-01422</span></div>
+        <div><span class="cil">주소</span><span class="civ">서울시 강남구 테헤란로79길 6 JS타워 3층</span></div>
+        <div><span class="cil">이메일</span><span class="civ">contact@taieng.co.kr</span></div>
+        <div><span class="cil">홈페이지</span><span class="civ">taieng.co.kr</span></div>
+      </div>
+      <div class="company-info-cell" style="border-left: 1px solid #e2e8f0; padding-left: 12px;">
+        <div style="font-size:8pt; color:#0f172a; font-weight:bold; margin-bottom:3px;">지식재산권</div>
+        <div style="font-size:7.8pt; color:#334155; line-height:1.55;">
+          · 법령 자동진단 엔진 외 <strong>특허 출원 8건</strong><br>
+          · TAI 상표 등록 완료<br>
+          · 법령·시설·공정·설비·작업 연계 분석 기술
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {# 4. 활용 안내 #}
+  <div class="sh" style="margin-top:10px;"><h2>4. 본 보고서 활용 안내</h2></div>
+  <div class="usage-box">
+    본 분석 보고서는 귀사의 내부 품의 진행 시 <strong>첨부 근거자료</strong>로 활용하실 수 있습니다.
+    품의서 본문에 정밀 진단 신청의 필요성을 기술하시고 본 보고서를 첨부하시면,
+    경영진이 법적 의무 건수와 과태료 노출 규모를 객관적으로 확인하실 수 있습니다.
+    정밀 진단은 <strong>safe.taieng.co.kr</strong>에서 직접 신청하실 수 있습니다.
+  </div>
+
+  <div class="pf" style="margin-top:10px;">
+    <table style="width:100%;">
+      <tr>
+        <td style="font-size:7pt; color:#94a3b8;">※ 본 보고서는 공개된 법령을 기반으로 정밀 분석하여 도출한 참고 자료이며 법적 효력이 없습니다. 실제 적용 여부는 관할 행정기관 또는 법률 전문가에게 확인하시기 바랍니다.</td>
+        <td style="text-align:right; white-space:nowrap; vertical-align:top;">3 / 3</td>
+      </tr>
+    </table>
+  </div>
+</div>{# /page 3 #}
+
+</body>
+</html>
+```
+
+---
+
+## 🔧 xhtml2pdf 호환성 주의사항
+
+### ⚠️ 지원 안 되는 CSS
+- `flexbox` (display: flex)
+- `grid` (display: grid)
+- `transform`, `box-shadow`, `filter`
+- 복잡한 selector (`:nth-of-type` 일부)
+
+### ✅ 대안 사용
+- 레이아웃: `<table>` 사용 (mockup에 이미 적용됨)
+- 카드 그리드: `display: table` + `display: table-cell` (✅ 지원)
+- 둥근 모서리: `border-radius` (✅ 지원)
+
+### 한글 폰트 — 백엔드에서 자동 주입
+백엔드의 `_render_html`이 렌더링 후 `@font-face` CSS + `font-family: "NanumGothic"` 을 자동으로 주입함.
+템플릿에서는 그냥 `font-family: "Malgun Gothic", "Apple SD Gothic Neo", "Noto Sans KR", Arial, sans-serif;` 정도로 작성 (백엔드가 덮어씀).
+
+**중요:** 기존 템플릿의 font-family 문자열 형식을 유지해야 백엔드의 `.replace()` 가 정상 동작:
+```python
+# routers/diagnosis_proposal.py 의 _render_html
+html = html.replace(
+    'font-family: "Noto Sans KR", "Malgun Gothic", "Apple SD Gothic Neo", Arial, sans-serif;',
+    'font-family: "NanumGothic", sans-serif;',
+)
+```
+
+따라서 템플릿에서는 `font-family: "Noto Sans KR", "Malgun Gothic", "Apple SD Gothic Neo", Arial, sans-serif;` **정확한 문자열**로 작성.
+
+### 페이지 분리
+```css
+.page { page-break-after: always; }
+.page:last-child { page-break-after: auto; }
+```
+또는 각 `.page` 에 `style="page-break-before: always;"` (첫 페이지 제외).
+
+---
+
+## ⚠️ 작업 시 주의사항
+
+### 파일 크기 (메모리 #1)
+- 예상 크기: 800~1,000 라인 (현재 proposal_pdf.html보다 약간 큼)
+- **권장: Claude Code 로컬 편집 + `git push`**
+- MCP `push_files` / `create_or_update_file` 사용 시 커밋 후 GitHub raw URL 에서 직접 파일 열어 리터럴 `\n` 유무 확인 필수
+
+### 이미지·아이콘 사용 금지
+- xhtml2pdf는 외부 이미지 로딩 불안정
+- 이모지(💡 🏢 🏗️ 등) → **텍스트로 대체** (mockup에 있는 이모지는 viewer-note/sector-switch 영역만이고, 실제 PDF 페이지엔 없음)
+
+### 페이지 페이지 구조 엄수
+- PDF는 3페이지 고정 (섹터별로 내용이 달라도 페이지 번호는 `1/3`, `2/3`, `3/3`)
+- mockup의 5페이지 (P3 3가지 변형)는 **비교용 표시**일 뿐, 실제 PDF는 선택된 섹터의 **3페이지만** 렌더링
+
+### dev 브랜치 원칙
+- 모든 커밋 → `dev`
+- 백엔드 PR과 **연계 머지 필수** (템플릿만 먼저 배포되면 UndefinedError)
+
+---
+
+## ✅ 검증
+
+### Step 1: Jinja 문법 검증
+```bash
+python -c "
+from jinja2 import Environment, FileSystemLoader
+env = Environment(loader=FileSystemLoader('templates'), autoescape=False)
+tmpl = env.get_template('proposal_pdf.html')
+print('Jinja syntax OK')
+"
+```
+
+### Step 2: 3개 섹터 샘플로 로컬 렌더
+```python
+# tests/test_proposal_template.py
+from routers.diagnosis_proposal import _render_html
+
+contexts = [
+    {  # INDUSTRY
+        "company_name": "테스트공업", "report_date": "2026년 04월 19일",
+        "sector": "INDUSTRY", "sector_label": "산업(제조)",
+        "risk_level": "MEDIUM", "workers": 45, "report_no": "TEST0001",
+        "total": 131, "appointment": 8, "inspection": 37, "action": 55, "report_notify": 31,
+        "law_count": 46, "penalty_sum_text": "약 2억 4,500만원",
+        "top5": [
+            {"title": "산업재해 발생 보고 미이행", "law": "산업안전보건법 제57조", "penalty": "1,000만원", "amount": 10000000},
+            # ...
+        ],
+        "csia_applicable": False,
+        "paid_tiers": {
+            "mode": "select",
+            "tiers": [
+                {"badge_class": "basic", "name": "제조·산업 기본", "price": 79000, "pages": 20},
+                {"badge_class": "standard", "name": "제조·산업 정밀", "price": 149000, "pages": 24},
+                {"badge_class": "premium", "name": "제조·산업 종합", "price": 249000, "pages": 28},
+            ],
+        },
+    },
+    # BUILDING, CONSTRUCTION 케이스도 추가
+]
+
+for ctx in contexts:
+    html = _render_html(ctx)
+    print(f"{ctx['sector']}: {len(html)} bytes, OK")
+```
+
+### Step 3: PDF 생성 확인
+```python
+from routers.diagnosis_proposal import _generate_pdf
+pdf_bytes = _generate_pdf(html)
+with open(f"/tmp/test_{ctx['sector']}.pdf", "wb") as f:
+    f.write(pdf_bytes)
+# 생성된 PDF를 열어 시각 확인
+```
+
+---
+
+## 📋 최종 체크리스트
+
+- [ ] `mockup.html` 의 `<style>` 섹션을 템플릿에 이전 (viewer-note/sector-switch 제외)
+- [ ] 페이지 헤더/푸터 작성
+- [ ] P1: 진단 정보 + 경영진 요약 박스 + 법적 의무 카드 4개 + TOP5
+- [ ] P2: 중대재해법 + 관리방법 비교 + 분석 요지
+- [ ] P3: `{% if paid_tiers.mode == "select" %}` 분기 (INDUSTRY 3카드 vs BUILDING/CONSTRUCTION 단일)
+- [ ] 활용 포인트 박스 (공통)
+- [ ] TAI 회사 정보 박스 (공통)
+- [ ] 활용 안내 (공통)
+- [ ] `{{ penalty_sum_text }}` 사용 (P1 경영진 박스 + P2 분석 요지)
+- [ ] `font-family` 문자열 유지 (백엔드 `.replace()` 호환)
+- [ ] Jinja 문법 검증 PASS
+- [ ] 3개 섹터 샘플 렌더링 테스트 PASS
+- [ ] PDF 시각 검증 (mockup과 일치)
+- [ ] dev 브랜치 커밋·푸시
+- [ ] PR 생성 (백엔드 PR과 연계)
+
+---
+
+## 🔗 백엔드 창과의 동기화
+
+| 순서 | 창 | 작업 |
+|---|---|---|
+| 1 | 백엔드 | DB 마이그레이션 + Storage 버킷 생성 |
+| 2 | 백엔드 | `diagnosis_proposal.py` v2.0.0 dev 커밋 |
+| 3 | **프론트** | **템플릿 v6 dev 커밋** |
+| 4 | 양쪽 | dev → main PR (1개 PR에 2 커밋 포함 권장) |
+| 5 | 양쪽 | main 머지 → Fly 배포 → E2E 검증 |
+
+**중요:** 백엔드만 먼저 배포 → context에 `max_penalty_text` 없음 → 기존 템플릿에서 Undefined → 500 에러
+**중요:** 템플릿만 먼저 배포 → `paid_tiers` 변수 없음 → Jinja UndefinedError
+
+⇒ **반드시 한 번에 머지** 또는 dev에서 양쪽 완료 후 같은 PR로 main 올리기.

--- a/docs/proposal_pdf_v6/README.md
+++ b/docs/proposal_pdf_v6/README.md
@@ -1,0 +1,488 @@
+# 기안 PDF 개편 구현 핸드오프 문서 (v6 기반)
+
+**작성일:** 2026-04-19
+**작업 브랜치:** `dev`
+**PR 대상:** `main` (머지 후 자동 배포)
+**관련 이슈:** tai-api #4 (기안 PDF 내용 수정)
+**참조 Mockup:** `/mnt/user-data/outputs/proposal_mockup_v6.html`
+
+---
+
+## 🎯 A. 작업 개요
+
+### A-1. 배경
+현행 `routers/diagnosis_proposal.py` + `templates/proposal_pdf.html`은 **TAI SaaS 플랜 영업자료** 성격이 강함. 고객사의 실제 사용 맥락은 **"무료 진단을 받은 안전관리자가 경영진에게 유료 정밀 진단 승인을 받기 위한 품의서의 첨부 근거자료"**. 따라서 PDF의 포지션을 재정의하고 콘텐츠를 전면 교체해야 함.
+
+### A-2. 목적
+기안 PDF를 **"품의서 첨부용 분석 보고서"**로 재포지셔닝:
+- ❌ 결재란 없음 (고객사 품의서가 결재받음)
+- ❌ TAI SaaS 영업 내용 제거 (이건 별도 건)
+- ✅ 법적 리스크 분석 결과 객관 제시
+- ✅ 유료 정밀 진단의 비용·산출물 안내
+- ✅ "관공서 안전감독 시 활용 가능" 전환 포인트 추가
+
+### A-3. 완료 기준
+1. 3개 섹터(INDUSTRY / BUILDING / CONSTRUCTION) 기안 PDF 정상 렌더링
+2. `penalty_sum` 합산 계산 정상 동작
+3. Supabase Storage 캐싱 로직 동작 (첫 생성 → 저장, 재요청 → 302 redirect)
+4. `GET /diagnosis/proposal-pdf/{public_token}` 엔드포인트 200/302 응답 확인
+
+---
+
+## 📐 B. v6 설계 명세
+
+### B-1. 페이지 구조 (3페이지)
+
+#### P1: 분석 보고서 표지 + 진단 요약
+- TAI 헤더 (로고·도메인 `taieng.co.kr`)
+- 진단 대상 / 작성일 / 사업장 유형 / 문서번호 / 상시 인원 / 위험도
+- **경영진 요약 박스** (네이비 배경)
+  - 메인 문구: "귀 사업장은 N건의 법적 의무를 이행해야 하며, 미이행 시 약 XX원 규모의 과태료에 노출되어 있습니다"
+  - 3개 수치: 적용 법령 수 / 법적 의무 총계 / **과태료 노출 총액 (합산·중대재해법 제외)**
+- 법적 의무 유형별 요약 (선임·점검·조치·보고 4개 카드)
+- 주요 리스크 TOP 5 테이블
+
+#### P2: 중대재해법 + 관리방법 비교 + 분석 요지
+- 중대재해처벌법 적용 여부 박스 (상시 인원 기준)
+- 안전관리 방법별 비용·리스크 비교표 (방치 / 엑셀 / 대행 — **TAI 행 없음**)
+- 관리 방식별 법적 리스크 수준 (막대 그래프)
+- 분석 요지 (다음 페이지 연결)
+
+#### P3: 섹터별 분기
+공통 구조: `1. 확인된 영역` → `2. 확인되지 않은 영역` → `3. 정밀 진단 안내` → `4. TAI 회사 정보` → `5. 본 보고서 활용 안내`
+
+**INDUSTRY** (3개 티어 카드):
+- 기본 79,000원 (상세 PDF 약 20p)
+- 정밀 149,000원 (상세 PDF 약 24p)
+- 종합 249,000원 (상세 PDF 약 28p)
+- 카드 하단: 배지 색상만 단계감 (회색/브랜드파랑/진네이비), **"추천" 배지 없음**
+
+**BUILDING** (면적 자동 판정 → 단일 티어):
+- 면적 < 5,000㎡ → 소형건물 99,000원 (약 20p)
+- 면적 ≥ 5,000㎡ → 대형건물 249,000원 (약 25p)
+- 현재 선택된 티어를 메인 박스로, 상위 티어는 하단 "※ 힌트" 박스
+
+**CONSTRUCTION** (공사금액 자동 판정 → 단일 티어):
+- 공사금액 < 50억원 → 건설 기본 145,000원 (약 22p)
+- 공사금액 ≥ 50억원 → 건설 종합 299,000원 (약 28p)
+- 현재 선택된 티어를 메인 박스로, 상위 티어는 하단 "※ 힌트" 박스
+
+**전 섹터 공통 — 정밀 진단 박스 직후:**
+```
+┌─ 활용 포인트 ─────────────────────────────┐
+│ 본 유료 리포트는 관공서 안전감독 시        │
+│ 법적 의무 이행을 입증하는 근거자료로       │
+│ 활용하실 수 있습니다.                      │
+└────────────────────────────────────────────┘
+```
+스타일: 초록 배경 `#f0fdf4`, 좌측 포인트 `#16a34a` 4px
+
+### B-2. 삭제되는 요소 (현행 v1.0.3 대비)
+- ❌ TAI Safe 도입 4단계
+- ❌ Before/After 업무구조 비교
+- ❌ 추천 플랜 박스 (네이비 강조)
+- ❌ 연간 절감액 숫자 (`annual_savings_*`)
+- ❌ `recommended_plan_*` 필드 전부
+- ❌ `_recommend_plan` 호출
+- ❌ `max_penalty_text` (중대재해법 포함되어 왜곡) → `penalty_sum_text`로 교체
+
+---
+
+## 🗃️ C. 변경 대상 파일
+
+### C-1. DB 마이그레이션 (Supabase)
+**마이그레이션명:** `add_proposal_pdf_url_to_anonymous_diagnosis_results`
+
+```sql
+ALTER TABLE anonymous_diagnosis_results
+ADD COLUMN IF NOT EXISTS proposal_pdf_url TEXT,
+ADD COLUMN IF NOT EXISTS proposal_pdf_generated_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_anon_diag_proposal_cache
+ON anonymous_diagnosis_results(public_token)
+WHERE proposal_pdf_url IS NOT NULL;
+```
+
+### C-2. Supabase Storage 버킷 생성
+**버킷명:** `proposals`
+- Public: `false` (공개 안함, 서명 URL 사용)
+- File size limit: `5242880` (5MB)
+- Allowed MIME: `["application/pdf"]`
+- RLS: anon role에 대해 INSERT/SELECT 허용 (public_token 경로 한정)
+
+버킷 생성 SQL:
+```sql
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'proposals', 'proposals', false, 5242880,
+  ARRAY['application/pdf']::text[]
+)
+ON CONFLICT (id) DO NOTHING;
+```
+
+RLS 정책 (Storage):
+```sql
+-- anon 사용자도 자신의 token으로 PDF 업로드/조회 가능
+CREATE POLICY "anon_upload_proposals" ON storage.objects
+FOR INSERT TO anon
+WITH CHECK (bucket_id = 'proposals');
+
+CREATE POLICY "anon_read_proposals" ON storage.objects
+FOR SELECT TO anon
+USING (bucket_id = 'proposals');
+
+CREATE POLICY "service_role_all_proposals" ON storage.objects
+FOR ALL TO service_role
+USING (bucket_id = 'proposals');
+```
+
+### C-3. Backend: `routers/diagnosis_proposal.py`
+v1.0.3 → **v2.0.0** 대폭 재작성. 주요 변경:
+
+#### C-3-1. `_build_context` 확장
+
+**삭제:**
+```python
+# 이 필드들 전부 제거
+max_penalty, max_penalty_text
+_recommend_plan, recommended_plan_name, recommended_plan_price
+recommended_plan_monthly, plan_code
+annual_savings_low, annual_savings_high
+_PLANS, _AGENCY_MONTHLY_LOW, _AGENCY_MONTHLY_HIGH (상수)
+```
+
+**추가:**
+```python
+# 1. 과태료 합산 (중대재해법 제외)
+def _compute_penalty_sum(rules_flat: List[Dict]) -> float:
+    total = 0.0
+    for r in rules_flat:
+        law_name = (r.get('law_name') or r.get('law') or '').strip()
+        if '중대재해' in law_name:
+            continue
+        total += _get_penalty_from_rule(r)
+    return total
+
+penalty_sum = _compute_penalty_sum(all_rules_flat)
+penalty_sum_text = _format_penalty(penalty_sum)
+
+# 2. 섹터별 유료 티어 생성
+def _build_paid_tiers(sector: str, input_data: Dict) -> Dict[str, Any]:
+    """
+    INDUSTRY: 3개 티어 리스트 반환
+    BUILDING: 1개 확정 + 상위 힌트
+    CONSTRUCTION: 1개 확정 + 상위 힌트
+    """
+    if sector == "INDUSTRY":
+        return {
+            "mode": "select",
+            "tiers": [
+                {"badge_class": "basic",    "code": "INDUSTRY_V2",       "name": "제조·산업 기본", "price": 79000,  "pages": 20},
+                {"badge_class": "standard", "code": "INDUSTRY_STANDARD", "name": "제조·산업 정밀", "price": 149000, "pages": 24},
+                {"badge_class": "premium",  "code": "INDUSTRY_PREMIUM",  "name": "제조·산업 종합", "price": 249000, "pages": 28},
+            ],
+        }
+    if sector == "BUILDING":
+        area = float(input_data.get("total_floor_area") or 0)
+        if area < 5000:
+            determined = {"code": "BUILDING_V2", "name": "소형건물 (5,000㎡ 미만)", "price": 99000, "pages": 20}
+            upper = {"name": "대형건물 등급", "price": 249000, "threshold": "연면적 5,000㎡ 이상"}
+        else:
+            determined = {"code": "BUILDING_LARGE_V2", "name": "대형건물 (5,000㎡ 이상)", "price": 249000, "pages": 25}
+            upper = None
+        return {
+            "mode": "determined",
+            "determined": determined,
+            "upper": upper,
+            "basis": f"입력 연면적 {int(area):,}㎡ 기준 자동 판정",
+        }
+    if sector == "CONSTRUCTION":
+        amount = float(input_data.get("project_amount") or 0)  # 억원 단위
+        if amount < 50:
+            determined = {"code": "CONSTRUCTION", "name": "건설 기본 등급 (50억원 미만)", "price": 145000, "pages": 22}
+            upper = {"name": "건설 종합 등급", "price": 299000, "threshold": "공사금액 50억원 이상"}
+        else:
+            determined = {"code": "CONSTRUCTION_PREMIUM", "name": "건설 종합 등급 (50억원 이상)", "price": 299000, "pages": 28}
+            upper = None
+        return {
+            "mode": "determined",
+            "determined": determined,
+            "upper": upper,
+            "basis": f"입력 공사금액 {int(amount):,}억원 기준 자동 판정",
+        }
+    # fallback
+    return {"mode": "select", "tiers": []}
+
+paid_tiers_data = _build_paid_tiers(sector, input_data)
+```
+
+#### C-3-2. 캐싱 로직 추가
+
+```python
+from fastapi.responses import RedirectResponse
+
+@router.get("/proposal-pdf/{public_token}")
+def get_proposal_pdf(public_token: str):
+    row = _fetch_row(public_token)
+
+    # 캐시 hit check
+    cached_url = row.get("proposal_pdf_url")
+    if cached_url:
+        log.info(f"[proposal-pdf] 캐시 hit: {public_token}")
+        return RedirectResponse(url=cached_url, status_code=302)
+
+    # PDF 생성
+    context = _build_context(row)
+    html    = _render_html(context)
+    pdf     = _generate_pdf(html)
+
+    # Storage 업로드
+    try:
+        sb = get_supabase()
+        filename = f"TAI_proposal_{context['report_no']}.pdf"
+        storage_path = f"{public_token}/{filename}"
+
+        sb.storage.from_("proposals").upload(
+            path=storage_path,
+            file=pdf,
+            file_options={"content-type": "application/pdf", "upsert": "true"},
+        )
+        public_url = sb.storage.from_("proposals").get_public_url(storage_path)
+
+        # DB에 URL 기록
+        sb.table("anonymous_diagnosis_results").update({
+            "proposal_pdf_url": public_url,
+            "proposal_pdf_generated_at": _now().isoformat(),
+        }).eq("public_token", public_token).execute()
+
+        log.info(f"[proposal-pdf] 생성+캐싱 완료: {public_token} → {public_url}")
+        return RedirectResponse(url=public_url, status_code=302)
+
+    except Exception as e:
+        # Storage 업로드 실패 시 fallback: 직접 스트리밍
+        log.error(f"[proposal-pdf] Storage 업로드 실패, 직접 전송: {e}")
+        return StreamingResponse(
+            io.BytesIO(pdf),
+            media_type="application/pdf",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(len(pdf)),
+                "Cache-Control": "no-store",
+            },
+        )
+```
+
+#### C-3-3. VERSION 문자열 업데이트
+```python
+VERSION = "2.0.0"  # v6 콘텐츠 + Storage 캐싱
+```
+
+### C-4. Template: `templates/proposal_pdf.html`
+**전면 재작성.** v6 mockup(`/mnt/user-data/outputs/proposal_mockup_v6.html`) 구조 그대로 Jinja2로 변환.
+
+주요 변수 바인딩:
+- `{{ company_name }}`, `{{ report_date }}`, `{{ sector_label }}`, `{{ workers }}`, `{{ risk_level }}`
+- `{{ report_no }}`, `{{ total }}`, `{{ appointment }}`, `{{ inspection }}`, `{{ action }}`, `{{ report_notify }}`
+- `{{ law_count }}`, **`{{ penalty_sum_text }}`** (기존 `max_penalty_text` 대체)
+- `{% for item in top5 %}...{% endfor %}`
+
+P3 섹터 분기:
+```jinja2
+{% if sector == "INDUSTRY" %}
+  {# 3개 티어 카드 #}
+  <div class="tier-grid">
+    {% for tier in paid_tiers.tiers %}
+      <div class="tier-card">
+        <div class="tier-badge {{ tier.badge_class }}">{{ tier.badge_class|upper }}</div>
+        <div class="tier-name">{{ tier.name }}</div>
+        <div class="tier-price">{{ "{:,}".format(tier.price) }}원</div>
+        <div class="tier-price-note">VAT 별도 · 1회성</div>
+        <div class="tier-output-title">산출물</div>
+        <div class="tier-output-item">상세 PDF 리포트</div>
+        <div class="tier-output-pages">약 {{ tier.pages }}페이지</div>
+      </div>
+    {% endfor %}
+  </div>
+{% else %}
+  {# BUILDING / CONSTRUCTION 단일 티어 #}
+  <div class="single-tier-box">
+    <span class="single-tier-badge">귀 사업장 해당</span>
+    <div style="font-size:12pt; font-weight:bold;">{{ paid_tiers.determined.name }}</div>
+    <div style="font-size:8.5pt; color:#64748b;">{{ paid_tiers.basis }}</div>
+    {# ... 비용/소요/산출물 3열 테이블 ... #}
+  </div>
+
+  {% if paid_tiers.upper %}
+    <div style="...">
+      ※ {{ paid_tiers.upper.threshold }}은 <strong>{{ paid_tiers.upper.name }}({{ "{:,}".format(paid_tiers.upper.price) }}원)</strong>이 적용됩니다. 입력 항목은 동일하나, 규모 기준에 따라 적용 법령 세트와 분석 결과가 달라집니다.
+    </div>
+  {% endif %}
+{% endif %}
+
+{# 전 섹터 공통: 활용 포인트 #}
+<div class="safety-value-box">
+  <strong>활용 포인트</strong><br>
+  본 유료 리포트는 <strong>관공서 안전감독 시</strong> 법적 의무 이행을 입증하는 근거자료로 활용하실 수 있습니다.
+</div>
+```
+
+---
+
+## 🛠️ D. 단계별 실행 체크리스트
+
+### Phase 1: DB 준비 (Supabase MCP)
+- [ ] `apply_migration` 실행: `add_proposal_pdf_url_to_anonymous_diagnosis_results`
+- [ ] Storage 버킷 `proposals` 생성 + RLS 정책
+- [ ] 스키마 확인: `proposal_pdf_url` 컬럼 존재 확인
+
+### Phase 2: Template 교체
+- [ ] `/mnt/user-data/outputs/proposal_mockup_v6.html` 참조
+- [ ] `templates/proposal_pdf.html`을 v6 mockup 구조로 재작성
+- [ ] Jinja2 변수 바인딩 (`{{ penalty_sum_text }}`, `{% if sector %}` 등)
+- [ ] **주의: 파일 크기 600+라인 예상 → Claude Code 로컬 편집 + git push 권장 (메모리 #1)**
+- [ ] MCP push_files 사용 시: 커밋 후 GitHub raw URL에서 파일 직접 확인 (리터럴 \n 유무)
+
+### Phase 3: Backend 수정
+- [ ] `routers/diagnosis_proposal.py` v2.0.0
+  - [ ] `_PLANS`, `_AGENCY_MONTHLY_*`, `_recommend_plan` 제거
+  - [ ] `_compute_penalty_sum` 추가
+  - [ ] `_build_paid_tiers` 추가 (섹터별 분기)
+  - [ ] `_build_context` 리팩토링 (삭제 필드 제거, 신규 필드 추가)
+  - [ ] 엔드포인트 캐싱 로직 추가 (RedirectResponse)
+- [ ] 로컬 `py_compile routers/*.py` 전체 검사 PASS
+- [ ] dev 브랜치 커밋 + 푸시
+
+### Phase 4: PR + 배포
+- [ ] dev → main PR 생성 (#N)
+- [ ] PR body에 변경 내역 + 테스트 결과 기재
+- [ ] GitHub Actions CI 통과 확인
+- [ ] main 머지
+- [ ] Fly 자동 배포 완료 확인 (app name: `tai-api-prod`, 양쪽 machine healthy)
+
+### Phase 5: E2E 검증
+- [ ] INDUSTRY 샘플 토큰으로 `GET /diagnosis/proposal-pdf/{token}` 호출
+  - 첫 요청: 200 → PDF 생성 → Storage 업로드 → DB URL 기록 → 302 redirect
+  - 재요청: 302 redirect 즉시 응답
+- [ ] BUILDING 샘플 토큰으로 동일 검증
+- [ ] CONSTRUCTION 샘플 토큰으로 동일 검증
+- [ ] Storage 버킷에서 PDF 파일 존재 확인
+- [ ] PDF 열어서 v6 mockup과 시각적 일치 확인
+
+---
+
+## ⚠️ E. 주의사항
+
+### E-1. dev 브랜치 원칙 (메모리 #14, #28)
+- **모든 커밋 → `dev` 브랜치**
+- `main` 직접 커밋 금지 (긴급 핫픽스만)
+- `github-tai:push_files` 호출 시 `"branch": "dev"` 명시 필수
+
+### E-2. 파일 크기 + MCP 안정성 (메모리 #1)
+- `templates/proposal_pdf.html`은 v6 기준 600~800 라인 예상
+- GitHub MCP의 `create_or_update_file` / `push_files` 사용 시 리터럴 `\n` 저장 사고 가능
+- **우선 전략: Claude Code 로컬 편집 + `git push`**
+- 불가피하게 MCP 사용 시:
+  1. 커밋 후 GitHub raw URL 열어 파일 직접 확인 (`\n`이 실제 개행인지)
+  2. 로컬에서 `python -m py_compile routers/diagnosis_proposal.py` 실행 후 푸시
+  3. Actions 배포 성공까지 모니터링
+
+### E-3. 유료 PDF와의 경계
+- 기안 PDF에는 **티어별 상세 분석 범위(시설/공정/설비)를 넣지 않음** (대표님 지시)
+- 이 내용은 **유료 PDF** 작업 시 이전 예정 → 별도 작업 (tai-api #5)
+
+### E-4. 중대재해법 처리
+- `penalty_sum`은 **중대재해법 제외** 합산 (오해 방지)
+- 판단 기준: `law_name`에 `"중대재해"` 포함 여부
+- P1 경영진 요약 박스 + P2 분석 요지 모두 **"약 2억 4,500만원 규모의 과태료 노출(합산, 중대재해법 제외)"** 톤 통일
+
+### E-5. 카카오 API 금지 (메모리 #23)
+- 이번 작업에 카카오 API 사용 없음 — 참고
+
+### E-6. Storage 캐싱 무효화
+- 이번 작업에는 캐시 무효화 로직 미포함 (최초 생성된 PDF가 영구 사용)
+- 추후 필요 시: `expires_at` 이후 자동 삭제 cron 또는 re-generate 엔드포인트 추가
+
+---
+
+## 📊 F. 참조 데이터
+
+### F-1. 가격 테이블 (DB: price_diagnosis_report)
+| 섹터 | 등급 | facility_type_code | 가격 | 판정 기준 |
+|---|---|---|---|---|
+| BUILDING | 소형 | BUILDING_V2 | 99,000원 | 연면적 < 5,000㎡ |
+| BUILDING | 대형 | BUILDING_LARGE_V2 | 249,000원 | 연면적 ≥ 5,000㎡ |
+| INDUSTRY | 기본 | INDUSTRY_V2 | 79,000원 | 사용자 선택 |
+| INDUSTRY | 정밀 | INDUSTRY_STANDARD | 149,000원 | 사용자 선택 |
+| INDUSTRY | 종합 | INDUSTRY_PREMIUM | 249,000원 | 사용자 선택 |
+| CONSTRUCTION | 기본 | CONSTRUCTION | 145,000원 | 공사금액 < 50억 |
+| CONSTRUCTION | 종합 | CONSTRUCTION_PREMIUM | 299,000원 (`total_report_fee`) | 공사금액 ≥ 50억 |
+
+⚠️ `CONSTRUCTION_PREMIUM.process_fee`는 385,000원이지만 **실제 표시 가격은 `total_report_fee`의 299,000원** (메모리 #21 확정).
+
+### F-2. 현행 파일 정보
+- `routers/diagnosis_proposal.py` (dev 브랜치 최신)
+  - SHA: `44c9c1a83c5db86dba0998f15d397fae4b5f91c5`
+  - 버전: v1.0.3 (2026-04-18, xhtml2pdf 한글 폰트 주입)
+  - 크기: 12,278 bytes
+- `templates/proposal_pdf.html` (dev 브랜치)
+  - 버전: v1.0.3
+  - 크기: 약 26.6 KB
+  - 구조: 표지 / 리스크 / TAI 도입제안 (3페이지)
+
+### F-3. DB 테이블 스키마 (anonymous_diagnosis_results)
+기존 컬럼:
+```
+id, public_token, input_data(jsonb), partial_result(jsonb), full_result(jsonb),
+created_at, expires_at, claimed_user_id, status, source_type,
+engine_version, rule_version, ci_hash, auth_log_id, disclaimer_log_id,
+tier_code, paid_amount, payment_ref
+```
+**추가 예정 컬럼:** `proposal_pdf_url TEXT`, `proposal_pdf_generated_at TIMESTAMPTZ`
+
+### F-4. mockup 파일 (시각 기준)
+`/mnt/user-data/outputs/proposal_mockup_v6.html`
+- 브라우저에서 열면 A4 프레임으로 5페이지 렌더링
+  - P1~P3: INDUSTRY 기준 3페이지
+  - P4: BUILDING P3 변형
+  - P5: CONSTRUCTION P3 변형
+- 하드코딩된 값:
+  - 회사명: "귀 사업장"
+  - 작성일: "2026년 4월 19일"
+  - 인원: 45명
+  - 법적 의무: 131건
+  - 과태료 노출: 약 2억 4,500만원
+  - 문서번호: TAI-2026-DR-A1B2C3D4
+
+---
+
+## 🔗 G. 향후 연계 작업 (이번 작업 범위 외)
+
+1. **유료 PDF 개편 (tai-api #5)**
+   - 티어별 상세 분석 범위(시설/공정/설비)를 유료 PDF 내부에 명시
+   - "본 진단은 X 등급으로 진행되었으며, 다음 범위까지 분석되었습니다"
+   - 별도 작업으로 분리
+
+2. **PDF 엔진 교체 (Phase 3)**
+   - xhtml2pdf → WeasyPrint 또는 Gotenberg 검토
+   - Storage 캐싱 적용 후 진행 (메모리 #28)
+
+3. **CI/CD 검증 파이프라인 (tai-api #3)**
+   - GitHub Actions에 `py_compile routers/*.py` 검증 스텝 추가
+   - MCP `\n` 버그 재발 방지
+
+---
+
+## ✅ H. 최종 확인 (PR 머지 전 필수)
+
+- [ ] `python -m py_compile routers/diagnosis_proposal.py` 통과
+- [ ] 로컬 또는 staging에서 3개 섹터 샘플로 PDF 생성 성공
+- [ ] 생성된 PDF가 v6 mockup과 시각적으로 일치 (결재란 없음, TAI 영업 내용 없음, 활용 포인트 박스 존재)
+- [ ] `penalty_sum_text`가 중대재해법 제외한 합산값으로 정상 표시
+- [ ] Storage 캐싱 동작: 첫 호출과 두 번째 호출 응답 시간 차이 확인 (두 번째는 캐시 redirect로 매우 빠름)
+- [ ] `engine_version` 컬럼에 버전 기록 (선택, 로그 추적용)
+
+---
+
+**작성자:** 기획창 (Claude)
+**핸드오프 대상:** Claude Code (또는 백엔드 구현 창)
+**작업 예상 시간:** Phase 1 (30분) + Phase 2~3 (2~3시간) + Phase 4~5 (30분) = **3~4시간**

--- a/docs/proposal_pdf_v6/mockup.html
+++ b/docs/proposal_pdf_v6/mockup.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8"/>
+<title>TAI 법령진단 분석 보고서 — v6 최종안</title>
+<style>
+body { font-family: "Malgun Gothic", "Apple SD Gothic Neo", "Noto Sans KR", Arial, sans-serif; font-size: 9.5pt; color: #0f172a; line-height: 1.5; margin: 0; padding: 20px; background: #e2e8f0; }
+.viewer-note { max-width: 210mm; margin: 0 auto 20px; padding: 14px 18px; background: #fef3c7; border-left: 4px solid #b45309; font-size: 10pt; border-radius: 4px; }
+.viewer-note strong { color: #78350f; }
+.sector-switch { max-width: 210mm; margin: 0 auto 20px; padding: 11px 16px; background: #1e293b; color: #fff; border-radius: 4px; font-size: 9.5pt; }
+.sector-switch strong { color: #60a5fa; }
+
+.page { width: 210mm; min-height: 297mm; background: white; margin: 0 auto 20px; padding: 14mm 12mm 16mm 12mm; box-shadow: 0 2px 20px rgba(0,0,0,0.1); box-sizing: border-box; page-break-after: always; }
+
+.sh { border-left: 4px solid #1A5FD4; padding: 0 0 0 8px; margin: 12px 0 7px 0; }
+.sh h2 { margin: 0; font-size: 12pt; color: #1A5FD4; font-weight: bold; }
+.sh p { margin: 2px 0 0; font-size: 8pt; color: #64748b; }
+
+.badge { padding: 2px 9px; border-radius: 10px; font-weight: bold; font-size: 10pt; }
+.b-high { background: #fef2f2; color: #dc2626; border: 1px solid #dc2626; }
+.b-med { background: #fffbeb; color: #b45309; border: 1px solid #b45309; }
+.b-low { background: #f0fdf4; color: #16a34a; border: 1px solid #16a34a; }
+
+.sc { background: #f1f5f9; padding: 9px 6px; text-align: center; border-radius: 3px; }
+.sc .k { font-size: 7.5pt; color: #64748b; }
+.sc .v { font-size: 18pt; font-weight: bold; color: #1A5FD4; margin: 3px 0; }
+
+.exec-box { background: #0f172a; color: #fff; border-radius: 3px; padding: 11px 13px; margin: 10px 0; }
+.exec-main { font-size: 11.5pt; font-weight: bold; margin-bottom: 8px; }
+.exec-num-val { font-size: 20pt; font-weight: bold; color: #60a5fa; }
+.exec-num-label { font-size: 7.5pt; color: rgba(255,255,255,0.65); }
+.exec-num-sub { font-size: 6.5pt; color: rgba(255,255,255,0.45); margin-top: 1px; }
+
+table.top5-table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+table.top5-table th { background: #1e293b; color: #fff; padding: 5px 7px; font-size: 8pt; text-align: left; }
+table.top5-table td { padding: 5px 7px; border-bottom: 1px solid #e2e8f0; font-size: 8.5pt; vertical-align: top; }
+table.top5-table tr:nth-child(even) td { background: #f8fafc; }
+
+table.cost-table { width: 100%; border-collapse: collapse; }
+table.cost-table th { background: #0f172a; color: #fff; padding: 6px 8px; font-size: 8.5pt; text-align: left; }
+table.cost-table td { padding: 6px 8px; border-bottom: 1px solid #e2e8f0; font-size: 8.5pt; vertical-align: top; }
+
+table.risk-bar-table { width: 100%; border-collapse: collapse; margin-bottom: 6px; }
+table.risk-bar-table td { padding: 3px 4px; font-size: 8pt; }
+.bar-danger { background: #dc2626; height: 14px; border-radius: 2px; }
+.bar-warning { background: #f97316; height: 14px; border-radius: 2px; }
+.bar-neutral { background: #94a3b8; height: 14px; border-radius: 2px; }
+
+.area-box { padding: 10px 13px; margin: 7px 0; border-radius: 3px; }
+.area-confirmed { background: #f0f9ff; border-left: 4px solid #0284c7; }
+.area-unconfirmed { background: #fef9c3; border-left: 4px solid #ca8a04; }
+.area-title { font-weight: bold; font-size: 10pt; margin-bottom: 5px; }
+.area-confirmed .area-title { color: #0369a1; }
+.area-unconfirmed .area-title { color: #854d0e; }
+.area-item { font-size: 8.8pt; margin: 3px 0 3px 10px; color: #334155; }
+
+/* 3개 티어 카드 (v6: 분석범위 삭제 → 산출물만) */
+.tier-grid { display: table; width: 100%; border-collapse: separate; border-spacing: 6px 0; margin-top: 9px; }
+.tier-card { display: table-cell; width: 33%; vertical-align: top; border: 1.5px solid #cbd5e1; border-radius: 4px; padding: 12px 11px; background: #fff; }
+.tier-badge { display: inline-block; color: #fff; font-size: 7.5pt; padding: 2px 9px; border-radius: 3px; font-weight: bold; margin-bottom: 7px; letter-spacing: 0.02em; }
+.tier-badge.basic { background: #64748b; }
+.tier-badge.standard { background: #1A5FD4; }
+.tier-badge.premium { background: #0f172a; }
+.tier-name { font-size: 11pt; font-weight: bold; color: #0f172a; margin-bottom: 3px; }
+.tier-price { font-size: 15pt; font-weight: bold; color: #1A5FD4; margin: 4px 0 2px; }
+.tier-price-note { font-size: 7.5pt; color: #64748b; margin-bottom: 10px; }
+.tier-output-title { font-size: 8pt; font-weight: bold; color: #0f172a; margin: 8px 0 4px; padding-top: 9px; border-top: 1px dashed #cbd5e1; }
+.tier-output-item { font-size: 9pt; color: #334155; margin: 3px 0 3px 4px; }
+.tier-output-pages { font-size: 7.8pt; color: #64748b; margin: 2px 0 2px 4px; }
+
+.single-tier-box { border: 2px solid #1A5FD4; border-radius: 4px; padding: 14px 16px; background: #eff6ff; margin: 9px 0; }
+.single-tier-badge { display: inline-block; background: #1A5FD4; color: #fff; font-size: 7.5pt; padding: 2px 9px; border-radius: 3px; font-weight: bold; margin-bottom: 6px; }
+.single-tier-row { display: table; width: 100%; border-collapse: separate; border-spacing: 6px 0; margin-top: 6px; }
+.single-tier-cell { display: table-cell; background: #fff; padding: 8px 10px; border-radius: 3px; vertical-align: top; width: 33%; }
+.single-tier-cell .dlabel { font-size: 7.5pt; color: #64748b; margin-bottom: 3px; }
+.single-tier-cell .dval { font-size: 12pt; font-weight: bold; color: #1A5FD4; }
+
+/* ★ v6 신규: 관공서 안전감독 활용 박스 */
+.safety-value-box {
+    margin-top: 10px;
+    padding: 10px 13px;
+    background: #f0fdf4;
+    border-left: 4px solid #16a34a;
+    border-radius: 3px;
+    font-size: 8.8pt;
+    color: #15803d;
+    line-height: 1.6;
+}
+.safety-value-box strong { color: #14532d; font-size: 9.2pt; }
+
+.usage-box { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 3px; padding: 11px 14px; margin: 10px 0; font-size: 9pt; color: #334155; line-height: 1.65; }
+
+.company-info { background: #fafafa; border: 1px solid #e2e8f0; border-radius: 3px; padding: 11px 14px; margin: 10px 0; }
+.company-info-title { font-size: 9pt; font-weight: bold; color: #0f172a; padding-bottom: 5px; margin-bottom: 6px; border-bottom: 1px solid #e2e8f0; }
+.company-info-row { display: table; width: 100%; border-collapse: collapse; }
+.company-info-cell { display: table-cell; width: 50%; vertical-align: top; padding: 2px 8px 2px 0; }
+.company-info-cell .cil { font-size: 7.5pt; color: #64748b; display: inline-block; width: 58px; }
+.company-info-cell .civ { font-size: 8pt; color: #334155; }
+
+.pf { border-top: 1px solid #e2e8f0; padding-top: 5px; margin-top: 10px; font-size: 7pt; color: #94a3b8; }
+.text-blue { color: #1A5FD4; font-weight: bold; }
+.text-red { color: #dc2626; font-weight: bold; }
+</style>
+</head>
+<body>
+
+<div class="viewer-note">
+  <strong>[Mockup v6 — 최종안]</strong><br>
+  ① INDUSTRY 3개 카드: 분석 범위(시설/공정/설비) 삭제, 산출물만 유지 (티어별 상세는 유료 PDF로 이전 예정)<br>
+  ② 전 섹터 유료 플랜 하단에 <strong>관공서 안전감독 활용 박스</strong> 신설<br>
+  ③ BUILDING/CONSTRUCTION 상위 등급 힌트 박스 뒤에도 동일 문구 배치
+</div>
+
+<div class="sector-switch">
+  📌 <strong>INDUSTRY 3페이지</strong> + <strong>BUILDING</strong>·<strong>CONSTRUCTION</strong> P3 변형
+</div>
+
+<!-- ========== PAGE 1 ========== -->
+<div class="page">
+
+<table style="width:100%; border-bottom: 3px solid #1A5FD4; padding-bottom: 7px; margin-bottom: 13px; border-collapse: collapse;">
+<tr>
+  <td style="vertical-align: middle;">
+    <span style="font-size:17pt; font-weight:bold; color:#1A5FD4;">TAI</span>
+    <span style="font-size:9pt; color:#64748b; margin-left:5px;">Engineering · taieng.co.kr</span>
+  </td>
+  <td style="text-align:right; vertical-align: middle;">
+    <span style="font-size:13.5pt; font-weight:bold; color:#0f172a;">산업안전 법령진단 분석 보고서</span><br/>
+    <span style="font-size:7.5pt; color:#64748b;">Legal Compliance Analysis Report</span>
+  </td>
+</tr>
+</table>
+
+<table style="width:100%; border-collapse: collapse; margin-bottom: 13px;">
+<tr>
+  <td style="width:49%; padding-right: 5px; vertical-align: top;">
+    <table style="width:100%; border-collapse: collapse; border: 1px solid #e2e8f0;">
+      <tr><td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; width:33%;">진단 대상</td><td style="padding:5px 8px; font-size:10pt; font-weight:bold;">귀 사업장</td></tr>
+      <tr><td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">작성일</td><td style="padding:5px 8px; font-size:8.5pt; border-top:1px solid #e2e8f0;">2026년 4월 19일</td></tr>
+      <tr><td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">사업장 유형</td><td style="padding:5px 8px; font-size:8.5pt; border-top:1px solid #e2e8f0;">산업(제조)</td></tr>
+    </table>
+  </td>
+  <td style="width:49%; padding-left: 5px; vertical-align: top;">
+    <table style="width:100%; border-collapse: collapse; border: 1px solid #e2e8f0;">
+      <tr><td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; width:33%;">문서번호</td><td style="padding:5px 8px; font-size:8.5pt;">TAI-2026-DR-A1B2C3D4</td></tr>
+      <tr><td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">상시 인원</td><td style="padding:5px 8px; font-size:8.5pt; border-top:1px solid #e2e8f0;">45명 <span style="color:#64748b;">(중대재해법 미적용 · 50인 기준)</span></td></tr>
+      <tr><td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">위험도</td><td style="padding:5px 8px; border-top:1px solid #e2e8f0;"><span class="badge b-med">보통 (MEDIUM)</span></td></tr>
+    </table>
+  </td>
+</tr>
+</table>
+
+<div class="exec-box">
+  <div class="exec-main">
+    귀 사업장은 <span style="color:#f59e0b;">131건</span>의 법적 의무를 이행해야 하며,
+    미이행 시 <span style="color:#f59e0b;">약 2억 4,500만원</span> 규모의 과태료에 노출되어 있습니다.
+  </div>
+  <table style="width:100%; border-collapse: collapse;">
+  <tr>
+    <td style="text-align:center; padding: 4px 6px; border-right: 1px solid rgba(255,255,255,0.2);">
+      <div class="exec-num-val">46</div>
+      <div class="exec-num-label">적용 법령 수</div>
+    </td>
+    <td style="text-align:center; padding: 4px 6px; border-right: 1px solid rgba(255,255,255,0.2);">
+      <div class="exec-num-val">131</div>
+      <div class="exec-num-label">법적 의무 총계</div>
+    </td>
+    <td style="text-align:center; padding: 4px 6px;">
+      <div class="exec-num-val" style="color:#f87171;">약 2.45억원</div>
+      <div class="exec-num-label">과태료 노출 총액</div>
+      <div class="exec-num-sub">(합산 · 중대재해법 제외)</div>
+    </td>
+  </tr>
+  </table>
+</div>
+
+<div class="sh"><h2>법적 의무 유형별 요약</h2></div>
+<table style="width:100%; border-collapse: collapse;">
+<tr>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">선임 의무</div><div class="v">8</div><div class="k">건</div></div></td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">점검·검사</div><div class="v">37</div><div class="k">건</div></div></td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">조치 의무</div><div class="v">55</div><div class="k">건</div></div></td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">보고·신고</div><div class="v">31</div><div class="k">건</div></div></td>
+</tr>
+</table>
+
+<div class="sh" style="margin-top:13px;"><h2>주요 리스크 TOP 5</h2><p>과태료 금액 기준 상위 5건 — 법령을 정밀 분석하여 도출</p></div>
+<table class="top5-table">
+<thead><tr><th style="width:6%;">순위</th><th style="width:42%;">위반 사항</th><th style="width:31%;">근거 법령</th><th style="width:21%;">처벌 내용</th></tr></thead>
+<tbody>
+<tr><td style="text-align:center; font-weight:bold; color:#1A5FD4;">1위</td><td>산업재해 발생 보고 미이행</td><td style="color:#64748b; font-size:8pt;">산업안전보건법 제57조</td><td style="color:#dc2626; font-weight:bold;">1,000만원</td></tr>
+<tr><td style="text-align:center; font-weight:bold; color:#1A5FD4;">2위</td><td>안전관리자 선임 의무</td><td style="color:#64748b; font-size:8pt;">산업안전보건법 제17조</td><td style="color:#dc2626; font-weight:bold;">500만원</td></tr>
+<tr><td style="text-align:center; font-weight:bold; color:#1A5FD4;">3위</td><td>근로자 안전보건교육 실시</td><td style="color:#64748b; font-size:8pt;">산업안전보건법 제29조</td><td style="color:#dc2626; font-weight:bold;">500만원</td></tr>
+<tr><td style="text-align:center; font-weight:bold; color:#1A5FD4;">4위</td><td>작업환경 측정 실시</td><td style="color:#64748b; font-size:8pt;">산업안전보건법 제125조</td><td style="color:#dc2626; font-weight:bold;">1,000만원</td></tr>
+<tr><td style="text-align:center; font-weight:bold; color:#1A5FD4;">5위</td><td>유해·위험설비 정기 검사</td><td style="color:#64748b; font-size:8pt;">산업안전보건법 제93조</td><td style="color:#dc2626; font-weight:bold;">500만원</td></tr>
+</tbody>
+</table>
+
+<div class="pf"><table style="width:100%; border-collapse:collapse;"><tr><td>TAI Engineering · taieng.co.kr · contact@taieng.co.kr</td><td style="text-align:right;">1 / 3</td></tr></table></div>
+</div><!-- /page1 -->
+
+
+<!-- ========== PAGE 2 ========== -->
+<div class="page">
+
+<table style="width:100%; border-collapse:collapse; border-bottom:2px solid #1A5FD4; padding-bottom:5px; margin-bottom:12px;">
+<tr><td><span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span> <span style="font-size:7.5pt; color:#64748b;">산업안전 법령진단 분석 보고서</span></td><td style="text-align:right; font-size:8pt; color:#64748b;">귀 사업장 · 2026년 4월 19일</td></tr>
+</table>
+
+<div class="sh"><h2>중대재해처벌법 적용 여부</h2></div>
+<div style="background:#fffbeb; border:1px solid #fcd34d; border-radius:3px; padding:10px 13px; margin:6px 0;">
+  <strong style="color:#b45309; font-size:10.5pt;">현재 상시 45인 — 즉시 적용 대상은 아닙니다</strong><br/>
+  <span style="font-size:8.8pt; color:#92400e; line-height:1.6;">상시 근로자 50인 이상 사업장에 중대재해처벌법이 적용됩니다. 현재 45명으로 5명 증가 시 즉시 적용되며, 5인 이상 사업장은 이미 산업안전보건법 처벌 대상이므로 사전 대비가 필요합니다.</span>
+</div>
+
+<div class="sh" style="margin-top:13px;"><h2>안전관리 방법별 비용·리스크 비교 (참고)</h2><p>법적 의무 미이행 시 노출되는 리스크와 관리 방식별 비용 분석</p></div>
+<table class="cost-table">
+<thead><tr><th style="width:23%;">관리 방법</th><th style="width:20%;">월 비용</th><th style="width:30%;">법적 리스크</th><th style="width:27%;">관리 수준</th></tr></thead>
+<tbody>
+<tr><td><strong>방치 (미조치)</strong></td><td style="color:#16a34a;">0원</td><td style="color:#dc2626;">과태료 수천만원 + 형사처벌 + 영업정지</td><td style="color:#dc2626;">법적 의무 미이행 — 처벌 위험 상존</td></tr>
+<tr><td><strong>엑셀·수기 관리</strong></td><td style="color:#16a34a;">0원</td><td style="color:#b45309;">누락·오기 발생 시 방치와 동일</td><td style="color:#b45309;">담당자 부재 시 관리 공백</td></tr>
+<tr><td><strong>안전관리 대행</strong></td><td>150 ~ 300만원</td><td style="color:#64748b;">사고 발생 시 책임 분산 한계</td><td>외부 의존도 높음</td></tr>
+</tbody>
+</table>
+
+<div class="sh" style="margin-top:13px;"><h2>관리 방식별 법적 리스크 수준</h2><p>막대가 길수록 처벌·사고 위험이 큰 방식</p></div>
+<table class="risk-bar-table">
+<tr><td style="width:18%; text-align:right; color:#64748b;">방치</td><td style="width:74%;"><table style="width:100%; border-collapse:collapse;"><tr><td style="width:100%;"><div class="bar-danger"></div></td></tr></table></td><td style="width:8%; color:#dc2626; font-weight:bold; padding-left:4px;">위험</td></tr>
+<tr><td style="text-align:right; color:#64748b;">엑셀 관리</td><td><table style="width:100%; border-collapse:collapse;"><tr><td style="width:88%;"><div class="bar-warning"></div></td><td style="width:12%;"></td></tr></table></td><td style="color:#f97316; font-weight:bold; padding-left:4px;">높음</td></tr>
+<tr><td style="text-align:right; color:#64748b;">안전 대행</td><td><table style="width:100%; border-collapse:collapse;"><tr><td style="width:42%;"><div class="bar-neutral"></div></td><td style="width:58%;"></td></tr></table></td><td style="color:#94a3b8; font-weight:bold; padding-left:4px;">보통</td></tr>
+</table>
+
+<div class="sh" style="margin-top:13px;"><h2>분석 요지</h2></div>
+<div style="background:#f1f5f9; border-radius:3px; padding:11px 14px; font-size:9pt; color:#334155; line-height:1.7;">
+  본 무료 진단 결과, 귀 사업장은 <strong class="text-blue">131건</strong>의 법적 의무에 대하여 <strong class="text-red">약 2억 4,500만원</strong> 규모의 과태료 노출(합산, 중대재해법 제외)이 확인되었으며, 중대재해처벌법 위반 시에는 별도로 경영책임자의 형사처벌이 가능합니다.<br/>
+  본 진단은 사업장 기본 정보만으로 도출된 일반 분석이며, 설비·공정·작업 단위의 개별 의무는 <strong>정밀 진단</strong>을 통해서만 확인할 수 있습니다. 다음 페이지에서 정밀 진단의 상세 구성과 예상 비용을 안내합니다.
+</div>
+
+<div class="pf"><table style="width:100%; border-collapse:collapse;"><tr><td>TAI Engineering · taieng.co.kr · contact@taieng.co.kr</td><td style="text-align:right;">2 / 3</td></tr></table></div>
+</div><!-- /page2 -->
+
+
+<!-- ========== PAGE 3 — INDUSTRY (v6: 분석범위 삭제, 산출물만) ========== -->
+<div class="page">
+
+<table style="width:100%; border-collapse:collapse; border-bottom:2px solid #1A5FD4; padding-bottom:5px; margin-bottom:12px;">
+<tr><td><span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span> <span style="font-size:7.5pt; color:#64748b;">산업안전 법령진단 분석 보고서</span></td><td style="text-align:right; font-size:8pt; color:#64748b;">귀 사업장 · 2026년 4월 19일</td></tr>
+</table>
+
+<div class="sh"><h2>1. 본 무료 진단에서 확인된 영역</h2></div>
+<div class="area-box area-confirmed">
+  <div class="area-title">분석 완료된 항목</div>
+  <div class="area-item">· 사업장 기본 정보 기반 법령 매칭 (업종·규모·위치)</div>
+  <div class="area-item">· 일반 법령 의무 131건 도출</div>
+  <div class="area-item">· 주요 리스크 TOP 5 식별 및 근거 법령 제시</div>
+  <div class="area-item">· 중대재해처벌법 적용 여부 자동 판정</div>
+</div>
+
+<div class="sh" style="margin-top:10px;"><h2>2. 본 무료 진단에서 확인되지 않은 영역</h2></div>
+<div class="area-box area-unconfirmed">
+  <div class="area-title">정밀 진단을 통해서만 확인 가능한 항목</div>
+  <div class="area-item">· <strong>시설별 상세 법령</strong> — 건축물·부속시설 개별 의무</div>
+  <div class="area-item">· <strong>위험물 취급 규정</strong> — 보유 위험물 종류·수량 기반 의무</div>
+  <div class="area-item">· <strong>공정 단위 안전의무</strong> — 작업 공정별 규정 (정밀 등급 이상)</div>
+  <div class="area-item">· <strong>설비별 개별 의무</strong> — 보유 설비 개별 점검·검사 규정 (종합 등급)</div>
+</div>
+
+<!-- ★ v6: 3개 티어 카드 — 분석 범위 삭제, 산출물만 -->
+<div class="sh" style="margin-top:11px;"><h2>3. 정밀 진단 (유료) — 3개 등급 안내</h2><p>사업장 특성에 맞는 등급을 선택하실 수 있습니다</p></div>
+
+<div class="tier-grid">
+  <div class="tier-card">
+    <div class="tier-badge basic">기본</div>
+    <div class="tier-name">제조·산업 기본</div>
+    <div class="tier-price">79,000원</div>
+    <div class="tier-price-note">VAT 별도 · 1회성</div>
+    <div class="tier-output-title">산출물</div>
+    <div class="tier-output-item">상세 PDF 리포트</div>
+    <div class="tier-output-pages">약 20페이지</div>
+  </div>
+
+  <div class="tier-card">
+    <div class="tier-badge standard">정밀</div>
+    <div class="tier-name">제조·산업 정밀</div>
+    <div class="tier-price">149,000원</div>
+    <div class="tier-price-note">VAT 별도 · 1회성</div>
+    <div class="tier-output-title">산출물</div>
+    <div class="tier-output-item">상세 PDF 리포트</div>
+    <div class="tier-output-pages">약 24페이지</div>
+  </div>
+
+  <div class="tier-card">
+    <div class="tier-badge premium">종합</div>
+    <div class="tier-name">제조·산업 종합</div>
+    <div class="tier-price">249,000원</div>
+    <div class="tier-price-note">VAT 별도 · 1회성</div>
+    <div class="tier-output-title">산출물</div>
+    <div class="tier-output-item">상세 PDF 리포트</div>
+    <div class="tier-output-pages">약 28페이지</div>
+  </div>
+</div>
+
+<div style="font-size:8pt; color:#64748b; margin-top:6px; padding-left:2px;">
+  ※ 공통 산출물: 전체 적용 법령 테이블 · 점검 일정 캘린더 · 선임 의무 양식 · 조항별 과태료 시뮬레이션<br>
+  ※ 등급별 상세 분석 범위는 safe.taieng.co.kr 신청 페이지에서 확인하실 수 있습니다.
+</div>
+
+<!-- ★ v6 신규: 관공서 안전감독 활용 박스 -->
+<div class="safety-value-box">
+  <strong>활용 포인트</strong><br>
+  본 유료 리포트는 <strong>관공서 안전감독 시</strong> 법적 의무 이행을 입증하는 근거자료로 활용하실 수 있습니다.
+</div>
+
+<div class="company-info" style="margin-top:10px;">
+  <div class="company-info-title">TAI Engineering</div>
+  <div class="company-info-row">
+    <div class="company-info-cell">
+      <div><span class="cil">사업자</span><span class="civ">723-39-01422</span></div>
+      <div><span class="cil">주소</span><span class="civ">서울시 강남구 테헤란로79길 6 JS타워 3층</span></div>
+      <div><span class="cil">이메일</span><span class="civ">contact@taieng.co.kr</span></div>
+      <div><span class="cil">홈페이지</span><span class="civ">taieng.co.kr</span></div>
+    </div>
+    <div class="company-info-cell" style="border-left: 1px solid #e2e8f0; padding-left: 12px;">
+      <div style="font-size:8pt; color:#0f172a; font-weight:bold; margin-bottom:3px;">지식재산권</div>
+      <div style="font-size:7.8pt; color:#334155; line-height:1.55;">
+        · 법령 자동진단 엔진 외 <strong>특허 출원 8건</strong><br>
+        · TAI 상표 등록 완료<br>
+        · 법령·시설·공정·설비·작업 연계 분석 기술
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="sh" style="margin-top:10px;"><h2>4. 본 보고서 활용 안내</h2></div>
+<div class="usage-box">
+  본 분석 보고서는 귀사의 내부 품의 진행 시 <strong>첨부 근거자료</strong>로 활용하실 수 있습니다. 품의서 본문에 정밀 진단 신청의 필요성을 기술하시고 본 보고서를 첨부하시면, 경영진이 법적 의무 건수와 과태료 노출 규모를 객관적으로 확인하실 수 있습니다. 정밀 진단은 <strong>safe.taieng.co.kr</strong>에서 직접 신청하실 수 있습니다.
+</div>
+
+<div class="pf" style="margin-top:10px;">
+  <table style="width:100%; border-collapse:collapse;">
+  <tr>
+    <td style="font-size:7pt; color:#94a3b8;">※ 본 보고서는 공개된 법령을 기반으로 정밀 분석하여 도출한 참고 자료이며 법적 효력이 없습니다. 실제 적용 여부는 관할 행정기관 또는 법률 전문가에게 확인하시기 바랍니다.</td>
+    <td style="text-align:right; white-space:nowrap; vertical-align:top;">3 / 3</td>
+  </tr>
+  </table>
+</div>
+</div><!-- /page3 INDUSTRY -->
+
+
+<!-- ========== PAGE 3 — BUILDING ========== -->
+<div class="sector-switch" style="background:#7c2d12;">
+  🏢 <strong style="color:#fdba74;">BUILDING 섹터 전용 P3</strong>
+</div>
+
+<div class="page">
+<table style="width:100%; border-collapse:collapse; border-bottom:2px solid #1A5FD4; padding-bottom:5px; margin-bottom:12px;">
+<tr><td><span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span> <span style="font-size:7.5pt; color:#64748b;">산업안전 법령진단 분석 보고서 — 건물</span></td><td style="text-align:right; font-size:8pt; color:#64748b;">귀 사업장 · 2026년 4월 19일</td></tr>
+</table>
+
+<div class="sh"><h2>1. 본 무료 진단에서 확인된 영역</h2></div>
+<div class="area-box area-confirmed">
+  <div class="area-title">분석 완료된 항목</div>
+  <div class="area-item">· 건축물대장 기반 법령 매칭 (용도·규모·층수)</div>
+  <div class="area-item">· 건물 일반 법령 의무 도출</div>
+  <div class="area-item">· 소방·승강기·전기안전 선임 의무</div>
+  <div class="area-item">· 중대재해처벌법 적용 여부 자동 판정</div>
+</div>
+
+<div class="sh" style="margin-top:10px;"><h2>2. 본 무료 진단에서 확인되지 않은 영역</h2></div>
+<div class="area-box area-unconfirmed">
+  <div class="area-title">정밀 진단을 통해서만 확인 가능한 항목</div>
+  <div class="area-item">· 건물 규모 기반 적용 법령 세부 매핑</div>
+  <div class="area-item">· 용도별 특수 규정 (근린·의료·판매 등)</div>
+  <div class="area-item">· 관리 주체·임차인 책임 구분</div>
+  <div class="area-item">· 세부 점검 주기 및 담당자 지정 기준</div>
+</div>
+
+<div class="sh" style="margin-top:11px;"><h2>3. 귀 사업장 해당 정밀 진단</h2><p>연면적 자동 판정 결과에 따라 아래 등급이 적용됩니다</p></div>
+
+<div class="single-tier-box">
+  <span class="single-tier-badge">귀 사업장 해당</span>
+  <div style="font-size:12pt; font-weight:bold; color:#0f172a; margin-bottom:4px;">소형건물 (5,000㎡ 미만)</div>
+  <div style="font-size:8.5pt; color:#64748b;">입력 연면적 2,800㎡ 기준 자동 판정</div>
+
+  <div class="single-tier-row">
+    <div class="single-tier-cell"><div class="dlabel">비용</div><div class="dval">99,000원</div><div style="font-size:7.5pt; color:#64748b;">VAT 별도 · 1회성</div></div>
+    <div class="single-tier-cell"><div class="dlabel">소요 시간</div><div class="dval">즉시</div><div style="font-size:7.5pt; color:#64748b;">결제 후 자동 분석</div></div>
+    <div class="single-tier-cell"><div class="dlabel">산출물</div><div class="dval">상세 PDF</div><div style="font-size:7.5pt; color:#64748b;">약 20페이지</div></div>
+  </div>
+
+  <div style="margin-top:10px; padding-top:9px; border-top:1px dashed #cbd5e1;">
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 전체 적용 법령 테이블</div>
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 층별·용도별 의무 매핑</div>
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 선임 의무자 양식 (소방·전기·승강기)</div>
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 건축물 정기점검 일정 캘린더</div>
+  </div>
+</div>
+
+<div style="background:#f8fafc; border:1px solid #e2e8f0; border-radius:3px; padding:10px 13px; margin-top:9px; font-size:8.5pt; color:#64748b; line-height:1.65;">
+  ※ 연면적 5,000㎡ 이상은 <strong>대형건물 등급(249,000원)</strong>이 적용됩니다. 입력 항목은 동일하나, 규모 기준에 따라 적용 법령 세트와 분석 결과가 달라집니다.
+</div>
+
+<!-- ★ v6 신규: 관공서 안전감독 활용 박스 -->
+<div class="safety-value-box">
+  <strong>활용 포인트</strong><br>
+  본 유료 리포트는 <strong>관공서 안전감독 시</strong> 법적 의무 이행을 입증하는 근거자료로 활용하실 수 있습니다.
+</div>
+
+<div class="company-info" style="margin-top:10px;">
+  <div class="company-info-title">TAI Engineering</div>
+  <div class="company-info-row">
+    <div class="company-info-cell">
+      <div><span class="cil">사업자</span><span class="civ">723-39-01422</span></div>
+      <div><span class="cil">주소</span><span class="civ">서울시 강남구 테헤란로79길 6 JS타워 3층</span></div>
+      <div><span class="cil">이메일</span><span class="civ">contact@taieng.co.kr</span></div>
+      <div><span class="cil">홈페이지</span><span class="civ">taieng.co.kr</span></div>
+    </div>
+    <div class="company-info-cell" style="border-left: 1px solid #e2e8f0; padding-left: 12px;">
+      <div style="font-size:8pt; color:#0f172a; font-weight:bold; margin-bottom:3px;">지식재산권</div>
+      <div style="font-size:7.8pt; color:#334155; line-height:1.55;">
+        · 법령 자동진단 엔진 외 <strong>특허 출원 8건</strong><br>
+        · TAI 상표 등록 완료
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="sh" style="margin-top:10px;"><h2>4. 본 보고서 활용 안내</h2></div>
+<div class="usage-box">
+  본 분석 보고서는 귀사의 내부 품의 진행 시 <strong>첨부 근거자료</strong>로 활용하실 수 있습니다. 정밀 진단은 <strong>safe.taieng.co.kr</strong>에서 직접 신청하실 수 있습니다.
+</div>
+
+<div class="pf" style="margin-top:10px;"><table style="width:100%; border-collapse:collapse;"><tr><td style="font-size:7pt; color:#94a3b8;">※ 본 보고서는 참고 자료이며 법적 효력이 없습니다.</td><td style="text-align:right;">3 / 3</td></tr></table></div>
+</div><!-- /page3 BUILDING -->
+
+
+<!-- ========== PAGE 3 — CONSTRUCTION ========== -->
+<div class="sector-switch" style="background:#14532d;">
+  🏗️ <strong style="color:#86efac;">CONSTRUCTION 섹터 전용 P3</strong>
+</div>
+
+<div class="page">
+<table style="width:100%; border-collapse:collapse; border-bottom:2px solid #1A5FD4; padding-bottom:5px; margin-bottom:12px;">
+<tr><td><span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span> <span style="font-size:7.5pt; color:#64748b;">산업안전 법령진단 분석 보고서 — 건설</span></td><td style="text-align:right; font-size:8pt; color:#64748b;">귀 사업장 · 2026년 4월 19일</td></tr>
+</table>
+
+<div class="sh"><h2>1. 본 무료 진단에서 확인된 영역</h2></div>
+<div class="area-box area-confirmed">
+  <div class="area-title">분석 완료된 항목</div>
+  <div class="area-item">· 현장 기본 정보 기반 법령 매칭 (공사금액·기간·인원)</div>
+  <div class="area-item">· 건설업 일반 법령 의무 도출</div>
+  <div class="area-item">· 안전관리자·보건관리자 선임 요건 판정</div>
+  <div class="area-item">· 중대재해처벌법 적용 여부 자동 판정</div>
+</div>
+
+<div class="sh" style="margin-top:10px;"><h2>2. 본 무료 진단에서 확인되지 않은 영역</h2></div>
+<div class="area-box area-unconfirmed">
+  <div class="area-title">정밀 진단을 통해서만 확인 가능한 항목</div>
+  <div class="area-item">· 공사금액 기반 적용 법령 세부 매핑</div>
+  <div class="area-item">· 안전관리비 산정 기준 및 요율</div>
+  <div class="area-item">· 원청·하청 안전 책임 분배 상세</div>
+  <div class="area-item">· 세부 점검 주기 및 담당자 지정 기준</div>
+</div>
+
+<div class="sh" style="margin-top:11px;"><h2>3. 귀 현장 해당 정밀 진단</h2><p>공사금액 자동 판정 결과에 따라 아래 등급이 적용됩니다</p></div>
+
+<div class="single-tier-box">
+  <span class="single-tier-badge">귀 현장 해당</span>
+  <div style="font-size:12pt; font-weight:bold; color:#0f172a; margin-bottom:4px;">건설 기본 등급 (50억원 미만)</div>
+  <div style="font-size:8.5pt; color:#64748b;">입력 공사금액 30억원 기준 자동 판정</div>
+
+  <div class="single-tier-row">
+    <div class="single-tier-cell"><div class="dlabel">비용</div><div class="dval">145,000원</div><div style="font-size:7.5pt; color:#64748b;">VAT 별도 · 1회성</div></div>
+    <div class="single-tier-cell"><div class="dlabel">소요 시간</div><div class="dval">즉시</div><div style="font-size:7.5pt; color:#64748b;">결제 후 자동 분석</div></div>
+    <div class="single-tier-cell"><div class="dlabel">산출물</div><div class="dval">상세 PDF</div><div style="font-size:7.5pt; color:#64748b;">약 22페이지</div></div>
+  </div>
+
+  <div style="margin-top:10px; padding-top:9px; border-top:1px dashed #cbd5e1;">
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 공종별 적용 법령 상세</div>
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 안전관리비 산정 가이드</div>
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· TBM·위험성평가 일정 캘린더</div>
+    <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">· 원청·하청 안전 책임 구분표</div>
+  </div>
+</div>
+
+<div style="background:#f8fafc; border:1px solid #e2e8f0; border-radius:3px; padding:10px 13px; margin-top:9px; font-size:8.5pt; color:#64748b; line-height:1.65;">
+  ※ 공사금액 50억원 이상은 <strong>건설 종합 등급(299,000원)</strong>이 적용됩니다. 입력 항목은 동일하나, 공사금액 기준에 따라 적용 법령 세트와 분석 결과가 달라집니다.
+</div>
+
+<!-- ★ v6 신규: 관공서 안전감독 활용 박스 -->
+<div class="safety-value-box">
+  <strong>활용 포인트</strong><br>
+  본 유료 리포트는 <strong>관공서 안전감독 시</strong> 법적 의무 이행을 입증하는 근거자료로 활용하실 수 있습니다.
+</div>
+
+<div class="company-info" style="margin-top:10px;">
+  <div class="company-info-title">TAI Engineering</div>
+  <div class="company-info-row">
+    <div class="company-info-cell">
+      <div><span class="cil">사업자</span><span class="civ">723-39-01422</span></div>
+      <div><span class="cil">주소</span><span class="civ">서울시 강남구 테헤란로79길 6 JS타워 3층</span></div>
+      <div><span class="cil">이메일</span><span class="civ">contact@taieng.co.kr</span></div>
+      <div><span class="cil">홈페이지</span><span class="civ">taieng.co.kr</span></div>
+    </div>
+    <div class="company-info-cell" style="border-left: 1px solid #e2e8f0; padding-left: 12px;">
+      <div style="font-size:8pt; color:#0f172a; font-weight:bold; margin-bottom:3px;">지식재산권</div>
+      <div style="font-size:7.8pt; color:#334155; line-height:1.55;">
+        · 법령 자동진단 엔진 외 <strong>특허 출원 8건</strong><br>
+        · TAI 상표 등록 완료
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="sh" style="margin-top:10px;"><h2>4. 본 보고서 활용 안내</h2></div>
+<div class="usage-box">
+  본 분석 보고서는 귀사의 내부 품의 진행 시 <strong>첨부 근거자료</strong>로 활용하실 수 있습니다. 정밀 진단은 <strong>safe.taieng.co.kr</strong>에서 직접 신청하실 수 있습니다.
+</div>
+
+<div class="pf" style="margin-top:10px;"><table style="width:100%; border-collapse:collapse;"><tr><td style="font-size:7pt; color:#94a3b8;">※ 본 보고서는 참고 자료이며 법적 효력이 없습니다.</td><td style="text-align:right;">3 / 3</td></tr></table></div>
+</div><!-- /page3 CONSTRUCTION -->
+
+</body>
+</html>

--- a/routers/diagnosis_proposal.py
+++ b/routers/diagnosis_proposal.py
@@ -1,7 +1,8 @@
 """
-routers/diagnosis_proposal.py — v1.0.3
-기안용 PDF 생성 — 결재권자용 3페이지 리스크 보고서
+routers/diagnosis_proposal.py — v2.0.0
+기안 PDF — 품의서 쳊부용 분석보고서 (v6 콘텐츠 + Storage 캐싱)
 
+v2.0.0 (2026-04-19): v6 콘텐츠 개편, Storage 캐싱, penalty_sum/paid_tiers 신규
 v1.0.3 (2026-04-18): xhtml2pdf 한글 폰트(NanumGothic) @font-face 주입
 v1.0.2 (2026-04-18): str 타입 규칙 항목 처리 (AttributeError 수정)
 v1.0.1 (2026-04-18): penalty_summary 한국어 텍스트 파싱 (ValueError 수정)
@@ -14,38 +15,26 @@ import logging
 import os
 import re
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import RedirectResponse, StreamingResponse
 
 from db.supabase_client import get_supabase
 
 log = logging.getLogger(__name__)
 router = APIRouter(prefix="/diagnosis", tags=["기안PDF"])
 
-VERSION = "1.0.3"
+VERSION = "2.0.0"
 
 SECTOR_LABEL: Dict[str, str] = {
     "INDUSTRY": "산업(제조)", "BUILDING": "건물·시설", "CONSTRUCTION": "건설",
     "MANUFACTURING": "산업(제조)", "SPECIAL_FACILITY": "건물·시설",
 }
-SECTOR_NORMALIZE: Dict[str, str] = {"MANUFACTURING": "INDUSTRY", "SPECIAL_FACILITY": "BUILDING"}
-
-_PLANS: Dict[str, Dict[str, Any]] = {
-    "INDUSTRY_STARTER_V2":      {"name": "산업 STARTER",  "monthly": 79000},
-    "INDUSTRY_BUSINESS_V2":     {"name": "산업 BUSINESS", "monthly": 149000},
-    "INDUSTRY_PRO":             {"name": "산업 PRO",       "monthly": 249000},
-    "INDUSTRY_CUSTOM_V2":       {"name": "산업 CUSTOM",    "monthly": None},
-    "BUILDING_BASIC":           {"name": "건물 BASIC",     "monthly": 59000},
-    "BUILDING_STANDARD":        {"name": "건물 STANDARD",  "monthly": 145000},
-    "BUILDING_CUSTOM":          {"name": "건물 CUSTOM",    "monthly": 249000},
-    "CONSTRUCTION_STANDARD_V2": {"name": "건설 STANDARD",  "monthly": 145000},
-    "CONSTRUCTION_PREMIUM_V2":  {"name": "건설 PREMIUM",   "monthly": 385000},
-    "CONSTRUCTION_CUSTOM_V2":   {"name": "건설 CUSTOM",    "monthly": None},
+SECTOR_NORMALIZE: Dict[str, str] = {
+    "MANUFACTURING": "INDUSTRY",
+    "SPECIAL_FACILITY": "BUILDING",
 }
-_AGENCY_MONTHLY_LOW  = 1_500_000
-_AGENCY_MONTHLY_HIGH = 3_000_000
 
 # xhtml2pdf 한글 폰트 — Dockerfile에서 fonts-nanum 설치 필요
 _FONT_FACE_CSS = """
@@ -78,10 +67,10 @@ def _parse_penalty_krw(text: Any) -> float:
     except ValueError:
         pass
     best = 0.0
-    for m in re.finditer(r'([0-9,]+(?:\.[0-9]+)?)\s*억\s*원?', s):
+    for m in re.finditer(r'([0-9,]+(?:\.[0-9]+)?)\s*\uc5b5\s*\uc6d0?', s):
         v = float(m.group(1).replace(',', ''))
         best = max(best, v * 100_000_000)
-    for m in re.finditer(r'([0-9,]+(?:\.[0-9]+)?)\s*만\s*원?', s):
+    for m in re.finditer(r'([0-9,]+(?:\.[0-9]+)?)\s*\ub9cc\s*\uc6d0?', s):
         v = float(m.group(1).replace(',', ''))
         best = max(best, v * 10_000)
     return best
@@ -89,17 +78,17 @@ def _parse_penalty_krw(text: Any) -> float:
 
 def _format_penalty(amount: float) -> str:
     if amount <= 0:
-        return "법령 기준"
+        return "\ubc95\ub839 \uae30\uc900"
     if amount >= 100_000_000:
         v = amount / 100_000_000
-        return f"{int(v):,}억원" if v == int(v) else f"{v:.1f}억원"
+        return f"{int(v):,}\uc5b5\uc6d0" if v == int(v) else f"{v:.1f}\uc5b5\uc6d0"
     if amount >= 10_000:
         v = amount / 10_000
-        return f"{int(v):,}만원"
-    return f"{int(amount):,}원"
+        return f"{int(v):,}\ub9cc\uc6d0"
+    return f"{int(amount):,}\uc6d0"
 
 
-def _get_penalty_from_rule(r) -> float:
+def _get_penalty_from_rule(r: Any) -> float:
     if not isinstance(r, dict):
         return _parse_penalty_krw(r) if isinstance(r, str) else 0.0
     amt = r.get("penalty_amount")
@@ -110,11 +99,115 @@ def _get_penalty_from_rule(r) -> float:
     return _parse_penalty_krw(r.get("penalty_summary") or r.get("penalty_text") or "")
 
 
+def _compute_penalty_sum(rules_flat: List[Dict[str, Any]]) -> float:
+    """\uc804\uccb4 \uaddc\uce59\uc758 \uacfc\ud0dc\ub8cc\ub97c \ud569\uc0b0. \uc911\ub300\uc7ac\ud574\uccab\ubc8c\ubc95 \ud56d\ubaa9\uc740 \uc81c\uc678."""
+    total = 0.0
+    for r in rules_flat:
+        if not isinstance(r, dict):
+            continue
+        law_name = str(r.get("law_name") or r.get("law") or "").strip()
+        if "\uc911\ub300\uc7ac\ud574" in law_name:
+            continue
+        total += _get_penalty_from_rule(r)
+    return total
+
+
+def _build_paid_tiers(sector: str, input_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    \uc139\ud130\ubcc4 \uc720\ub8cc \ud2f0\uc5b4 \uad6c\uc131 \uc0dd\uc131.
+    - INDUSTRY: 3\uac1c \ud2f0\uc5b4 \ub9ac\uc2a4\ud2b8 (\uc0ac\uc6a9\uc790 \uc120\ud0dd\ud615)
+    - BUILDING: \uba74\uc801 \uae30\uc900 \uc790\ub3d9 \ud310\uc815 (\ub2e8\uc77c \ud655\uc815 + \uc0c1\uc704 \ud78c\ud2b8)
+    - CONSTRUCTION: \uacf5\uc0ac\uae08\uc561 \uae30\uc900 \uc790\ub3d9 \ud310\uc815 (\ub2e8\uc77c \ud655\uc815 + \uc0c1\uc704 \ud78c\ud2b8)
+    """
+    if sector == "INDUSTRY":
+        return {
+            "mode": "select",
+            "tiers": [
+                {"badge_class": "basic",    "code": "INDUSTRY_V2",       "name": "\uc81c\uc870\u00b7\uc0b0\uc5c5 \uae30\ubcf8", "price": 79000,  "pages": 20},
+                {"badge_class": "standard", "code": "INDUSTRY_STANDARD", "name": "\uc81c\uc870\u00b7\uc0b0\uc5c5 \uc815\ubc00", "price": 149000, "pages": 24},
+                {"badge_class": "premium",  "code": "INDUSTRY_PREMIUM",  "name": "\uc81c\uc870\u00b7\uc0b0\uc5c5 \uc885\ud569", "price": 249000, "pages": 28},
+            ],
+        }
+
+    if sector == "BUILDING":
+        try:
+            area = float(input_data.get("total_floor_area") or 0)
+        except (TypeError, ValueError):
+            area = 0.0
+
+        if area < 5000:
+            determined = {
+                "code": "BUILDING_V2",
+                "name": "\uc18c\ud615\uac74\ubb3c (5,000\u33a1 \ubbf8\ub9cc)",
+                "price": 99000,
+                "pages": 20,
+            }
+            upper: Optional[Dict[str, Any]] = {
+                "name": "\ub300\ud615\uac74\ubb3c \ub4f1\uae09",
+                "price": 249000,
+                "threshold": "\uc5f0\uba74\uc801 5,000\u33a1 \uc774\uc0c1",
+            }
+        else:
+            determined = {
+                "code": "BUILDING_LARGE_V2",
+                "name": "\ub300\ud615\uac74\ubb3c (5,000\u33a1 \uc774\uc0c1)",
+                "price": 249000,
+                "pages": 25,
+            }
+            upper = None
+
+        return {
+            "mode": "determined",
+            "determined": determined,
+            "upper": upper,
+            "basis": f"\uc785\ub825 \uc5f0\uba74\uc801 {int(area):,}\u33a1 \uae30\uc900 \uc790\ub3d9 \ud310\uc815",
+        }
+
+    if sector == "CONSTRUCTION":
+        try:
+            raw_amount = input_data.get("project_amount") or 0
+            amount_won = float(raw_amount)
+            # 10\uc5b5 \uc774\uc0c1\uc774\uba74 \uc6d0 \ub2e8\uc704, \uc544\ub2c8\uba74 \uc5b5\uc6d0 \ub2e8\uc704\ub85c \uac00\uc815
+            amount_eok = amount_won / 100_000_000 if amount_won >= 1_000_000_000 else amount_won
+        except (TypeError, ValueError):
+            amount_eok = 0.0
+
+        if amount_eok < 50:
+            determined = {
+                "code": "CONSTRUCTION",
+                "name": "\uac74\uc124 \uae30\ubcf8 \ub4f1\uae09 (50\uc5b5\uc6d0 \ubbf8\ub9cc)",
+                "price": 145000,
+                "pages": 22,
+            }
+            upper = {
+                "name": "\uac74\uc124 \uc885\ud569 \ub4f1\uae09",
+                "price": 299000,
+                "threshold": "\uacf5\uc0ac\uae08\uc561 50\uc5b5\uc6d0 \uc774\uc0c1",
+            }
+        else:
+            determined = {
+                "code": "CONSTRUCTION_PREMIUM",
+                "name": "\uac74\uc124 \uc885\ud569 \ub4f1\uae09 (50\uc5b5\uc6d0 \uc774\uc0c1)",
+                "price": 299000,
+                "pages": 28,
+            }
+            upper = None
+
+        return {
+            "mode": "determined",
+            "determined": determined,
+            "upper": upper,
+            "basis": f"\uc785\ub825 \uacf5\uc0ac\uae08\uc561 {int(amount_eok):,}\uc5b5\uc6d0 \uae30\uc900 \uc790\ub3d9 \ud310\uc815",
+        }
+
+    return {"mode": "select", "tiers": []}
+
+
 def _fetch_row(token: str) -> Dict[str, Any]:
     sb = get_supabase()
     res = sb.table("anonymous_diagnosis_results").select("*").eq("public_token", token).limit(1).execute()
     if not res.data:
-        raise HTTPException(status_code=404, detail="진단 결과를 찾을 수 없습니다.")
+        raise HTTPException(status_code=404, detail="\uc9c4\ub2e8 \uacb0\uacfc\ub97c \ucc3e\uc744 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.")
     row = res.data[0]
     exp = row.get("expires_at")
     if exp:
@@ -123,7 +216,7 @@ def _fetch_row(token: str) -> Dict[str, Any]:
             if exp_dt.tzinfo is None:
                 exp_dt = exp_dt.replace(tzinfo=timezone.utc)
             if _now() > exp_dt:
-                raise HTTPException(status_code=410, detail="만료된 진단 결과입니다.")
+                raise HTTPException(status_code=410, detail="\ub9cc\ub8cc\ub41c \uc9c4\ub2e8 \uacb0\uacfc\uc785\ub2c8\ub2e4.")
         except HTTPException:
             raise
         except Exception:
@@ -146,7 +239,7 @@ def _get_top5(full: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "title": (
                     r.get("rule_name") or r.get("title") or
                     r.get("obligation_summary") or r.get("obligation") or
-                    r.get("name") or "법적 의무 사항"
+                    r.get("name") or "\ubc95\uc801 \uc758\ubb34 \uc0ac\ud56d"
                 ),
                 "law": r.get("law_name") or r.get("law") or r.get("law_short_name") or "-",
                 "penalty": penalty_text,
@@ -164,31 +257,12 @@ def _get_top5(full: Dict[str, Any]) -> List[Dict[str, Any]]:
     seen: set = set()
     deduped: List[Dict[str, Any]] = []
     for c in candidates:
-        key = c["title"][:30]
-        if key not in seen:
-            seen.add(key)
+        k = c["title"][:30]
+        if k not in seen:
+            seen.add(k)
             deduped.append(c)
     deduped.sort(key=lambda x: x["amount"], reverse=True)
     return deduped[:5]
-
-
-def _recommend_plan(sector: str, severity: str, obl_cnt: int, workers: int) -> Tuple[str, Dict[str, Any]]:
-    try:
-        from routers.diagnosis_plan_recommend import (
-            _recommend_industry, _recommend_building, _recommend_construction,
-        )
-        if sector == "INDUSTRY":
-            code, _ = _recommend_industry(severity, obl_cnt, workers)
-        elif sector == "BUILDING":
-            code, _ = _recommend_building(severity, obl_cnt, workers)
-        elif sector == "CONSTRUCTION":
-            code, _ = _recommend_construction(severity, obl_cnt, workers)
-        else:
-            code = "INDUSTRY_STARTER_V2"
-    except Exception as e:
-        log.warning(f"[proposal-pdf] 플랜 추천 오류 (fallback): {e}")
-        code = "INDUSTRY_STARTER_V2"
-    return code, _PLANS.get(code, {"name": "맞춤 플랜", "monthly": None})
 
 
 def _build_context(row: Dict[str, Any]) -> Dict[str, Any]:
@@ -196,12 +270,12 @@ def _build_context(row: Dict[str, Any]) -> Dict[str, Any]:
     partial    = row.get("partial_result") or {}
     full       = row.get("full_result") or {}
 
-    raw_sector = str(input_data.get("sector") or full.get("sector") or partial.get("sector") or "INDUSTRY").upper()
+    raw_sector   = str(input_data.get("sector") or full.get("sector") or partial.get("sector") or "INDUSTRY").upper()
     sector       = SECTOR_NORMALIZE.get(raw_sector, raw_sector)
-    sector_label = SECTOR_LABEL.get(raw_sector, "산업")
+    sector_label = SECTOR_LABEL.get(raw_sector, "\uc0b0\uc5c5")
 
-    company_name = input_data.get("company_name") or input_data.get("site_kind") or "귀 사업장"
-    report_date  = _now().strftime("%Y년 %m월 %d일")
+    company_name = input_data.get("company_name") or input_data.get("site_kind") or "\uadc0 \uc0ac\uc5c5\uc7a5"
+    report_date  = _now().strftime("%Y\ub144 %m\uc6d4 %d\uc77c")
     workers      = int(input_data.get("workers") or input_data.get("worker_count") or 0)
 
     summary       = partial.get("summary") or full.get("summary") or {}
@@ -222,38 +296,35 @@ def _build_context(row: Dict[str, Any]) -> Dict[str, Any]:
         items = full.get(key) or []
         all_rules_flat.extend(r for r in items if isinstance(r, dict))
 
-    max_penalty = max(
-        (_get_penalty_from_rule(r) for r in all_rules_flat),
-        default=0.0,
-    )
-    max_penalty_text = _format_penalty(max_penalty)
+    # v2.0.0: \uacfc\ud0dc\ub8cc \ud569\uc0b0 (\uc911\ub300\uc7ac\ud574\ubc95 \uc81c\uc678)
+    penalty_sum      = _compute_penalty_sum(all_rules_flat)
+    penalty_sum_text = _format_penalty(penalty_sum)
 
-    top5 = _get_top5(full)
+    top5            = _get_top5(full)
     csia_applicable = workers >= 50
 
-    plan_code, plan_info = _recommend_plan(sector, risk_level, total, workers)
-    monthly = plan_info.get("monthly")
-    plan_price = f"월 {monthly:,}원" if monthly else "맞춤 견적"
-
-    monthly_plan = monthly or 149_000
-    annual_savings_low  = max(0, int((_AGENCY_MONTHLY_LOW  - monthly_plan) * 12 / 10_000))
-    annual_savings_high = max(0, int((_AGENCY_MONTHLY_HIGH - monthly_plan) * 12 / 10_000))
+    # v2.0.0: \uc139\ud130\ubcc4 \uc720\ub8cc \ud2f0\uc5b4
+    paid_tiers = _build_paid_tiers(sector, input_data)
 
     return {
-        "company_name": company_name, "report_date": report_date,
-        "sector_label": sector_label, "sector": sector,
-        "risk_level": risk_level, "workers": workers,
-        "report_no": str(row.get("public_token", ""))[:8].upper(),
-        "total": total, "appointment": appointment, "inspection": inspection,
-        "action": action, "report_notify": report_notify,
-        "law_count": law_count, "max_penalty_text": max_penalty_text,
-        "top5": top5, "csia_applicable": csia_applicable,
-        "recommended_plan_name": plan_info.get("name", ""),
-        "recommended_plan_price": plan_price,
-        "recommended_plan_monthly": monthly or 0,
-        "plan_code": plan_code,
-        "annual_savings_low": annual_savings_low,
-        "annual_savings_high": annual_savings_high,
+        "company_name":     company_name,
+        "report_date":      report_date,
+        "sector_label":     sector_label,
+        "sector":           sector,
+        "risk_level":       risk_level,
+        "workers":          workers,
+        "report_no":        str(row.get("public_token", ""))[:8].upper(),
+        "total":            total,
+        "appointment":      appointment,
+        "inspection":       inspection,
+        "action":           action,
+        "report_notify":    report_notify,
+        "law_count":        law_count,
+        "penalty_sum":      penalty_sum,
+        "penalty_sum_text": penalty_sum_text,
+        "top5":             top5,
+        "csia_applicable":  csia_applicable,
+        "paid_tiers":       paid_tiers,
     }
 
 
@@ -267,7 +338,7 @@ def _render_html(context: Dict[str, Any]) -> str:
         template = env.get_template("proposal_pdf.html")
         html = template.render(**context)
 
-        # xhtml2pdf 한글 폰트 주입: @font-face + body font-family 교체
+        # xhtml2pdf \ud55c\uae00 \ud3f0\ud2b8 \uc8fc\uc785
         html = html.replace("</style>", _FONT_FACE_CSS + "\n</style>")
         html = html.replace(
             'font-family: "Noto Sans KR", "Malgun Gothic", "Apple SD Gothic Neo", Arial, sans-serif;',
@@ -275,38 +346,71 @@ def _render_html(context: Dict[str, Any]) -> str:
         )
         return html
     except Exception as e:
-        log.error(f"[proposal-pdf] 템플릿 렌더링 실패: {e}")
-        raise HTTPException(status_code=500, detail=f"템플릿 렌더링 실패: {e}")
+        log.error(f"[proposal-pdf] \ud15c\ud50c\ub9bf \ub80c\ub354\ub9c1 \uc2e4\ud328: {e}")
+        raise HTTPException(status_code=500, detail=f"\ud15c\ud50c\ub9bf \ub80c\ub354\ub9c1 \uc2e4\ud328: {e}")
 
 
 def _generate_pdf(html: str) -> bytes:
     try:
         from xhtml2pdf import pisa
     except ImportError:
-        raise HTTPException(status_code=500, detail="xhtml2pdf 라이브러리가 설치되어 있지 않습니다.")
+        raise HTTPException(status_code=500, detail="xhtml2pdf \ub77c\uc774\ube0c\ub7ec\ub9ac\uac00 \uc124\uce58\ub418\uc5b4 \uc788\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4.")
 
     buf = io.BytesIO()
     result = pisa.pisaDocument(io.BytesIO(html.encode("utf-8")), buf, encoding="utf-8")
     if result.err:
-        raise HTTPException(status_code=500, detail=f"PDF 생성 실패: {result.err}")
+        raise HTTPException(status_code=500, detail=f"PDF \uc0dd\uc131 \uc2e4\ud328: {result.err}")
     return buf.getvalue()
 
 
 @router.get("/proposal-pdf/{public_token}")
 def get_proposal_pdf(public_token: str):
-    """기안용 PDF — 결재권자용 3페이지 리스크 보고서 (공개 엔드포인트)."""
-    row     = _fetch_row(public_token)
-    context = _build_context(row)
-    html    = _render_html(context)
-    pdf     = _generate_pdf(html)
+    """\uae30\uc548\uc6a9 PDF \u2014 \ud488\uc758\uc11c \uccca\ubd80 \uadfc\uac70\uc790\ub8cc (\uacf5\uac1c \uc5d4\ub4dc\ud3ec\uc778\ud2b8, Storage \uce90\uc2f1 \uc801\uc6a9)."""
+    row = _fetch_row(public_token)
 
+    # Cache hit check \u2014 \uc774\ubbf8 \uc0dd\uc131\ub41c PDF\uac00 \uc788\uc73c\uba74 \uc989\uc2dc redirect
+    cached_url = row.get("proposal_pdf_url")
+    if cached_url:
+        log.info(f"[proposal-pdf] cache hit: {public_token}")
+        return RedirectResponse(url=cached_url, status_code=302)
+
+    # PDF \uc0dd\uc131
+    context  = _build_context(row)
+    html     = _render_html(context)
+    pdf      = _generate_pdf(html)
     filename = f"TAI_proposal_{context['report_no']}.pdf"
-    return StreamingResponse(
-        io.BytesIO(pdf),
-        media_type="application/pdf",
-        headers={
-            "Content-Disposition": f'attachment; filename="{filename}"',
-            "Content-Length": str(len(pdf)),
-            "Cache-Control": "no-store",
-        },
-    )
+
+    # Storage \uc5c5\ub85c\ub4dc \ud6c4 DB\uc5d0 URL \uae30\ub85d (\uc2e4\ud328 \uc2dc \uc9c1\uc811 \uc2a4\ud2b8\ub9ac\ubc0d fallback)
+    try:
+        sb           = get_supabase()
+        storage_path = f"{public_token}/{filename}"
+
+        sb.storage.from_("proposals").upload(
+            path=storage_path,
+            file=pdf,
+            file_options={
+                "content-type": "application/pdf",
+                "upsert": "true",
+            },
+        )
+        public_url = sb.storage.from_("proposals").get_public_url(storage_path)
+
+        sb.table("anonymous_diagnosis_results").update({
+            "proposal_pdf_url":          public_url,
+            "proposal_pdf_generated_at": _now().isoformat(),
+        }).eq("public_token", public_token).execute()
+
+        log.info(f"[proposal-pdf] generated+cached: {public_token}")
+        return RedirectResponse(url=public_url, status_code=302)
+
+    except Exception as e:
+        log.error(f"[proposal-pdf] storage upload failed, streaming fallback: {e}")
+        return StreamingResponse(
+            io.BytesIO(pdf),
+            media_type="application/pdf",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length":      str(len(pdf)),
+                "Cache-Control":       "no-store",
+            },
+        )

--- a/templates/proposal_pdf.html
+++ b/templates/proposal_pdf.html
@@ -2,12 +2,12 @@
 <html lang="ko">
 <head>
 <meta charset="UTF-8"/>
+<title>산업안전 법령진단 분석 보고서</title>
 <style>
 /* ============================================================
-   TAI Safe — 기안용 PDF 템플릿 (결재권자용)
+   TAI — 기안 PDF v6 템플릿 (품의서 첨부용 분석 보고서)
    Stack: Jinja2 + xhtml2pdf
-   xhtml2pdf 호환: 테이블 레이아웃, inline-block 최소화
-   SVG 미사용: HTML 테이블·CSS 바 차트로 대체
+   xhtml2pdf 호환: 테이블 레이아웃, display:table/table-cell
    ============================================================ */
 
 @page {
@@ -25,254 +25,135 @@ body {
 }
 
 /* ---- 페이지 구분 ---- */
-.page      { page-break-after: always; }
-.page-last { /* no break */ }
+.page { page-break-after: always; }
+.page:last-child { page-break-after: auto; }
 
 /* ---- 섹션 헤더 ---- */
-.sh {
-    border-left: 4px solid #1A5FD4;
-    padding: 0 0 0 8px;
-    margin: 12px 0 7px 0;
-}
-.sh h2 {
-    margin: 0;
-    font-size: 12pt;
-    color: #1A5FD4;
-    font-weight: bold;
-}
-.sh p {
-    margin: 2px 0 0;
-    font-size: 8pt;
-    color: #64748b;
-}
+.sh { border-left: 4px solid #1A5FD4; padding: 0 0 0 8px; margin: 12px 0 7px 0; }
+.sh h2 { margin: 0; font-size: 12pt; color: #1A5FD4; font-weight: bold; }
+.sh p { margin: 2px 0 0; font-size: 8pt; color: #64748b; }
 
 /* ---- 뱃지 ---- */
-.badge {
-    padding: 2px 9px;
-    border-radius: 10px;
-    font-weight: bold;
-    font-size: 10pt;
-}
-.b-high     { background: #fef2f2; color: #dc2626; border: 1px solid #dc2626; }
-.b-med      { background: #fffbeb; color: #b45309; border: 1px solid #b45309; }
-.b-low      { background: #f0fdf4; color: #16a34a; border: 1px solid #16a34a; }
-.b-critical { background: #dc2626; color: #fff; }
+.badge { padding: 2px 9px; border-radius: 10px; font-weight: bold; font-size: 10pt; }
+.b-high { background: #fef2f2; color: #dc2626; border: 1px solid #dc2626; }
+.b-med  { background: #fffbeb; color: #b45309; border: 1px solid #b45309; }
+.b-low  { background: #f0fdf4; color: #16a34a; border: 1px solid #16a34a; }
 
-/* ---- 요약 카드 그리드 (4열 테이블) ---- */
-.sc {
-    background: #f1f5f9;
-    padding: 9px 6px;
-    text-align: center;
-    border-radius: 3px;
-}
+/* ---- 요약 카드 (4열 테이블) ---- */
+.sc { background: #f1f5f9; padding: 9px 6px; text-align: center; border-radius: 3px; }
 .sc .k { font-size: 7.5pt; color: #64748b; }
 .sc .v { font-size: 18pt; font-weight: bold; color: #1A5FD4; margin: 3px 0; }
 
 /* ---- 경영진 요약 박스 ---- */
-.exec-box {
-    background: #0f172a;
-    color: #fff;
-    border-radius: 3px;
-    padding: 11px 13px;
-    margin: 10px 0;
-}
-.exec-main {
-    font-size: 11.5pt;
-    font-weight: bold;
-    margin-bottom: 8px;
-}
-.exec-num-val   { font-size: 20pt; font-weight: bold; color: #60a5fa; }
+.exec-box { background: #0f172a; color: #fff; border-radius: 3px; padding: 11px 13px; margin: 10px 0; }
+.exec-main { font-size: 11.5pt; font-weight: bold; margin-bottom: 8px; }
+.exec-num-val { font-size: 20pt; font-weight: bold; color: #60a5fa; }
 .exec-num-label { font-size: 7.5pt; color: rgba(255,255,255,0.65); }
+.exec-num-sub { font-size: 6.5pt; color: rgba(255,255,255,0.45); margin-top: 1px; }
 
 /* ---- TOP 5 테이블 ---- */
-table.top5-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 5px;
-}
-table.top5-table th {
-    background: #1e293b;
-    color: #fff;
-    padding: 5px 7px;
-    font-size: 8pt;
-    text-align: left;
-}
-table.top5-table td {
-    padding: 5px 7px;
-    border-bottom: 1px solid #e2e8f0;
-    font-size: 8.5pt;
-    vertical-align: top;
-}
+table.top5-table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+table.top5-table th { background: #1e293b; color: #fff; padding: 5px 7px; font-size: 8pt; text-align: left; }
+table.top5-table td { padding: 5px 7px; border-bottom: 1px solid #e2e8f0; font-size: 8.5pt; vertical-align: top; }
 table.top5-table tr:nth-child(even) td { background: #f8fafc; }
 
 /* ---- 비용 비교 테이블 ---- */
-table.cost-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-table.cost-table th {
-    background: #0f172a;
-    color: #fff;
-    padding: 6px 8px;
-    font-size: 8.5pt;
-    text-align: left;
-}
-table.cost-table td {
-    padding: 6px 8px;
-    border-bottom: 1px solid #e2e8f0;
-    font-size: 8.5pt;
-    vertical-align: top;
-}
-.tai-row td {
-    background: #eff6ff;
-    font-weight: bold;
-}
-.tai-row td:first-child { border-left: 3px solid #1A5FD4; }
+table.cost-table { width: 100%; border-collapse: collapse; }
+table.cost-table th { background: #0f172a; color: #fff; padding: 6px 8px; font-size: 8.5pt; text-align: left; }
+table.cost-table td { padding: 6px 8px; border-bottom: 1px solid #e2e8f0; font-size: 8.5pt; vertical-align: top; }
 
 /* ---- 리스크 바 차트 ---- */
-table.risk-bar-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 6px;
-}
+table.risk-bar-table { width: 100%; border-collapse: collapse; margin-bottom: 6px; }
 table.risk-bar-table td { padding: 3px 4px; font-size: 8pt; }
 .bar-danger  { background: #dc2626; height: 14px; border-radius: 2px; }
 .bar-warning { background: #f97316; height: 14px; border-radius: 2px; }
 .bar-neutral { background: #94a3b8; height: 14px; border-radius: 2px; }
-.bar-good    { background: #1A5FD4; height: 14px; border-radius: 2px; }
 
-/* ---- 경고 박스 ---- */
-.wb {
-    background: #fef2f2;
-    border: 2px solid #dc2626;
-    border-radius: 3px;
-    padding: 9px 11px;
-    margin: 8px 0;
-}
-.wb-title { font-weight: bold; color: #dc2626; font-size: 10.5pt; margin-bottom: 6px; }
-.csia-row td {
-    padding: 4px;
-    vertical-align: top;
-    width: 33%;
-}
-.csia-cell {
-    background: #fff;
-    border: 1px solid #fca5a5;
-    border-radius: 3px;
-    padding: 7px;
-    text-align: center;
-}
-.csia-cell .label { font-size: 8pt; color: #64748b; margin-bottom: 3px; }
-.csia-cell .val   { font-weight: bold; color: #dc2626; font-size: 9.5pt; }
-.csia-cell .sub   { font-size: 7.5pt; color: #dc2626; }
-.csia-banner {
-    background: #7f1d1d;
-    color: #fff;
-    padding: 7px 10px;
-    border-radius: 3px;
-    margin-top: 7px;
-    text-align: center;
-    font-weight: bold;
-    font-size: 10.5pt;
-}
+/* ---- 확인/미확인 영역 박스 ---- */
+.area-box { padding: 10px 13px; margin: 7px 0; border-radius: 3px; }
+.area-confirmed { background: #f0f9ff; border-left: 4px solid #0284c7; }
+.area-unconfirmed { background: #fef9c3; border-left: 4px solid #ca8a04; }
+.area-title { font-weight: bold; font-size: 10pt; margin-bottom: 5px; }
+.area-confirmed .area-title { color: #0369a1; }
+.area-unconfirmed .area-title { color: #854d0e; }
+.area-item { font-size: 8.8pt; margin: 3px 0 3px 10px; color: #334155; }
 
-/* ---- 도입 4단계 ---- */
-table.step-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-table.step-table td { padding: 3px; vertical-align: top; }
-.step-box {
-    background: #eff6ff;
-    border-top: 3px solid #1A5FD4;
-    padding: 9px 6px;
-    text-align: center;
-}
-.step-num   { font-size: 18pt; font-weight: bold; color: #1A5FD4; }
-.step-title { font-weight: bold; font-size: 8.5pt; margin: 3px 0; }
-.step-desc  { font-size: 7.5pt; color: #64748b; }
-.step-arrow { text-align: center; vertical-align: middle; font-size: 14pt; color: #1A5FD4; padding: 3px 2px; }
+/* ---- 3개 티어 카드 (INDUSTRY) ---- */
+.tier-grid { display: table; width: 100%; border-collapse: separate; border-spacing: 6px 0; margin-top: 9px; }
+.tier-card { display: table-cell; width: 33%; vertical-align: top; border: 1.5px solid #cbd5e1; border-radius: 4px; padding: 12px 11px; background: #fff; }
+.tier-badge { display: inline-block; color: #fff; font-size: 7.5pt; padding: 2px 9px; border-radius: 3px; font-weight: bold; margin-bottom: 7px; letter-spacing: 0.02em; }
+.tier-badge.basic { background: #64748b; }
+.tier-badge.standard { background: #1A5FD4; }
+.tier-badge.premium { background: #0f172a; }
+.tier-name { font-size: 11pt; font-weight: bold; color: #0f172a; margin-bottom: 3px; }
+.tier-price { font-size: 15pt; font-weight: bold; color: #1A5FD4; margin: 4px 0 2px; }
+.tier-price-note { font-size: 7.5pt; color: #64748b; margin-bottom: 10px; }
+.tier-output-title { font-size: 8pt; font-weight: bold; color: #0f172a; margin: 8px 0 4px; padding-top: 9px; border-top: 1px dashed #cbd5e1; }
+.tier-output-item { font-size: 9pt; color: #334155; margin: 3px 0 3px 4px; }
+.tier-output-pages { font-size: 7.8pt; color: #64748b; margin: 2px 0 2px 4px; }
 
-/* ---- 전후 비교 ---- */
-table.ba-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-table.ba-table td { padding: 4px; vertical-align: top; }
-.ba-before {
-    background: #fef2f2;
-    border: 1px solid #fca5a5;
-    border-radius: 3px;
-    padding: 8px 10px;
-}
-.ba-after {
+/* ---- 단일 티어 박스 (BUILDING / CONSTRUCTION) ---- */
+.single-tier-box { border: 2px solid #1A5FD4; border-radius: 4px; padding: 14px 16px; background: #eff6ff; margin: 9px 0; }
+.single-tier-badge { display: inline-block; background: #1A5FD4; color: #fff; font-size: 7.5pt; padding: 2px 9px; border-radius: 3px; font-weight: bold; margin-bottom: 6px; }
+.single-tier-row { display: table; width: 100%; border-collapse: separate; border-spacing: 6px 0; margin-top: 6px; }
+.single-tier-cell { display: table-cell; background: #fff; padding: 8px 10px; border-radius: 3px; vertical-align: top; width: 33%; }
+.single-tier-cell .dlabel { font-size: 7.5pt; color: #64748b; margin-bottom: 3px; }
+.single-tier-cell .dval { font-size: 12pt; font-weight: bold; color: #1A5FD4; }
+
+/* ---- 관공서 안전감독 활용 박스 ---- */
+.safety-value-box {
+    margin-top: 10px;
+    padding: 10px 13px;
     background: #f0fdf4;
-    border: 1px solid #86efac;
+    border-left: 4px solid #16a34a;
     border-radius: 3px;
-    padding: 8px 10px;
+    font-size: 8.8pt;
+    color: #15803d;
+    line-height: 1.6;
 }
-.ba-title { font-weight: bold; font-size: 9.5pt; margin-bottom: 5px; }
-.ba-item  { font-size: 8pt; margin: 2px 0; color: #374151; }
+.safety-value-box strong { color: #14532d; font-size: 9.2pt; }
 
-/* ---- 추천 플랜 박스 ---- */
-.plan-box {
-    background: #1A5FD4;
-    color: #fff;
-    border-radius: 3px;
-    padding: 11px 13px;
-    margin: 8px 0;
-}
-.plan-name  { font-size: 13pt; font-weight: bold; }
-.plan-price { font-size: 10.5pt; margin: 4px 0; opacity: 0.9; }
-.plan-note  { font-size: 8pt; opacity: 0.8; margin-top: 4px; }
+/* ---- 활용 안내 박스 ---- */
+.usage-box { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 3px; padding: 11px 14px; margin: 10px 0; font-size: 9pt; color: #334155; line-height: 1.65; }
 
-/* ---- 정보 박스 ---- */
-.ib {
-    background: #eff6ff;
-    border-left: 4px solid #1A5FD4;
-    padding: 7px 10px;
-    margin: 7px 0;
-    font-size: 8.5pt;
-}
+/* ---- 회사 정보 ---- */
+.company-info { background: #fafafa; border: 1px solid #e2e8f0; border-radius: 3px; padding: 11px 14px; margin: 10px 0; }
+.company-info-title { font-size: 9pt; font-weight: bold; color: #0f172a; padding-bottom: 5px; margin-bottom: 6px; border-bottom: 1px solid #e2e8f0; }
+.company-info-row { display: table; width: 100%; border-collapse: collapse; }
+.company-info-cell { display: table-cell; width: 50%; vertical-align: top; padding: 2px 8px 2px 0; }
+.company-info-cell .cil { font-size: 7.5pt; color: #64748b; display: inline-block; width: 58px; }
+.company-info-cell .civ { font-size: 8pt; color: #334155; }
 
 /* ---- 푸터 ---- */
-.pf {
-    border-top: 1px solid #e2e8f0;
-    padding-top: 5px;
-    margin-top: 10px;
-    font-size: 7pt;
-    color: #94a3b8;
-}
+.pf { border-top: 1px solid #e2e8f0; padding-top: 5px; margin-top: 10px; font-size: 7pt; color: #94a3b8; }
 
 /* ---- 유틸 ---- */
 .text-blue { color: #1A5FD4; font-weight: bold; }
 .text-red  { color: #dc2626; font-weight: bold; }
-.text-warn { color: #b45309; }
-.text-gray { color: #64748b; }
 </style>
 </head>
 <body>
 
-<!-- ================================================================
-     PAGE 1 : 표지 + 경영진 요약 + 의무 요약 + TOP 5 리스크
-================================================================ -->
+{# ================================================================
+   PAGE 1 : 표지 + 경영진 요약 + 의무 유형별 요약 + TOP 5 리스크
+================================================================ #}
 <div class="page">
 
-<!-- 보고서 헤더 -->
+{# 보고서 헤더 #}
 <table style="width:100%; border-bottom: 3px solid #1A5FD4; padding-bottom: 7px; margin-bottom: 13px; border-collapse: collapse;">
 <tr>
   <td style="vertical-align: middle;">
     <span style="font-size:17pt; font-weight:bold; color:#1A5FD4;">TAI</span>
-    <span style="font-size:9pt; color:#64748b; margin-left:5px;">Engineering · safe.taieng.co.kr</span>
+    <span style="font-size:9pt; color:#64748b; margin-left:5px;">Engineering &middot; taieng.co.kr</span>
   </td>
   <td style="text-align:right; vertical-align: middle;">
-    <span style="font-size:13.5pt; font-weight:bold; color:#0f172a;">산업안전 법적의무 리스크 보고서</span><br/>
-    <span style="font-size:7.5pt; color:#64748b;">Occupational Safety Legal Compliance Report</span>
+    <span style="font-size:13.5pt; font-weight:bold; color:#0f172a;">산업안전 법령진단 분석 보고서</span><br/>
+    <span style="font-size:7.5pt; color:#64748b;">Legal Compliance Analysis Report</span>
   </td>
 </tr>
 </table>
 
-<!-- 진단 정보 2열 -->
+{# 진단 정보 2열 #}
 <table style="width:100%; border-collapse: collapse; margin-bottom: 13px;">
 <tr>
   <td style="width:49%; padding-right: 5px; vertical-align: top;">
@@ -282,7 +163,7 @@ table.ba-table td { padding: 4px; vertical-align: top; }
         <td style="padding:5px 8px; font-size:10pt; font-weight:bold;">{{ company_name }}</td>
       </tr>
       <tr>
-        <td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">보고서 일자</td>
+        <td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">작성일</td>
         <td style="padding:5px 8px; font-size:8.5pt; border-top:1px solid #e2e8f0;">{{ report_date }}</td>
       </tr>
       <tr>
@@ -294,23 +175,30 @@ table.ba-table td { padding: 4px; vertical-align: top; }
   <td style="width:49%; padding-left: 5px; vertical-align: top;">
     <table style="width:100%; border-collapse: collapse; border: 1px solid #e2e8f0;">
       <tr>
-        <td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; width:33%;">보고서 번호</td>
-        <td style="padding:5px 8px; font-size:8.5pt;">{{ report_no }}</td>
+        <td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; width:33%;">문서번호</td>
+        <td style="padding:5px 8px; font-size:8.5pt;">TAI-2026-DR-{{ report_no }}</td>
       </tr>
       <tr>
         <td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">상시 인원</td>
         <td style="padding:5px 8px; font-size:8.5pt; border-top:1px solid #e2e8f0;">
           {{ workers }}명
-          {% if workers >= 50 %}<span style="color:#dc2626; font-weight:bold;"> (중대재해법 적용)</span>{% endif %}
+          {% if csia_applicable %}
+            <span style="color:#dc2626; font-weight:bold;">(중대재해법 적용)</span>
+          {% else %}
+            <span style="color:#64748b;">(중대재해법 미적용 &middot; 50인 기준)</span>
+          {% endif %}
         </td>
       </tr>
       <tr>
         <td style="background:#f1f5f9; padding:5px 8px; font-size:7.5pt; color:#64748b; border-top:1px solid #e2e8f0;">위험도</td>
         <td style="padding:5px 8px; border-top:1px solid #e2e8f0;">
-          {% if risk_level == 'CRITICAL' %}<span class="badge b-critical">매우높음 (CRITICAL)</span>
-          {% elif risk_level == 'HIGH' %}<span class="badge b-high">높음 (HIGH)</span>
-          {% elif risk_level == 'MEDIUM' %}<span class="badge b-med">보통 (MEDIUM)</span>
-          {% else %}<span class="badge b-low">낮음 (LOW)</span>{% endif %}
+          {% if risk_level == "HIGH" %}
+            <span class="badge b-high">높음 (HIGH)</span>
+          {% elif risk_level == "LOW" %}
+            <span class="badge b-low">낮음 (LOW)</span>
+          {% else %}
+            <span class="badge b-med">보통 (MEDIUM)</span>
+          {% endif %}
         </td>
       </tr>
     </table>
@@ -318,10 +206,11 @@ table.ba-table td { padding: 4px; vertical-align: top; }
 </tr>
 </table>
 
-<!-- 경영진 요약 박스 -->
+{# 경영진 요약 박스 #}
 <div class="exec-box">
   <div class="exec-main">
-    귀 사업장에 <span style="color:#f59e0b;">{{ total }}건</span>의 법적 의무 사항이 확인되었습니다.
+    귀 사업장은 <span style="color:#f59e0b;">{{ total }}건</span>의 법적 의무를 이행해야 하며,
+    미이행 시 <span style="color:#f59e0b;">{{ penalty_sum_text }}</span> 규모의 과태료에 노출되어 있습니다.
   </div>
   <table style="width:100%; border-collapse: collapse;">
   <tr>
@@ -334,35 +223,27 @@ table.ba-table td { padding: 4px; vertical-align: top; }
       <div class="exec-num-label">법적 의무 총계</div>
     </td>
     <td style="text-align:center; padding: 4px 6px;">
-      <div class="exec-num-val" style="color:#f87171;">{{ max_penalty_text }}</div>
-      <div class="exec-num-label">미이행 시 최대 과태료</div>
+      <div class="exec-num-val" style="color:#f87171;">{{ penalty_sum_text }}</div>
+      <div class="exec-num-label">과태료 노출 총액</div>
+      <div class="exec-num-sub">(합산 &middot; 중대재해법 제외)</div>
     </td>
   </tr>
   </table>
 </div>
 
-<!-- 의무 유형별 요약 카드 -->
+{# 법적 의무 유형별 요약 4카드 #}
 <div class="sh"><h2>법적 의무 유형별 요약</h2></div>
 <table style="width:100%; border-collapse: collapse;">
 <tr>
-  <td style="width:25%; padding: 3px;">
-    <div class="sc"><div class="k">선임 의무</div><div class="v">{{ appointment }}</div><div class="k">건</div></div>
-  </td>
-  <td style="width:25%; padding: 3px;">
-    <div class="sc"><div class="k">점검·검사</div><div class="v">{{ inspection }}</div><div class="k">건</div></div>
-  </td>
-  <td style="width:25%; padding: 3px;">
-    <div class="sc"><div class="k">조치 의무</div><div class="v">{{ action }}</div><div class="k">건</div></div>
-  </td>
-  <td style="width:25%; padding: 3px;">
-    <div class="sc"><div class="k">보고·신고</div><div class="v">{{ report_notify }}</div><div class="k">건</div></div>
-  </td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">선임 의무</div><div class="v">{{ appointment }}</div><div class="k">건</div></div></td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">점검&middot;검사</div><div class="v">{{ inspection }}</div><div class="k">건</div></div></td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">조치 의무</div><div class="v">{{ action }}</div><div class="k">건</div></div></td>
+  <td style="width:25%; padding: 3px;"><div class="sc"><div class="k">보고&middot;신고</div><div class="v">{{ report_notify }}</div><div class="k">건</div></div></td>
 </tr>
 </table>
 
-<!-- TOP 5 리스크 -->
-<div class="sh" style="margin-top:13px;"><h2>주요 리스크 TOP 5</h2><p>과태료 금액 기준 상위 5건 — 법령을 정밀 분석하여 도출</p></div>
-
+{# 주요 리스크 TOP 5 #}
+<div class="sh" style="margin-top:13px;"><h2>주요 리스크 TOP 5</h2><p>과태료 금액 기준 상위 5건 &mdash; 법령을 정밀 분석하여 도출</p></div>
 <table class="top5-table">
 <thead>
 <tr>
@@ -392,35 +273,61 @@ table.ba-table td { padding: 4px; vertical-align: top; }
 </tbody>
 </table>
 
-<!-- 1페이지 푸터 -->
+{# P1 푸터 #}
 <div class="pf">
   <table style="width:100%; border-collapse:collapse;">
   <tr>
-    <td>TAI Engineering &middot; safe.taieng.co.kr &middot; contact@taieng.co.kr &middot; 사업자 723-39-01422</td>
+    <td>TAI Engineering &middot; taieng.co.kr &middot; contact@taieng.co.kr</td>
     <td style="text-align:right;">1 / 3</td>
   </tr>
   </table>
 </div>
 
-</div><!-- /page1 -->
+</div>{# /page 1 #}
 
 
-<!-- ================================================================
-     PAGE 2 : 비용 비교 + 리스크 시각화 + 중대재해법 경고
-================================================================ -->
+{# ================================================================
+   PAGE 2 : 중대재해법 + 안전관리 비용비교 + 분석 요지
+================================================================ #}
 <div class="page">
 
-<!-- 헤더 -->
+{# 간략 헤더 #}
 <table style="width:100%; border-collapse:collapse; border-bottom:2px solid #1A5FD4; padding-bottom:5px; margin-bottom:12px;">
 <tr>
-  <td><span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span> <span style="font-size:7.5pt; color:#64748b;">산업안전 법적의무 리스크 보고서</span></td>
+  <td>
+    <span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span>
+    <span style="font-size:7.5pt; color:#64748b;">산업안전 법령진단 분석 보고서</span>
+  </td>
   <td style="text-align:right; font-size:8pt; color:#64748b;">{{ company_name }} &middot; {{ report_date }}</td>
 </tr>
 </table>
 
-<!-- 안전관리 방법별 비용·리스크 비교 -->
-<div class="sh"><h2>안전관리 방법별 비용·리스크 비교</h2><p>방치 대비 TAI Safe 도입 시 비용 효율 및 법적 리스크 분석</p></div>
+{# 중대재해처벌법 적용 여부 #}
+<div class="sh"><h2>중대재해처벌법 적용 여부</h2></div>
+{% if csia_applicable %}
+  <div style="background:#fef2f2; border:1px solid #dc2626; border-radius:3px; padding:10px 13px; margin:6px 0;">
+    <strong style="color:#dc2626; font-size:10.5pt;">즉시 적용 대상입니다 (상시 {{ workers }}명)</strong><br/>
+    <span style="font-size:8.8pt; color:#92400e; line-height:1.6;">
+      중대재해처벌법에 따라 경영책임자는 산재 발생 시 1년 이상 징역 또는 10억원 이하 벌금에 처해질 수 있습니다.
+      즉시 안전보건관리체계 구축 및 이행이 필요합니다.
+    </span>
+  </div>
+{% else %}
+  <div style="background:#fffbeb; border:1px solid #fcd34d; border-radius:3px; padding:10px 13px; margin:6px 0;">
+    <strong style="color:#b45309; font-size:10.5pt;">현재 상시 {{ workers }}인 &mdash; 즉시 적용 대상은 아닙니다</strong><br/>
+    <span style="font-size:8.8pt; color:#92400e; line-height:1.6;">
+      상시 근로자 50인 이상 사업장에 중대재해처벌법이 적용됩니다.
+      {% set remaining = 50 - workers %}
+      {% if remaining > 0 and remaining <= 10 %}
+        현재 {{ workers }}명으로 {{ remaining }}명 증가 시 즉시 적용되며,
+      {% endif %}
+      5인 이상 사업장은 이미 산업안전보건법 처벌 대상이므로 사전 대비가 필요합니다.
+    </span>
+  </div>
+{% endif %}
 
+{# 안전관리 방법별 비용·리스크 비교 (정적 테이블) #}
+<div class="sh" style="margin-top:13px;"><h2>안전관리 방법별 비용&middot;리스크 비교 (참고)</h2><p>법적 의무 미이행 시 노출되는 리스크와 관리 방식별 비용 분석</p></div>
 <table class="cost-table">
 <thead>
 <tr>
@@ -435,12 +342,12 @@ table.ba-table td { padding: 4px; vertical-align: top; }
   <td><strong>방치 (미조치)</strong></td>
   <td style="color:#16a34a;">0원</td>
   <td style="color:#dc2626;">과태료 수천만원 + 형사처벌 + 영업정지</td>
-  <td style="color:#dc2626;">법적 의무 미이행 — 처벌 위험 상존</td>
+  <td style="color:#dc2626;">법적 의무 미이행 &mdash; 처벌 위험 상존</td>
 </tr>
 <tr>
-  <td><strong>엑셀·수기 관리</strong></td>
+  <td><strong>엑셀&middot;수기 관리</strong></td>
   <td style="color:#16a34a;">0원</td>
-  <td style="color:#b45309;">누락·오기 발생 시 방치와 동일</td>
+  <td style="color:#b45309;">누락&middot;오기 발생 시 방치와 동일</td>
   <td style="color:#b45309;">담당자 부재 시 관리 공백</td>
 </tr>
 <tr>
@@ -449,260 +356,257 @@ table.ba-table td { padding: 4px; vertical-align: top; }
   <td style="color:#64748b;">사고 발생 시 책임 분산 한계</td>
   <td>외부 의존도 높음</td>
 </tr>
-<tr class="tai-row">
-  <td><strong>TAI Safe</strong> ★ 추천</td>
-  <td><span class="text-blue">{{ recommended_plan_price }}</span><br/><span style="font-size:7.5pt; color:#64748b;">부가세 별도</span></td>
-  <td style="color:#1A5FD4;">자동화로 누락 최소화<br/>실시간 이상 감지</td>
-  <td style="color:#1A5FD4;">법적 의무 {{ total }}건 자동 추적</td>
-</tr>
 </tbody>
 </table>
 
-<div class="ib" style="margin-top:9px;">
-  <strong>핵심 비교:</strong> 안전관리 대행(월 150~300만원) 대비, TAI Safe는 <strong class="text-blue">{{ recommended_plan_price }}</strong>로
-  동일한 법적 의무 {{ total }}건을 자동으로 추적·관리합니다.
-  연간 절감 가능 비용: 약 <strong>{{ annual_savings_low }}만원 ~ {{ annual_savings_high }}만원</strong> (대행사 대비 기준)
-</div>
-
-<!-- 리스크 수준 시각화 (HTML 바 차트 — SVG #23 대체) -->
-<div class="sh" style="margin-top:13px;"><h2>관리 방식별 법적 리스크 수준</h2><p>막대가 길수록 처벌·사고 위험이 큰 방식</p></div>
-
+{# 관리 방식별 법적 리스크 수준 막대 #}
+<div class="sh" style="margin-top:13px;"><h2>관리 방식별 법적 리스크 수준</h2><p>막대가 길수록 처벌&middot;사고 위험이 큰 방식</p></div>
 <table class="risk-bar-table">
 <tr>
   <td style="width:18%; text-align:right; color:#64748b;">방치</td>
-  <td style="width:74%;">
-    <table style="width:100%; border-collapse:collapse;"><tr><td style="width:100%;"><div class="bar-danger"></div></td></tr></table>
-  </td>
+  <td style="width:74%;"><table style="width:100%; border-collapse:collapse;"><tr><td style="width:100%;"><div class="bar-danger"></div></td></tr></table></td>
   <td style="width:8%; color:#dc2626; font-weight:bold; padding-left:4px;">위험</td>
 </tr>
 <tr>
   <td style="text-align:right; color:#64748b;">엑셀 관리</td>
-  <td>
-    <table style="width:100%; border-collapse:collapse;"><tr><td style="width:88%;"><div class="bar-warning"></div></td><td style="width:12%;"></td></tr></table>
-  </td>
+  <td><table style="width:100%; border-collapse:collapse;"><tr><td style="width:88%;"><div class="bar-warning"></div></td><td style="width:12%;"></td></tr></table></td>
   <td style="color:#f97316; font-weight:bold; padding-left:4px;">높음</td>
 </tr>
 <tr>
   <td style="text-align:right; color:#64748b;">안전 대행</td>
-  <td>
-    <table style="width:100%; border-collapse:collapse;"><tr><td style="width:42%;"><div class="bar-neutral"></div></td><td style="width:58%;"></td></tr></table>
-  </td>
+  <td><table style="width:100%; border-collapse:collapse;"><tr><td style="width:42%;"><div class="bar-neutral"></div></td><td style="width:58%;"></td></tr></table></td>
   <td style="color:#94a3b8; font-weight:bold; padding-left:4px;">보통</td>
-</tr>
-<tr>
-  <td style="text-align:right; color:#1A5FD4; font-weight:bold;">TAI Safe</td>
-  <td>
-    <table style="width:100%; border-collapse:collapse;"><tr><td style="width:14%;"><div class="bar-good"></div></td><td style="width:86%;"></td></tr></table>
-  </td>
-  <td style="color:#1A5FD4; font-weight:bold; padding-left:4px;">최소</td>
 </tr>
 </table>
 
-<!-- 중대재해처벌법 경고 -->
-<div class="sh" style="margin-top:13px;"><h2>중대재해처벌법 (중처법) 리스크</h2></div>
-
-{% if csia_applicable %}
-<div class="wb">
-  <div class="wb-title">&#9888; 귀 사업장은 중대재해처벌법 적용 대상입니다 (상시 {{ workers }}인 이상)</div>
-  <table style="width:100%; border-collapse:collapse;" class="csia-row">
-  <tr>
-    <td>
-      <div class="csia-cell">
-        <div class="label">사망사고 시</div>
-        <div class="val">1년 이상 징역</div>
-        <div class="sub">또는 10억 이하 벌금</div>
-      </div>
-    </td>
-    <td>
-      <div class="csia-cell">
-        <div class="label">부상·질병 시</div>
-        <div class="val">7년 이하 징역</div>
-        <div class="sub">또는 1억 이하 벌금</div>
-      </div>
-    </td>
-    <td>
-      <div class="csia-cell">
-        <div class="label">양벌규정 (법인)</div>
-        <div class="val">50억 이하 벌금</div>
-        <div class="sub">법인 형사처벌</div>
-      </div>
-    </td>
-  </tr>
-  </table>
-  <div class="csia-banner">&#9889; 경영책임자 개인이 처벌 대상입니다</div>
+{# 분석 요지 #}
+<div class="sh" style="margin-top:13px;"><h2>분석 요지</h2></div>
+<div style="background:#f1f5f9; border-radius:3px; padding:11px 14px; font-size:9pt; color:#334155; line-height:1.7;">
+  본 무료 진단 결과, 귀 사업장은
+  <strong class="text-blue">{{ total }}건</strong>의 법적 의무에 대하여
+  <strong class="text-red">{{ penalty_sum_text }}</strong> 규모의 과태료 노출(합산, 중대재해법 제외)이 확인되었으며,
+  {% if csia_applicable %}
+    중대재해처벌법이 적용되므로 경영책임자의 형사처벌 리스크까지 존재합니다.
+  {% else %}
+    중대재해처벌법 위반 시에는 별도로 경영책임자의 형사처벌이 가능합니다.
+  {% endif %}
+  <br/>
+  본 진단은 사업장 기본 정보만으로 도출된 일반 분석이며,
+  설비&middot;공정&middot;작업 단위의 개별 의무는 <strong>정밀 진단</strong>을 통해서만 확인할 수 있습니다.
+  다음 페이지에서 정밀 진단의 상세 구성과 예상 비용을 안내합니다.
 </div>
-{% else %}
-<div style="background:#fffbeb; border:1px solid #fcd34d; border-radius:3px; padding:9px 11px; margin:6px 0;">
-  <strong style="color:#b45309;">현재 {{ workers }}인 미만 — 중대재해처벌법 즉시 적용 대상은 아닙니다</strong><br/>
-  <span style="font-size:8.5pt; color:#92400e;">
-    단, 인원 증가 시 즉시 적용됩니다. 5인 이상 사업장도 산업안전보건법 처벌 대상이므로 사전 대비가 필요합니다.
-  </span>
-</div>
-{% endif %}
 
-<!-- 2페이지 푸터 -->
+{# P2 푸터 #}
 <div class="pf">
   <table style="width:100%; border-collapse:collapse;">
   <tr>
-    <td>TAI Engineering &middot; safe.taieng.co.kr &middot; contact@taieng.co.kr</td>
+    <td>TAI Engineering &middot; taieng.co.kr &middot; contact@taieng.co.kr</td>
     <td style="text-align:right;">2 / 3</td>
   </tr>
   </table>
 </div>
 
-</div><!-- /page2 -->
+</div>{# /page 2 #}
 
 
-<!-- ================================================================
-     PAGE 3 : TAI 소개 + 도입 4단계 + 업무 분산 구조 + 추천 플랜 견적
-================================================================ -->
-<div class="page-last">
+{# ================================================================
+   PAGE 3 : 섹터별 분기 — 확인/미확인 영역 + 정밀 진단 안내
+================================================================ #}
+<div class="page">
 
-<!-- 헤더 -->
+{# 간략 헤더 (섹터별 제목) #}
 <table style="width:100%; border-collapse:collapse; border-bottom:2px solid #1A5FD4; padding-bottom:5px; margin-bottom:12px;">
 <tr>
-  <td><span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span> <span style="font-size:7.5pt; color:#64748b;">산업안전 법적의무 리스크 보고서</span></td>
+  <td>
+    <span style="font-size:12pt; font-weight:bold; color:#1A5FD4;">TAI</span>
+    <span style="font-size:7.5pt; color:#64748b;">
+      산업안전 법령진단 분석 보고서
+      {% if sector == "BUILDING" %} &mdash; 건물
+      {% elif sector == "CONSTRUCTION" %} &mdash; 건설
+      {% endif %}
+    </span>
+  </td>
   <td style="text-align:right; font-size:8pt; color:#64748b;">{{ company_name }} &middot; {{ report_date }}</td>
 </tr>
 </table>
 
-<!-- 도입 4단계 (HTML 테이블 — SVG #24 대체) -->
-<div class="sh"><h2>TAI Safe 도입 4단계</h2><p>법령진단 완료 후 당일 운영 시작 가능 · 초기 세팅 1일 이내</p></div>
-
-<table class="step-table">
-<tr>
-  <td style="width:22%;">
-    <div class="step-box">
-      <div class="step-num">1</div>
-      <div class="step-title">법령 진단</div>
-      <div class="step-desc">AI가 사업장 특성을 정밀 분석하여 적용 법령 자동 도출</div>
-    </div>
-  </td>
-  <td class="step-arrow" style="width:4%;">&#8594;</td>
-  <td style="width:22%;">
-    <div class="step-box">
-      <div class="step-num">2</div>
-      <div class="step-title">초기 세팅</div>
-      <div class="step-desc">안전관리자가 설비·인원 등록 (1일 이내 완료)</div>
-    </div>
-  </td>
-  <td class="step-arrow" style="width:4%;">&#8594;</td>
-  <td style="width:22%;">
-    <div class="step-box">
-      <div class="step-num">3</div>
-      <div class="step-title">운영 시작</div>
-      <div class="step-desc">점검 일정 자동 생성 · 담당자 배정 · D-3 사전 알림</div>
-    </div>
-  </td>
-  <td class="step-arrow" style="width:4%;">&#8594;</td>
-  <td style="width:22%;">
-    <div class="step-box">
-      <div class="step-num">4</div>
-      <div class="step-title">자동 모니터링</div>
-      <div class="step-desc">법령 변경 감지 · 이행 현황 실시간 추적 · 월간 리포트</div>
-    </div>
-  </td>
-</tr>
-</table>
-
-<!-- 업무 분산 구조 (HTML 테이블 — SVG #25 대체) -->
-<div class="sh" style="margin-top:13px;"><h2>안전관리 업무 구조 전환</h2><p>안전관리자 1인 집중 &#8594; 전원 참여 체계 · TAI의 핵심 설계 철학</p></div>
-
-<table class="ba-table">
-<tr>
-  <td style="width:45%;">
-    <div class="ba-before">
-      <div class="ba-title" style="color:#dc2626;">&#10007; 도입 전 (현재)</div>
-      <div class="ba-item">&#183; 안전관리자 1인이 모든 업무 직접 처리</div>
-      <div class="ba-item">&#183; 수기 기록 &#8594; 누락·오기 빈번히 발생</div>
-      <div class="ba-item">&#183; 담당자 부재 시 전체 관리 공백</div>
-      <div class="ba-item">&#183; 법령 변경 인지 지연 &#8594; 불이행 위험</div>
-      <div class="ba-item">&#183; 사고 발생 후 대응 &#8594; 처벌 위험 상존</div>
-    </div>
-  </td>
-  <td style="width:10%; text-align:center; vertical-align:middle; font-size:16pt; color:#1A5FD4;">&#8594;</td>
-  <td style="width:45%;">
-    <div class="ba-after">
-      <div class="ba-title" style="color:#16a34a;">&#10003; TAI Safe 도입 후</div>
-      <div class="ba-item">&#183; 업무가 담당자별로 자동 배분·알림</div>
-      <div class="ba-item">&#183; 모바일 점검 &#8594; 실시간 기록·저장</div>
-      <div class="ba-item">&#183; D-3 사전 알림으로 누락 방지</div>
-      <div class="ba-item">&#183; 법령 변경 자동 감지·즉시 적용</div>
-      <div class="ba-item">&#183; 예방 중심 운영 &#8594; 처벌 위험 최소화</div>
-    </div>
-  </td>
-</tr>
-</table>
-
-<!-- 추천 플랜 + 견적 -->
-<div class="sh" style="margin-top:13px;"><h2>추천 플랜 및 도입 견적</h2><p>{{ total }}건의 법적 의무를 자동 관리하는 최적 플랜</p></div>
-
-<div class="plan-box">
-  <table style="width:100%; border-collapse:collapse;">
-  <tr>
-    <td style="vertical-align:top; width:58%;">
-      <div class="plan-name">{{ recommended_plan_name }}</div>
-      <div class="plan-price">{{ recommended_plan_price }} <span style="font-size:8pt; opacity:0.8;">(부가세 별도)</span></div>
-      <div class="plan-note">
-        &#183; 기본 10명 포함 &middot; 초과 인원 3,000원/명<br/>
-        &#183; 법적 의무 {{ total }}건 자동 추적 관리<br/>
-        &#183; 법령 변경 알림 + 점검 일정 자동 생성<br/>
-        &#183; D-3 이행 알림 + 누락 에스칼레이션 + 월간 리포트
-      </div>
-    </td>
-    <td style="vertical-align:middle; text-align:center; width:42%; border-left:1px solid rgba(255,255,255,0.3); padding-left:10px;">
-      <div style="font-size:8.5pt; margin-bottom:5px;">지금 바로 무료 진단 결과 확인</div>
-      <div style="font-size:11pt; font-weight:bold;">safe.taieng.co.kr</div>
-      <div style="font-size:8.5pt; margin-top:5px;">contact@taieng.co.kr</div>
-      <div style="font-size:8.5pt;">www.taieng.co.kr</div>
-      <div style="margin-top:8px; background:rgba(255,255,255,0.15); border-radius:3px; padding:5px 8px; font-size:8pt;">
-        무료 진단 후 즉시 도입 가능<br/>별도 설치 없이 웹 브라우저로 사용
-      </div>
-    </td>
-  </tr>
-  </table>
+{# 1. 확인된 영역 (섹터별) #}
+<div class="sh"><h2>1. 본 무료 진단에서 확인된 영역</h2></div>
+<div class="area-box area-confirmed">
+  <div class="area-title">분석 완료된 항목</div>
+  {% if sector == "INDUSTRY" %}
+    <div class="area-item">&middot; 사업장 기본 정보 기반 법령 매칭 (업종&middot;규모&middot;위치)</div>
+    <div class="area-item">&middot; 일반 법령 의무 {{ total }}건 도출</div>
+    <div class="area-item">&middot; 주요 리스크 TOP 5 식별 및 근거 법령 제시</div>
+    <div class="area-item">&middot; 중대재해처벌법 적용 여부 자동 판정</div>
+  {% elif sector == "BUILDING" %}
+    <div class="area-item">&middot; 건축물대장 기반 법령 매칭 (용도&middot;규모&middot;층수)</div>
+    <div class="area-item">&middot; 건물 일반 법령 의무 {{ total }}건 도출</div>
+    <div class="area-item">&middot; 소방&middot;승강기&middot;전기안전 선임 의무</div>
+    <div class="area-item">&middot; 중대재해처벌법 적용 여부 자동 판정</div>
+  {% elif sector == "CONSTRUCTION" %}
+    <div class="area-item">&middot; 현장 기본 정보 기반 법령 매칭 (공사금액&middot;기간&middot;인원)</div>
+    <div class="area-item">&middot; 건설업 일반 법령 의무 {{ total }}건 도출</div>
+    <div class="area-item">&middot; 안전관리자&middot;보건관리자 선임 요건 판정</div>
+    <div class="area-item">&middot; 중대재해처벌법 적용 여부 자동 판정</div>
+  {% endif %}
 </div>
 
-<!-- TAI Engineering 소개 -->
-<div style="background:#f8fafc; border:1px solid #e2e8f0; border-radius:3px; padding:8px 10px; margin-top:9px;">
-  <table style="width:100%; border-collapse:collapse;">
-  <tr>
-    <td style="vertical-align:top; width:50%; padding-right:8px;">
-      <strong style="font-size:9pt;">TAI Engineering이란?</strong><br/>
-      <span style="font-size:8pt; color:#475569; line-height:1.6;">
-        산업안전보건법·중대재해처벌법 대응을 위한 B2B 안전관리 SaaS입니다.
-        안전관리자 1인이 집중 처리하던 구조를 전 직원 분산 참여 체계로 전환하여
-        법적 의무 누락을 근본적으로 방지합니다.
-      </span>
-    </td>
-    <td style="vertical-align:top; width:50%; padding-left:8px; border-left:1px solid #e2e8f0;">
-      <strong style="font-size:9pt;">기술력 및 특허</strong><br/>
-      <span style="font-size:8pt; color:#475569; line-height:1.6;">
-        법령 자동진단 엔진 특허 출원 8건 · 상표 등록<br/>
-        산업안전보건법·소방법·전기안전법 등 통합 분석<br/>
-        건물·산업·건설 3개 섹터 전문 지원
-      </span>
-    </td>
-  </tr>
-  </table>
+{# 2. 확인되지 않은 영역 (섹터별) #}
+<div class="sh" style="margin-top:10px;"><h2>2. 본 무료 진단에서 확인되지 않은 영역</h2></div>
+<div class="area-box area-unconfirmed">
+  <div class="area-title">정밀 진단을 통해서만 확인 가능한 항목</div>
+  {% if sector == "INDUSTRY" %}
+    <div class="area-item">&middot; <strong>시설별 상세 법령</strong> &mdash; 건축물&middot;부속시설 개별 의무</div>
+    <div class="area-item">&middot; <strong>위험물 취급 규정</strong> &mdash; 보유 위험물 종류&middot;수량 기반 의무</div>
+    <div class="area-item">&middot; <strong>공정 단위 안전의무</strong> &mdash; 작업 공정별 규정 (정밀 등급 이상)</div>
+    <div class="area-item">&middot; <strong>설비별 개별 의무</strong> &mdash; 보유 설비 개별 점검&middot;검사 규정 (종합 등급)</div>
+  {% elif sector == "BUILDING" %}
+    <div class="area-item">&middot; 건물 규모 기반 적용 법령 세부 매핑</div>
+    <div class="area-item">&middot; 용도별 특수 규정 (근린&middot;의료&middot;판매 등)</div>
+    <div class="area-item">&middot; 관리 주체&middot;임차인 책임 구분</div>
+    <div class="area-item">&middot; 세부 점검 주기 및 담당자 지정 기준</div>
+  {% elif sector == "CONSTRUCTION" %}
+    <div class="area-item">&middot; 공사금액 기반 적용 법령 세부 매핑</div>
+    <div class="area-item">&middot; 안전관리비 산정 기준 및 요율</div>
+    <div class="area-item">&middot; 원청&middot;하청 안전 책임 분배 상세</div>
+    <div class="area-item">&middot; 세부 점검 주기 및 담당자 지정 기준</div>
+  {% endif %}
 </div>
 
-<!-- 3페이지 푸터 + 면책 -->
-<div class="pf" style="margin-top:12px;">
-  <table style="width:100%; border-collapse:collapse;">
-  <tr>
-    <td style="font-size:7pt; color:#94a3b8;">
-      &#8251; 본 보고서는 공개된 법령을 기반으로 정밀 분석하여 도출한 참고 자료이며 법적 효력이 없습니다. 실제 적용 여부는 전문가와 확인하시기 바랍니다.
-    </td>
-    <td style="text-align:right; white-space:nowrap;">3 / 3</td>
-  </tr>
-  </table>
-  <div style="text-align:center; margin-top:3px; font-size:7pt; color:#94a3b8;">
-    TAI Engineering &middot; 서울특별시 강남구 테헤란로79길 6 JS타워 3층 V1314 &middot; 사업자등록번호 723-39-01422
+{# 3. 정밀 진단 안내 — 섹터별 분기 #}
+{% if paid_tiers.mode == "select" %}
+  {# === INDUSTRY: 3개 티어 카드 === #}
+  <div class="sh" style="margin-top:11px;">
+    <h2>3. 정밀 진단 (유료) &mdash; 3개 등급 안내</h2>
+    <p>사업장 특성에 맞는 등급을 선택하실 수 있습니다</p>
+  </div>
+
+  <div class="tier-grid">
+    {% for tier in paid_tiers.tiers %}
+    <div class="tier-card">
+      <div class="tier-badge {{ tier.badge_class }}">
+        {% if tier.badge_class == "basic" %}기본
+        {% elif tier.badge_class == "standard" %}정밀
+        {% elif tier.badge_class == "premium" %}종합
+        {% endif %}
+      </div>
+      <div class="tier-name">{{ tier.name }}</div>
+      <div class="tier-price">{{ "{:,}".format(tier.price) }}원</div>
+      <div class="tier-price-note">VAT 별도 &middot; 1회성</div>
+      <div class="tier-output-title">산출물</div>
+      <div class="tier-output-item">상세 PDF 리포트</div>
+      <div class="tier-output-pages">약 {{ tier.pages }}페이지</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div style="font-size:8pt; color:#64748b; margin-top:6px; padding-left:2px;">
+    ※ 공통 산출물: 전체 적용 법령 테이블 &middot; 점검 일정 캘린더 &middot; 선임 의무 양식 &middot; 조항별 과태료 시뮬레이션<br/>
+    ※ 등급별 상세 분석 범위는 safe.taieng.co.kr 신청 페이지에서 확인하실 수 있습니다.
+  </div>
+
+{% else %}
+  {# === BUILDING / CONSTRUCTION: 단일 티어 + 상위 힌트 === #}
+  <div class="sh" style="margin-top:11px;">
+    <h2>3. 귀 {% if sector == "BUILDING" %}사업장{% else %}현장{% endif %} 해당 정밀 진단</h2>
+    <p>{% if sector == "BUILDING" %}연면적{% else %}공사금액{% endif %} 자동 판정 결과에 따라 아래 등급이 적용됩니다</p>
+  </div>
+
+  <div class="single-tier-box">
+    <span class="single-tier-badge">귀 {% if sector == "BUILDING" %}사업장{% else %}현장{% endif %} 해당</span>
+    <div style="font-size:12pt; font-weight:bold; color:#0f172a; margin-bottom:4px;">{{ paid_tiers.determined.name }}</div>
+    <div style="font-size:8.5pt; color:#64748b;">{{ paid_tiers.basis }}</div>
+
+    <div class="single-tier-row">
+      <div class="single-tier-cell">
+        <div class="dlabel">비용</div>
+        <div class="dval">{{ "{:,}".format(paid_tiers.determined.price) }}원</div>
+        <div style="font-size:7.5pt; color:#64748b;">VAT 별도 &middot; 1회성</div>
+      </div>
+      <div class="single-tier-cell">
+        <div class="dlabel">소요 시간</div>
+        <div class="dval">즉시</div>
+        <div style="font-size:7.5pt; color:#64748b;">결제 후 자동 분석</div>
+      </div>
+      <div class="single-tier-cell">
+        <div class="dlabel">산출물</div>
+        <div class="dval">상세 PDF</div>
+        <div style="font-size:7.5pt; color:#64748b;">약 {{ paid_tiers.determined.pages }}페이지</div>
+      </div>
+    </div>
+
+    <div style="margin-top:10px; padding-top:9px; border-top:1px dashed #cbd5e1;">
+      {% if sector == "BUILDING" %}
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 전체 적용 법령 테이블</div>
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 층별&middot;용도별 의무 매핑</div>
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 선임 의무자 양식 (소방&middot;전기&middot;승강기)</div>
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 건축물 정기점검 일정 캘린더</div>
+      {% else %}
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 공종별 적용 법령 상세</div>
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 안전관리비 산정 가이드</div>
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; TBM&middot;위험성평가 일정 캘린더</div>
+        <div style="font-size:8.8pt; color:#334155; margin:3px 0 3px 8px;">&middot; 원청&middot;하청 안전 책임 구분표</div>
+      {% endif %}
+    </div>
+  </div>
+
+  {# 상위 등급 힌트 (이미 최상위면 표시 안 함) #}
+  {% if paid_tiers.upper %}
+  <div style="background:#f8fafc; border:1px solid #e2e8f0; border-radius:3px; padding:10px 13px; margin-top:9px; font-size:8.5pt; color:#64748b; line-height:1.65;">
+    ※ {{ paid_tiers.upper.threshold }}은 <strong>{{ paid_tiers.upper.name }}({{ "{:,}".format(paid_tiers.upper.price) }}원)</strong>이 적용됩니다.
+    입력 항목은 동일하나, 규모 기준에 따라 적용 법령 세트와 분석 결과가 달라집니다.
+  </div>
+  {% endif %}
+{% endif %}
+
+{# 활용 포인트 박스 (전 섹터 공통) #}
+<div class="safety-value-box">
+  <strong>활용 포인트</strong><br/>
+  본 유료 리포트는 <strong>관공서 안전감독 시</strong> 법적 의무 이행을 입증하는 근거자료로 활용하실 수 있습니다.
+</div>
+
+{# TAI 회사 정보 #}
+<div class="company-info" style="margin-top:10px;">
+  <div class="company-info-title">TAI Engineering</div>
+  <div class="company-info-row">
+    <div class="company-info-cell">
+      <div><span class="cil">사업자</span><span class="civ">723-39-01422</span></div>
+      <div><span class="cil">주소</span><span class="civ">서울시 강남구 테헤란로79길 6 JS타워 3층</span></div>
+      <div><span class="cil">이메일</span><span class="civ">contact@taieng.co.kr</span></div>
+      <div><span class="cil">홈페이지</span><span class="civ">taieng.co.kr</span></div>
+    </div>
+    <div class="company-info-cell" style="border-left: 1px solid #e2e8f0; padding-left: 12px;">
+      <div style="font-size:8pt; color:#0f172a; font-weight:bold; margin-bottom:3px;">지식재산권</div>
+      <div style="font-size:7.8pt; color:#334155; line-height:1.55;">
+        &middot; 법령 자동진단 엔진 외 <strong>특허 출원 8건</strong><br/>
+        &middot; TAI 상표 등록 완료<br/>
+        &middot; 법령&middot;시설&middot;공정&middot;설비&middot;작업 연계 분석 기술
+      </div>
+    </div>
   </div>
 </div>
 
-</div><!-- /page3/page-last -->
+{# 4. 본 보고서 활용 안내 #}
+<div class="sh" style="margin-top:10px;"><h2>4. 본 보고서 활용 안내</h2></div>
+<div class="usage-box">
+  본 분석 보고서는 귀사의 내부 품의 진행 시 <strong>첨부 근거자료</strong>로 활용하실 수 있습니다.
+  품의서 본문에 정밀 진단 신청의 필요성을 기술하시고 본 보고서를 첨부하시면,
+  경영진이 법적 의무 건수와 과태료 노출 규모를 객관적으로 확인하실 수 있습니다.
+  정밀 진단은 <strong>safe.taieng.co.kr</strong>에서 직접 신청하실 수 있습니다.
+</div>
+
+{# P3 푸터 + 면책 #}
+<div class="pf" style="margin-top:10px;">
+  <table style="width:100%; border-collapse:collapse;">
+  <tr>
+    <td style="font-size:7pt; color:#94a3b8;">※ 본 보고서는 공개된 법령을 기반으로 정밀 분석하여 도출한 참고 자료이며 법적 효력이 없습니다. 실제 적용 여부는 관할 행정기관 또는 법률 전문가에게 확인하시기 바랍니다.</td>
+    <td style="text-align:right; white-space:nowrap; vertical-align:top;">3 / 3</td>
+  </tr>
+  </table>
+</div>
+
+</div>{# /page 3 #}
 
 </body>
 </html>


### PR DESCRIPTION
# 기안 PDF v2.0.0 — 백엔드 작업 완료

> **⚠️ 단독 머지 금지 — 프론트(템플릿) 창 작업과 동시 머지 필요**
> `templates/proposal_pdf.html` v6 업데이트와 함께 머지해야 Jinja2 UndefinedError 방지

---

## 변경 내역

### DB 마이그레이션 (`add_proposal_pdf_url_to_anonymous_diagnosis_results`)
- `anonymous_diagnosis_results.proposal_pdf_url TEXT` 컬럼 추가
- `anonymous_diagnosis_results.proposal_pdf_generated_at TIMESTAMPTZ` 컬럼 추가
- `idx_anon_diag_proposal_cache` 인덱스 추가 (public_token, pdf URL 있는 레코드만)

### Supabase Storage
- `proposals` 버킷 생성 (public: true, 5MB, application/pdf)
- RLS 정책 3개: anon_upload, public_read, service_role_all

### `routers/diagnosis_proposal.py` v1.0.3 → v2.0.0

**삭제 (SaaS 영업 내용 배제):**
- `_PLANS`, `_AGENCY_MONTHLY_LOW`, `_AGENCY_MONTHLY_HIGH` 상수
- `_recommend_plan()` 함수
- `max_penalty_text`, `recommended_plan_*`, `annual_savings_*` context 필드

**신규:**
- `_compute_penalty_sum()` — 전체 과태료 합산, 중대재해처벌법 제외
- `_build_paid_tiers()` — 섹터별 유료 티어 구성
  - INDUSTRY: 3개 선택형 (79K / 149K / 249K)
  - BUILDING: 면적 자동판정 (5,000㎡ 기준)
  - CONSTRUCTION: 공사금액 자동판정 (50억원 기준)
- `RedirectResponse` 캐싱: 첫 생성 → Storage 업로드 → DB 기록 → 302
- 재요청: `proposal_pdf_url` DB hit → 즉시 302

**`_build_context` 반환 스펙 (프론트 창 계약):**
```
penalty_sum: float
penalty_sum_text: str  (max_penalty_text 대체)
paid_tiers: dict       (mode/tiers or mode/determined/upper/basis)
```

---

## 검증 결과

| 항목 | 결과 |
|---|---|
| DB 마이그레이션 | ✅ PASS |
| proposals 버킷 | ✅ public=true, 5MB, application/pdf |
| RLS 정책 | ✅ 3개 생성 |
| py_compile | ✅ PASS |
| 단위 테스트 `_build_paid_tiers` 7케이스 | ✅ PASS |
| 단위 테스트 `_compute_penalty_sum` 중대재해 제외 | ✅ PASS |
| dev 브랜치 커밋 | ✅ d20a135d |

---

## 관련
- Closes tai-api #4 (기안 PDF 내용 수정) — 프론트 PR과 함께
- 다음 작업: tai-api #5 (유료 PDF 개편), tai-api #3 (CI/CD)