### PR TITLE
feat: diagram_proxy v1.0.1 — SVG 프록시 (Supabase Storage 한글 파일명 503 우회)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,8 @@
-# main.py — v5.31.1
+# main.py — v5.32.0
+# v5.32.0: diagram_proxy 라우터 등록 (GET /api/v1/diagrams/{number}) — Supabase Storage 한글 SVG 우회
 # v5.31.1: diagnosis_proposal 라우터 등록 (GET /diagnosis/proposal-pdf/{public_token})
 # v5.31.0: diagnosis_report 라우터 등록 (GET /diagnosis/report-pdf/{public_token})
 # v5.30.0: diagnosis_integrated 라우터 등록 (BE-10 진단통합 백엔드)
-# v5.29.0: diagnosis_plan_recommend 라우터 등록 (BE-08 진단 기반 플랜 추천)
-# v5.28.0: overdue_checker 라우터 등록 (BE-10 업무지연 에스켈레이션)
-# v5.27.0: diagnosis_transform 라우터 등록
-# v5.26.0: diagnosis_roi 라우터 등록
 import logging
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
@@ -113,10 +110,11 @@ from routers.diagnosis_plan_recommend import router as plan_recommend_router
 from routers.diagnosis_integrated    import router as diagnosis_integrated_router   # v5.30.0
 from routers.diagnosis_report        import router as diagnosis_report_router        # v5.31.0
 from routers.diagnosis_proposal      import router as diagnosis_proposal_router      # v5.31.1
+from routers.diagram_proxy           import router as diagram_proxy_router           # v5.32.0
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "5.31.1"
+APP_VERSION = "5.32.0"
 
 
 @asynccontextmanager
@@ -184,6 +182,7 @@ app.include_router(plan_recommend_router)           # 공개: 진단 결과 페�
 app.include_router(diagnosis_integrated_router)    # v5.30.0 — 공개: 마케팅사이트 익명 사용자
 app.include_router(diagnosis_report_router)        # v5.31.0 — 공개: 유료 PDF 온디맨드 생성
 app.include_router(diagnosis_proposal_router)       # v5.31.1 — 공개: 기안용 proposal PDF
+app.include_router(diagram_proxy_router)            # v5.32.0 — 공개: SVG 다이어그램 프록시 (한글 파일명 우회)
 
 # 인증 필요 엔드포인트
 app.include_router(auth_router)

--- a/routers/diagram_proxy.py
+++ b/routers/diagram_proxy.py
@@ -1,0 +1,86 @@
+"""
+diagram_proxy.py v1.0.0
+Supabase Storage 한글 파일명 CDN 503 문제 우회
+Python supabase-py로 직접 다운로드 후 SVG 반환
+GET /api/v1/diagrams/{number}  -> SVG 스트림
+GET /api/v1/diagrams/          -> 전체 목록 JSON
+"""
+
+import os
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+from supabase import create_client, Client
+
+router = APIRouter(prefix="/diagrams", tags=["diagrams"])
+
+# 1-25 번호 -> 한글 파일명 매핑
+DIAGRAM_FILES: dict[int, str] = {
+    1:  "01-\uc911\ub300\uc7ac\ud574\ucc98\ubc8c\ubc95-\uc801\uc6a9-\ud750\ub984\ub3c4.svg",
+    2:  "02-\uc0b0\uc5c5\uc548\uc804\ubcf4\uac74\ubc95-\uc758\ubb34-\uacc4\uce35\ub3c4.svg",
+    3:  "03-\uac74\ucd95\ubb3c\uad00\ub9ac\ubc95-\uc801\uc6a9-\ubc94\uc704.svg",
+    4:  "04-\uac74\uc124\ud604\uc7a5-3\ubc95-\ube44\uad50\ud45c.svg",
+    5:  "05-\ud655\ub300\uc801\uc6a9-\ud0c0\uc784\ub77c\uc778.svg",
+    6:  "06-\uacfc\ud0dc\ub8cc-\ubc8c\uce59-\uad6c\uc870.svg",
+    7:  "07-\uacbd\uc601\ucc45\uc784\uc790-9\ub300\uc758\ubb34.svg",
+    8:  "08-\uc548\uc804\uad00\ub9ac\uc790-\uc120\uc784\uae30\uc900.svg",
+    9:  "09-\uad00\ub9ac\ucc45\uc784\uc790-\uccb4\uacc4\ub3c4.svg",
+    10: "10-\uc548\uc804\ubcf4\uac74\uad00\ub9ac\uccb4\uc81c-\uad6c\ucd95\uc694\uac74.svg",
+    11: "11-\uc5c5\ubb34\ubd84\uc0b0-\ube44\ud3ec\uc560\ud504\ud130.svg",
+    12: "12-\uc804\ubb38\uae30\uad00\uc704\ud0c1-vs-\uc790\uccb4\uc120\uc784.svg",
+    13: "13-\uc124\ube44-\uc815\uae30\uac80\uc0ac-\uc8fc\uae30.svg",
+    14: "14-PTW-\ubc1c\uae09-\ud504\ub85c\uc138\uc2a4.svg",
+    15: "15-TBM-\uc9c4\ud589-\ud50c\ub85c\uc6b0.svg",
+    16: "16-\uc704\ud5d8\uc131\ud3c9\uac00-5\ub2e8\uacc4.svg",
+    17: "17-\uc791\uc5c5\uc911\uc9c0-\ud310\ub2e8\uae30\uc900.svg",
+    18: "18-\ud2b9\uc218\ud2b9\ubcc4\uad50\uc721-\ub9e4\ud2b8\ub9ad\uc2a4.svg",
+    19: "19-\uac74\ubb3c-\ub178\ud6c4\ub3c4\ubcc4-\uc810\uac80\uc758\ubb34.svg",
+    20: "20-\uc18c\ubc29\uc2dc\uc124-\uc790\uccb4\uc810\uac80-\uc77c\uc815.svg",
+    21: "21-\uc11d\uba74\uc870\uc0ac-\ub300\uc0c1\ud310\uc815.svg",
+    22: "22-\uc2b9\uac15\uae30-\ubcf4\uc77c\ub7ec-\uc555\ub825\uc6a9\uae30-\uac80\uc0ac\uc8fc\uae30.svg",
+    23: "23-TAI-ROI-\ube44\uad50.svg",
+    24: "24-TAI-\ub3c4\uc785-4\ub2e8\uacc4.svg",
+    25: "25-\uc548\uc804\uad00\ub9ac-\ubd84\uc0b0\uad6c\uc870\ub3c4.svg",
+}
+
+
+def _get_supabase() -> Client:
+    url = os.environ["SUPABASE_URL"]
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ["SUPABASE_KEY"]
+    return create_client(url, key)
+
+
+@router.get("/", summary="다이어그램 목록")
+async def list_diagrams():
+    """diagram_templates 테이블 전체 목록 반환"""
+    sb = _get_supabase()
+    res = sb.table("diagram_templates").select(
+        "diagram_number,title_ko,diagram_type,sector_filter,is_default,usage_locations"
+    ).order("diagram_number").execute()
+    return {"diagrams": res.data}
+
+
+@router.get("/{number}", summary="SVG 다이어그램 스트림")
+async def get_diagram_svg(number: int):
+    """
+    다이어그램 번호(1-25)로 SVG 파일 직접 반환.
+    Supabase Storage 한글 파일명 CDN 503 우회.
+    """
+    filename = DIAGRAM_FILES.get(number)
+    if not filename:
+        raise HTTPException(status_code=404, detail=f"diagram {number} not found")
+
+    try:
+        sb = _get_supabase()
+        data: bytes = sb.storage.from_("diagrams").download(filename)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Storage error: {str(e)}")
+
+    return Response(
+        content=data,
+        media_type="image/svg+xml",
+        headers={
+            "Cache-Control": "public, max-age=86400",
+            "Access-Control-Allow-Origin": "*",
+            "Content-Disposition": "inline",
+        },
+    )

--- a/routers/diagram_proxy.py
+++ b/routers/diagram_proxy.py
@@ -1,49 +1,51 @@
 """
-diagram_proxy.py v1.0.0
+diagram_proxy.py v1.0.1
 Supabase Storage 한글 파일명 CDN 503 문제 우회
 Python supabase-py로 직접 다운로드 후 SVG 반환
 GET /api/v1/diagrams/{number}  -> SVG 스트림
 GET /api/v1/diagrams/          -> 전체 목록 JSON
+v1.0.1: dict[int,str] -> Dict[int,str] (Python 3.8 호환)
 """
 
 import os
+from typing import Dict
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
-from supabase import create_client, Client
+from supabase import create_client
 
 router = APIRouter(prefix="/diagrams", tags=["diagrams"])
 
 # 1-25 번호 -> 한글 파일명 매핑
-DIAGRAM_FILES: dict[int, str] = {
-    1:  "01-\uc911\ub300\uc7ac\ud574\ucc98\ubc8c\ubc95-\uc801\uc6a9-\ud750\ub984\ub3c4.svg",
-    2:  "02-\uc0b0\uc5c5\uc548\uc804\ubcf4\uac74\ubc95-\uc758\ubb34-\uacc4\uce35\ub3c4.svg",
-    3:  "03-\uac74\ucd95\ubb3c\uad00\ub9ac\ubc95-\uc801\uc6a9-\ubc94\uc704.svg",
-    4:  "04-\uac74\uc124\ud604\uc7a5-3\ubc95-\ube44\uad50\ud45c.svg",
-    5:  "05-\ud655\ub300\uc801\uc6a9-\ud0c0\uc784\ub77c\uc778.svg",
-    6:  "06-\uacfc\ud0dc\ub8cc-\ubc8c\uce59-\uad6c\uc870.svg",
-    7:  "07-\uacbd\uc601\ucc45\uc784\uc790-9\ub300\uc758\ubb34.svg",
-    8:  "08-\uc548\uc804\uad00\ub9ac\uc790-\uc120\uc784\uae30\uc900.svg",
-    9:  "09-\uad00\ub9ac\ucc45\uc784\uc790-\uccb4\uacc4\ub3c4.svg",
-    10: "10-\uc548\uc804\ubcf4\uac74\uad00\ub9ac\uccb4\uc81c-\uad6c\ucd95\uc694\uac74.svg",
-    11: "11-\uc5c5\ubb34\ubd84\uc0b0-\ube44\ud3ec\uc560\ud504\ud130.svg",
-    12: "12-\uc804\ubb38\uae30\uad00\uc704\ud0c1-vs-\uc790\uccb4\uc120\uc784.svg",
-    13: "13-\uc124\ube44-\uc815\uae30\uac80\uc0ac-\uc8fc\uae30.svg",
-    14: "14-PTW-\ubc1c\uae09-\ud504\ub85c\uc138\uc2a4.svg",
-    15: "15-TBM-\uc9c4\ud589-\ud50c\ub85c\uc6b0.svg",
-    16: "16-\uc704\ud5d8\uc131\ud3c9\uac00-5\ub2e8\uacc4.svg",
-    17: "17-\uc791\uc5c5\uc911\uc9c0-\ud310\ub2e8\uae30\uc900.svg",
-    18: "18-\ud2b9\uc218\ud2b9\ubcc4\uad50\uc721-\ub9e4\ud2b8\ub9ad\uc2a4.svg",
-    19: "19-\uac74\ubb3c-\ub178\ud6c4\ub3c4\ubcc4-\uc810\uac80\uc758\ubb34.svg",
-    20: "20-\uc18c\ubc29\uc2dc\uc124-\uc790\uccb4\uc810\uac80-\uc77c\uc815.svg",
-    21: "21-\uc11d\uba74\uc870\uc0ac-\ub300\uc0c1\ud310\uc815.svg",
-    22: "22-\uc2b9\uac15\uae30-\ubcf4\uc77c\ub7ec-\uc555\ub825\uc6a9\uae30-\uac80\uc0ac\uc8fc\uae30.svg",
-    23: "23-TAI-ROI-\ube44\uad50.svg",
-    24: "24-TAI-\ub3c4\uc785-4\ub2e8\uacc4.svg",
-    25: "25-\uc548\uc804\uad00\ub9ac-\ubd84\uc0b0\uad6c\uc870\ub3c4.svg",
+DIAGRAM_FILES: Dict[int, str] = {
+    1:  "01-중대재해처벌법-적용-흐름도.svg",
+    2:  "02-산업안전보건법-의무-계층도.svg",
+    3:  "03-건축물관리법-적용-범위.svg",
+    4:  "04-건설현장-3법-비교표.svg",
+    5:  "05-확대적용-타임라인.svg",
+    6:  "06-과태료-벌칙-구조.svg",
+    7:  "07-경영책임자-9대의무.svg",
+    8:  "08-안전관리자-선임기준.svg",
+    9:  "09-관리책임자-체계도.svg",
+    10: "10-안전보건관리체제-구축요건.svg",
+    11: "11-업무분산-비포애프터.svg",
+    12: "12-전문기관위탁-vs-자체선임.svg",
+    13: "13-설비-정기검사-주기.svg",
+    14: "14-PTW-발급-프로세스.svg",
+    15: "15-TBM-진행-플로우.svg",
+    16: "16-위험성평가-5단계.svg",
+    17: "17-작업중지-판단기준.svg",
+    18: "18-특수특별교육-매트릭스.svg",
+    19: "19-건물-노후도별-점검의무.svg",
+    20: "20-소방시설-자체점검-일정.svg",
+    21: "21-석면조사-대상판정.svg",
+    22: "22-승강기-보일러-압력용기-검사주기.svg",
+    23: "23-TAI-ROI-비교.svg",
+    24: "24-TAI-도입-4단계.svg",
+    25: "25-안전관리-분산구조도.svg",
 }
 
 
-def _get_supabase() -> Client:
+def _get_supabase():
     url = os.environ["SUPABASE_URL"]
     key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ["SUPABASE_KEY"]
     return create_client(url, key)
@@ -53,9 +55,12 @@ def _get_supabase() -> Client:
 async def list_diagrams():
     """diagram_templates 테이블 전체 목록 반환"""
     sb = _get_supabase()
-    res = sb.table("diagram_templates").select(
-        "diagram_number,title_ko,diagram_type,sector_filter,is_default,usage_locations"
-    ).order("diagram_number").execute()
+    res = (
+        sb.table("diagram_templates")
+        .select("diagram_number,title_ko,diagram_type,sector_filter,is_default,usage_locations")
+        .order("diagram_number")
+        .execute()
+    )
     return {"diagrams": res.data}
 
 


### PR DESCRIPTION
## 변경 내역

### 신규: `routers/diagram_proxy.py` v1.0.1
- `GET /api/v1/diagrams/` — diagram_templates 전체 목록
- `GET /api/v1/diagrams/{number}` — SVG 파일 스트림 (1~25)
- Supabase Storage CDN이 한글 파일명 public URL에 503 반환하는 문제를 Python supabase-py `storage.download()`로 우회
- `Dict` import 추가 (Python 3.8 호환)
- `Cache-Control: public, max-age=86400`, CORS `*` 헤더 포함

### 수정: `main.py` v5.32.0
- `diagram_proxy_router` 공개 엔드포인트로 등록

## 영향 범위
- 신규 엔드포인트 추가만 — 기존 기능 영향 없음
- `new.taieng.co.kr/service/saas.html` SVG 이미지 복구