### PR TITLE
fix: Fix Chat 대화 저장·복원 버그 5건 수정 (이슈 #12)

### DIFF
--- a/docs/fix-chat-bug-fix/README.md
+++ b/docs/fix-chat-bug-fix/README.md
@@ -1,0 +1,168 @@
+# Fix Chat 대화 저장·복원 버그 수정 작업지시서
+
+**작성일**: 2026-04-19
+**우선순위**: 높음 (핵심 기능 미작동)
+**관련 파일**:
+- 백엔드: `routers/fix_chat.py` (v1.1.1)
+- 프론트: `taiengineering/taieng/nexas/fix-request.html`
+- DB: `fix_chat_sessions`, `fix_chat_messages`, `matching_requests`
+
+---
+
+## 버그 요약
+
+fix-request 채팅 페이지에서:
+1. 대화가 DB에 저장되지 않음
+2. 새로고침/재방문 시 이전 대화가 출력되지 않음
+3. 로그인 후에도 비회원 대화가 연결되지 않음
+
+---
+
+## 버그 상세 (5건)
+
+### 🔒 B1: sendMessage() API 실패 시 더미 폴백 → DB 미저장
+
+**현상**: 사용자가 메시지를 보내면 화면에는 응답이 나오지만 DB에는 아무것도 저장 안 됨
+
+**원인**: `sendMessage()`의 try/catch 구조
+```javascript
+try {
+  const res = await fetch(`${API}/fix/chat/message`, {...});
+  // API 성공 시 정상 처리
+} catch(e) {
+  // API 실패 → 더미 응답 반환, DB에는 아무것도 안 씀
+  const dummies = ['말씀해주신 상황을...', ...];
+  appendExpertMsg(dummies[...]);
+}
+```
+
+**증거**: DB에 16개 세션 존재, 최근 5개 모두 `current_turn=0`
+
+**수정**: 
+- catch 블록에서 더미 응답 제거
+- API 실패 시 사용자에게 "일시적 오류" 메시지 표시 + 재시도 버튼
+- 또는 메시지를 로컬에 큐잉하여 재전송
+
+### 🔒 B2: Claude API 호출 실패 (백엔드)
+
+**현상**: `/fix/chat/message` API가 502 반환
+
+**원인 추정**: `ANTHROPIC_API_KEY` 환경변수가 Fly.io에 미설정 또는 만료
+
+**확인 방법**:
+```bash
+fly secrets list -a tai-api-prod | grep ANTHROPIC
+```
+
+**수정**:
+- ANTHROPIC_API_KEY가 없으면 → 백엔드에서 기본 응답 반환 (더미가 아닌 서버 측 폴백)
+- fix_chat.py의 `_call_claude()`에서 KEY 없을 때 간단한 규칙 기반 응답 반환
+- 메시지는 KEY 유무와 무관하게 항상 DB에 저장
+
+### 🔒 B3: 새로고침 시 이전 메시지 미복원
+
+**현상**: 페이지 새로고침 시 "이전 대화를 이어서 진행하겠습니다"만 출력, 실제 대화 내용은 안 보임
+
+**원인**: `startChat()`에서 savedSession이 있으면 인사만 하고 return
+```javascript
+const savedSession = sessionStorage.getItem('fix_session_id');
+if (savedSession) {
+  sessionId = savedSession;
+  appendExpertMsg('이전 대화를 이어서...');
+  return; // ← 이전 메시지를 불러오는 API 호출 없음
+}
+```
+
+**수정**:
+- 저장된 session_id가 있으면 → API로 이전 메시지 목록 조회
+- 조회된 메시지를 시간순으로 chatBody에 렌더링
+- 필요 API: `GET /fix/chat/sessions/{session_id}/messages` (신규 추가)
+
+### 🔒 B4: sessionStorage → localStorage 변경
+
+**현상**: 브라우저 탭/창 닫으면 session_id 소멸 → 대화 영구 손실
+
+**원인**: `sessionStorage` 사용 (탭 닫으면 삭제됨)
+
+**수정**:
+- `sessionStorage` → `localStorage`로 변경
+- key: `tai_fix_session_id`
+- 세션이 COMPLETED 상태이면 localStorage에서 삭제
+
+### 🔒 B5: 비회원→회원 전환 시 세션 연결
+
+**현상**: 비회원이 대화 후 회원가입/로그인해도 이전 대화에 접근 불가
+
+**원인**: 
+1. 비회원 세션의 `user_id`가 null
+2. 로그인 후 세션을 사용자에게 연결하는 로직 없음
+3. 사용자용 세션 조회 API가 없음 (admin API만 존재)
+
+**수정 (백엔드)**:
+- `POST /fix/chat/claim` — 로그인한 사용자가 세션 소유권 주장
+  - 요청: `{ session_id: "xxx" }` + JWT 인증
+  - 동작: `fix_chat_sessions.user_id = 현재 사용자 id` + `max_turns 업그레이드 (MEMBER=10)`
+  - 조건: 해당 세션의 user_id가 null일 때만 허용
+- `GET /fix/chat/my/sessions` — 내 세션 목록 조회
+  - 응답: `[{id, status, intent, current_turn, created_at, preview}]`
+- `GET /fix/chat/my/sessions/{session_id}/messages` — 내 세션 메시지 조회
+  - 응답: `[{role, content, created_at}]`
+
+**수정 (프론트)**:
+- 로그인 성공 후 → localStorage에 session_id가 있으면 → `/fix/chat/claim` 호출
+- claim 성공 → 이전 메시지 불러와서 화면에 렌더링
+- turnBadge를 MEMBER 기준으로 업데이트 (10턴)
+
+---
+
+## 작업 순서
+
+### Phase 1: 즉시 (DB 저장 보장)
+1. B2: ANTHROPIC_API_KEY 확인 + 백엔드 폴백 추가
+2. B1: 프론트 catch 블록 수정 → 더미 제거, 에러 표시
+3. B4: sessionStorage → localStorage 변경
+
+### Phase 2: 대화 복원
+4. B3: 백엔드에 `GET /fix/chat/sessions/{id}/messages` 추가
+5. B3: 프론트 startChat()에서 이전 메시지 로드
+
+### Phase 3: 비회원→회원 연결
+6. B5: 백엔드에 claim + my/sessions API 추가
+7. B5: 프론트 로그인 후 claim 호출 + 대화 복원
+
+---
+
+## 테스트 시나리오
+
+### T1: 기본 대화 저장
+1. fix-request 페이지 열기
+2. 메시지 3개 전송
+3. DB 확인: fix_chat_sessions.current_turn = 3, fix_chat_messages 6개 (user 3 + assistant 3)
+
+### T2: 새로고침 복원
+1. T1 후 페이지 새로고침
+2. 이전 대화 6개 메시지가 화면에 출력되는지 확인
+
+### T3: 브라우저 닫기 복원
+1. T1 후 브라우저 완전 종료 → 재실행
+2. fix-request 접속 → 이전 대화 복원 확인
+
+### T4: 비회원→회원 전환
+1. 비회원으로 3턴 대화
+2. 회원가입 → 로그인
+3. fix-request 재접속 → 이전 대화 연결 + 잔여턴 7턴 표시
+
+---
+
+## 관련 기존 문서
+
+- `docs/workorder-fix-chat-backend.md` — 원래 설계서 (백엔드)
+- `docs/workorder-fix-chat-frontend.md` — 원래 설계서 (프론트)
+- `docs/workorder-fix-provider-api.md` — 전체 매칭 플로우 확정
+
+## 절대 규칙
+
+- 🔒 기존 fix_chat.py의 admin API 3개 (stats, sessions, session detail)는 변경 금지
+- 🔒 기존 채팅 UI (채팅 헤더, 버블, 타이핑 인디케이터, 입력바) DOM 구조 유지
+- 🔒 3턴 제한 후 블러 결과카드 + CTA 로직 유지
+- 🔒 from/type URL 파라미터 기반 인사 메시지 분기 유지

--- a/docs/proposal_pdf_v6/session_log_20260419.md
+++ b/docs/proposal_pdf_v6/session_log_20260419.md
@@ -1,0 +1,91 @@
+# 2026-04-19 기획창 세션 작업 이력
+
+## 완료 작업
+
+### 1. 기안 PDF v6 개편 (PR#10 merged)
+- 포지션: 품의서 첨부용 분석보고서 (결재란 없음, TAI SaaS 영업 없음)
+- 과태료: penalty_sum (중대재해법 제외 합산)
+- INDUSTRY 3등급 동등안내 (추천배지 없음)
+- 활용포인트: "관공서 안전감독 시 법적 의무 이행 입증 근거자료"
+- 도메인: taieng.co.kr 공식
+- diagnosis_proposal.py v2.0.0 + proposal_pdf.html 612줄
+- Supabase Storage proposals 버킷 (캐싱, 302 redirect)
+
+### 2. Gotenberg PDF 엔진 교체 (Cursor 작업)
+- xhtml2pdf → Gotenberg (Docker Chromium) 교체 완료
+- tai-gotenberg Fly 앱: nrt 리전, 1GB, auto_stop
+- diagnosis_proposal.py v2.1.0
+- BUILDING 310KB / INDUSTRY 313KB, 4페이지
+- 캐싱 302 redirect 정상 동작
+- 비용: ~$5~7/월
+
+#### Gotenberg 해결 이슈
+- .internal DNS 해석 실패 → tai-gotenberg.fly.dev (public URL) 사용
+- Chromium OOM → 512MB → 1GB 증량
+- Cold start 실패 → CHROMIUM_AUTO_START=true + START_TIMEOUT=60s
+- URL: safe.taieng.co.kr → https://taieng.co.kr 통일
+
+#### Gotenberg 커밋 이력 (main)
+| SHA | 내용 |
+|---|---|
+| 366bc8d | feat: Gotenberg Chromium PDF 엔진 적용 (v2.1.0) |
+| c9bca5f | fix: httpx timeout 30s → 60s |
+| 074ccc1 | fix: Gotenberg 메모리 512MB → 1GB |
+| cdbf800 | fix: URL을 https://taieng.co.kr로 통일 |
+| 54674e8 | fix: Chromium auto-start + startup timeout 60s |
+
+### 3. 유료 진단 입력 폼 SaaS 일치 (Cursor + 기획창)
+- DB 마이그레이션 실행 완료 (기획창 Supabase MCP)
+  - PAID2: has_welding 등 8건 비활성화, process_list searchable_select로 수정
+  - PAID3: has_crane 등 12건 비활성화, equipment_list (table, 40개 select) 신규
+- Cursor 코드 작업 완료:
+  - diagnosis_fields.py: /process-options, /equipment-options 엔드포인트 추가
+  - diagnosis_integrated.py: tier/form_data 처리, 무료 tier 매핑 보정
+  - legal_engine.py: equipment_list → has_crane 등 변환 로직
+  - free-diagnosis.html: table 렌더링, searchable_select, system_codes 연동
+
+### 4. 유료 진단 리포트 기획 시작
+- full_result 데이터 구조 파악 완료 (25개 키, 72~101KB)
+- 웹 요약(paid-diagnosis-result.html) + PDF(Gotenberg 20~28p) 2종 필요
+- 상세 설계는 다음 세션에서 진행
+
+## 미해결 이슈
+
+### ISS-01: Gotenberg .internal DNS
+- Fly.io 내부 DNS(tai-gotenberg.internal) 해석 안 됨
+- 현재: tai-gotenberg.fly.dev (public URL) 사용 중
+- 영향: 외부 경유로 ~50ms 지연 추가
+- 조치: Fly 지원팀 확인 후 .internal 재시도 (비용 절감)
+
+### ISS-02: 기안 PDF 4페이지 렌더링
+- v6 mockup은 3페이지이나 실제 PDF는 4페이지
+- 원인: P3 콘텐츠가 A4 한 장 초과
+- 조치: Gotenberg CSS (@page, page-break) 활용한 템플릿 재디자인 (v7) 필요
+
+### ISS-03: 연면적 0㎡ 표시
+- FREE 진단 토큰으로 기안 PDF 생성 시 "입력 연면적 0㎡ 기준 자동 판정" 노출
+- 원인: FREE 진단에서 total_floor_area 미입력
+- 조치: 0일 때 "정보 없음" fallback 또는 FREE 토큰 기안 PDF 차단
+
+### ISS-04: process_list → facility_ctx 매핑 미구현
+- legal_engine.py에서 equipment_list → has_crane 등 변환은 완료
+- process_list는 아직 facility_ctx에 매핑 안 됨
+- 영향: 공정 기반 법령 매칭이 불완전할 수 있음
+- 조치: 룰이 process_list를 직접 참조하면 별도 매핑 필요
+
+### ISS-05: disclaimer_log_id 누락
+- 유료 직입 runPaidDiagnosis에서 disclaimer_log_id 없이 호출 가능
+- 백엔드가 면책 동의를 강제하면 에러 발생 가능
+- 조치: 프론트에서 면책 체크박스 → log_id 전달 플로우 확인 필요
+
+### ISS-06: 유료 PDF + 웹 요약 미구현
+- 유료 진단 결과의 웹 표시(paid-diagnosis-result.html)와 PDF(diagnosis_report.py) 미완성
+- 데이터 구조는 파악 완료 (full_result 25개 키)
+- 조치: 다음 세션에서 설계 + 구현
+
+## 참조 파일
+- docs/proposal_pdf_v6/README.md — 종합 핸드오프
+- docs/proposal_pdf_v6/01_backend_task.md — 백엔드 작업지시
+- docs/proposal_pdf_v6/02_frontend_task.md — 프론트 작업지시
+- /mnt/user-data/outputs/diagnosis_input_saas_align_task.md — 입력 폼 SaaS 일치 작업지시
+- /mnt/user-data/outputs/gotenberg_migration_task.md — Gotenberg 교체 작업지시

--- a/main.py
+++ b/main.py
@@ -1,11 +1,8 @@
-# main.py — v5.31.1
+# main.py — v5.32.0
+# v5.32.0: diagram_proxy 라우터 등록 (GET /api/v1/diagrams/{number}) — Supabase Storage 한글 SVG 우회
 # v5.31.1: diagnosis_proposal 라우터 등록 (GET /diagnosis/proposal-pdf/{public_token})
 # v5.31.0: diagnosis_report 라우터 등록 (GET /diagnosis/report-pdf/{public_token})
 # v5.30.0: diagnosis_integrated 라우터 등록 (BE-10 진단통합 백엔드)
-# v5.29.0: diagnosis_plan_recommend 라우터 등록 (BE-08 진단 기반 플랜 추천)
-# v5.28.0: overdue_checker 라우터 등록 (BE-10 업무지연 에스켈레이션)
-# v5.27.0: diagnosis_transform 라우터 등록
-# v5.26.0: diagnosis_roi 라우터 등록
 import logging
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
@@ -113,10 +110,11 @@ from routers.diagnosis_plan_recommend import router as plan_recommend_router
 from routers.diagnosis_integrated    import router as diagnosis_integrated_router   # v5.30.0
 from routers.diagnosis_report        import router as diagnosis_report_router        # v5.31.0
 from routers.diagnosis_proposal      import router as diagnosis_proposal_router      # v5.31.1
+from routers.diagram_proxy           import router as diagram_proxy_router           # v5.32.0
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "5.31.1"
+APP_VERSION = "5.32.0"
 
 
 @asynccontextmanager
@@ -184,6 +182,7 @@ app.include_router(plan_recommend_router)           # 공개: 진단 결과 페�
 app.include_router(diagnosis_integrated_router)    # v5.30.0 — 공개: 마케팅사이트 익명 사용자
 app.include_router(diagnosis_report_router)        # v5.31.0 — 공개: 유료 PDF 온디맨드 생성
 app.include_router(diagnosis_proposal_router)       # v5.31.1 — 공개: 기안용 proposal PDF
+app.include_router(diagram_proxy_router)            # v5.32.0 — 공개: SVG 다이어그램 프록시 (한글 파일명 우회)
 
 # 인증 필요 엔드포인트
 app.include_router(auth_router)

--- a/routers/diagram_proxy.py
+++ b/routers/diagram_proxy.py
@@ -1,0 +1,86 @@
+"""
+diagram_proxy.py v1.0.0
+Supabase Storage 한글 파일명 CDN 503 문제 우회
+Python supabase-py로 직접 다운로드 후 SVG 반환
+GET /api/v1/diagrams/{number}  -> SVG 스트림
+GET /api/v1/diagrams/          -> 전체 목록 JSON
+"""
+
+import os
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import Response
+from supabase import create_client, Client
+
+router = APIRouter(prefix="/diagrams", tags=["diagrams"])
+
+# 1-25 번호 -> 한글 파일명 매핑
+DIAGRAM_FILES: dict[int, str] = {
+    1:  "01-\uc911\ub300\uc7ac\ud574\ucc98\ubc8c\ubc95-\uc801\uc6a9-\ud750\ub984\ub3c4.svg",
+    2:  "02-\uc0b0\uc5c5\uc548\uc804\ubcf4\uac74\ubc95-\uc758\ubb34-\uacc4\uce35\ub3c4.svg",
+    3:  "03-\uac74\ucd95\ubb3c\uad00\ub9ac\ubc95-\uc801\uc6a9-\ubc94\uc704.svg",
+    4:  "04-\uac74\uc124\ud604\uc7a5-3\ubc95-\ube44\uad50\ud45c.svg",
+    5:  "05-\ud655\ub300\uc801\uc6a9-\ud0c0\uc784\ub77c\uc778.svg",
+    6:  "06-\uacfc\ud0dc\ub8cc-\ubc8c\uce59-\uad6c\uc870.svg",
+    7:  "07-\uacbd\uc601\ucc45\uc784\uc790-9\ub300\uc758\ubb34.svg",
+    8:  "08-\uc548\uc804\uad00\ub9ac\uc790-\uc120\uc784\uae30\uc900.svg",
+    9:  "09-\uad00\ub9ac\ucc45\uc784\uc790-\uccb4\uacc4\ub3c4.svg",
+    10: "10-\uc548\uc804\ubcf4\uac74\uad00\ub9ac\uccb4\uc81c-\uad6c\ucd95\uc694\uac74.svg",
+    11: "11-\uc5c5\ubb34\ubd84\uc0b0-\ube44\ud3ec\uc560\ud504\ud130.svg",
+    12: "12-\uc804\ubb38\uae30\uad00\uc704\ud0c1-vs-\uc790\uccb4\uc120\uc784.svg",
+    13: "13-\uc124\ube44-\uc815\uae30\uac80\uc0ac-\uc8fc\uae30.svg",
+    14: "14-PTW-\ubc1c\uae09-\ud504\ub85c\uc138\uc2a4.svg",
+    15: "15-TBM-\uc9c4\ud589-\ud50c\ub85c\uc6b0.svg",
+    16: "16-\uc704\ud5d8\uc131\ud3c9\uac00-5\ub2e8\uacc4.svg",
+    17: "17-\uc791\uc5c5\uc911\uc9c0-\ud310\ub2e8\uae30\uc900.svg",
+    18: "18-\ud2b9\uc218\ud2b9\ubcc4\uad50\uc721-\ub9e4\ud2b8\ub9ad\uc2a4.svg",
+    19: "19-\uac74\ubb3c-\ub178\ud6c4\ub3c4\ubcc4-\uc810\uac80\uc758\ubb34.svg",
+    20: "20-\uc18c\ubc29\uc2dc\uc124-\uc790\uccb4\uc810\uac80-\uc77c\uc815.svg",
+    21: "21-\uc11d\uba74\uc870\uc0ac-\ub300\uc0c1\ud310\uc815.svg",
+    22: "22-\uc2b9\uac15\uae30-\ubcf4\uc77c\ub7ec-\uc555\ub825\uc6a9\uae30-\uac80\uc0ac\uc8fc\uae30.svg",
+    23: "23-TAI-ROI-\ube44\uad50.svg",
+    24: "24-TAI-\ub3c4\uc785-4\ub2e8\uacc4.svg",
+    25: "25-\uc548\uc804\uad00\ub9ac-\ubd84\uc0b0\uad6c\uc870\ub3c4.svg",
+}
+
+
+def _get_supabase() -> Client:
+    url = os.environ["SUPABASE_URL"]
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ["SUPABASE_KEY"]
+    return create_client(url, key)
+
+
+@router.get("/", summary="다이어그램 목록")
+async def list_diagrams():
+    """diagram_templates 테이블 전체 목록 반환"""
+    sb = _get_supabase()
+    res = sb.table("diagram_templates").select(
+        "diagram_number,title_ko,diagram_type,sector_filter,is_default,usage_locations"
+    ).order("diagram_number").execute()
+    return {"diagrams": res.data}
+
+
+@router.get("/{number}", summary="SVG 다이어그램 스트림")
+async def get_diagram_svg(number: int):
+    """
+    다이어그램 번호(1-25)로 SVG 파일 직접 반환.
+    Supabase Storage 한글 파일명 CDN 503 우회.
+    """
+    filename = DIAGRAM_FILES.get(number)
+    if not filename:
+        raise HTTPException(status_code=404, detail=f"diagram {number} not found")
+
+    try:
+        sb = _get_supabase()
+        data: bytes = sb.storage.from_("diagrams").download(filename)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Storage error: {str(e)}")
+
+    return Response(
+        content=data,
+        media_type="image/svg+xml",
+        headers={
+            "Cache-Control": "public, max-age=86400",
+            "Access-Control-Allow-Origin": "*",
+            "Content-Disposition": "inline",
+        },
+    )

--- a/routers/diagram_proxy.py
+++ b/routers/diagram_proxy.py
@@ -1,49 +1,51 @@
 """
-diagram_proxy.py v1.0.0
+diagram_proxy.py v1.0.1
 Supabase Storage 한글 파일명 CDN 503 문제 우회
 Python supabase-py로 직접 다운로드 후 SVG 반환
 GET /api/v1/diagrams/{number}  -> SVG 스트림
 GET /api/v1/diagrams/          -> 전체 목록 JSON
+v1.0.1: dict[int,str] -> Dict[int,str] (Python 3.8 호환)
 """
 
 import os
+from typing import Dict
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
-from supabase import create_client, Client
+from supabase import create_client
 
 router = APIRouter(prefix="/diagrams", tags=["diagrams"])
 
 # 1-25 번호 -> 한글 파일명 매핑
-DIAGRAM_FILES: dict[int, str] = {
-    1:  "01-\uc911\ub300\uc7ac\ud574\ucc98\ubc8c\ubc95-\uc801\uc6a9-\ud750\ub984\ub3c4.svg",
-    2:  "02-\uc0b0\uc5c5\uc548\uc804\ubcf4\uac74\ubc95-\uc758\ubb34-\uacc4\uce35\ub3c4.svg",
-    3:  "03-\uac74\ucd95\ubb3c\uad00\ub9ac\ubc95-\uc801\uc6a9-\ubc94\uc704.svg",
-    4:  "04-\uac74\uc124\ud604\uc7a5-3\ubc95-\ube44\uad50\ud45c.svg",
-    5:  "05-\ud655\ub300\uc801\uc6a9-\ud0c0\uc784\ub77c\uc778.svg",
-    6:  "06-\uacfc\ud0dc\ub8cc-\ubc8c\uce59-\uad6c\uc870.svg",
-    7:  "07-\uacbd\uc601\ucc45\uc784\uc790-9\ub300\uc758\ubb34.svg",
-    8:  "08-\uc548\uc804\uad00\ub9ac\uc790-\uc120\uc784\uae30\uc900.svg",
-    9:  "09-\uad00\ub9ac\ucc45\uc784\uc790-\uccb4\uacc4\ub3c4.svg",
-    10: "10-\uc548\uc804\ubcf4\uac74\uad00\ub9ac\uccb4\uc81c-\uad6c\ucd95\uc694\uac74.svg",
-    11: "11-\uc5c5\ubb34\ubd84\uc0b0-\ube44\ud3ec\uc560\ud504\ud130.svg",
-    12: "12-\uc804\ubb38\uae30\uad00\uc704\ud0c1-vs-\uc790\uccb4\uc120\uc784.svg",
-    13: "13-\uc124\ube44-\uc815\uae30\uac80\uc0ac-\uc8fc\uae30.svg",
-    14: "14-PTW-\ubc1c\uae09-\ud504\ub85c\uc138\uc2a4.svg",
-    15: "15-TBM-\uc9c4\ud589-\ud50c\ub85c\uc6b0.svg",
-    16: "16-\uc704\ud5d8\uc131\ud3c9\uac00-5\ub2e8\uacc4.svg",
-    17: "17-\uc791\uc5c5\uc911\uc9c0-\ud310\ub2e8\uae30\uc900.svg",
-    18: "18-\ud2b9\uc218\ud2b9\ubcc4\uad50\uc721-\ub9e4\ud2b8\ub9ad\uc2a4.svg",
-    19: "19-\uac74\ubb3c-\ub178\ud6c4\ub3c4\ubcc4-\uc810\uac80\uc758\ubb34.svg",
-    20: "20-\uc18c\ubc29\uc2dc\uc124-\uc790\uccb4\uc810\uac80-\uc77c\uc815.svg",
-    21: "21-\uc11d\uba74\uc870\uc0ac-\ub300\uc0c1\ud310\uc815.svg",
-    22: "22-\uc2b9\uac15\uae30-\ubcf4\uc77c\ub7ec-\uc555\ub825\uc6a9\uae30-\uac80\uc0ac\uc8fc\uae30.svg",
-    23: "23-TAI-ROI-\ube44\uad50.svg",
-    24: "24-TAI-\ub3c4\uc785-4\ub2e8\uacc4.svg",
-    25: "25-\uc548\uc804\uad00\ub9ac-\ubd84\uc0b0\uad6c\uc870\ub3c4.svg",
+DIAGRAM_FILES: Dict[int, str] = {
+    1:  "01-중대재해처벌법-적용-흐름도.svg",
+    2:  "02-산업안전보건법-의무-계층도.svg",
+    3:  "03-건축물관리법-적용-범위.svg",
+    4:  "04-건설현장-3법-비교표.svg",
+    5:  "05-확대적용-타임라인.svg",
+    6:  "06-과태료-벌칙-구조.svg",
+    7:  "07-경영책임자-9대의무.svg",
+    8:  "08-안전관리자-선임기준.svg",
+    9:  "09-관리책임자-체계도.svg",
+    10: "10-안전보건관리체제-구축요건.svg",
+    11: "11-업무분산-비포애프터.svg",
+    12: "12-전문기관위탁-vs-자체선임.svg",
+    13: "13-설비-정기검사-주기.svg",
+    14: "14-PTW-발급-프로세스.svg",
+    15: "15-TBM-진행-플로우.svg",
+    16: "16-위험성평가-5단계.svg",
+    17: "17-작업중지-판단기준.svg",
+    18: "18-특수특별교육-매트릭스.svg",
+    19: "19-건물-노후도별-점검의무.svg",
+    20: "20-소방시설-자체점검-일정.svg",
+    21: "21-석면조사-대상판정.svg",
+    22: "22-승강기-보일러-압력용기-검사주기.svg",
+    23: "23-TAI-ROI-비교.svg",
+    24: "24-TAI-도입-4단계.svg",
+    25: "25-안전관리-분산구조도.svg",
 }
 
 
-def _get_supabase() -> Client:
+def _get_supabase():
     url = os.environ["SUPABASE_URL"]
     key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ["SUPABASE_KEY"]
     return create_client(url, key)
@@ -53,9 +55,12 @@ def _get_supabase() -> Client:
 async def list_diagrams():
     """diagram_templates 테이블 전체 목록 반환"""
     sb = _get_supabase()
-    res = sb.table("diagram_templates").select(
-        "diagram_number,title_ko,diagram_type,sector_filter,is_default,usage_locations"
-    ).order("diagram_number").execute()
+    res = (
+        sb.table("diagram_templates")
+        .select("diagram_number,title_ko,diagram_type,sector_filter,is_default,usage_locations")
+        .order("diagram_number")
+        .execute()
+    )
     return {"diagrams": res.data}
 
 

--- a/routers/fix_chat.py
+++ b/routers/fix_chat.py
@@ -1,11 +1,16 @@
 # routers/fix_chat.py — TAI Fix 대화형 입력부 API
+# v1.2.0 (2026-04-19): B1~B5 버그 수정
+#   B2: _call_claude() KEY 없었 때 규칙 기반 폴백, 메시지 항상 DB 저장
+#   B3: GET /fix/chat/sessions/{id}/messages 신규 — 이전 메시지 복원
+#   B5: POST /fix/chat/claim 신규 — 비회원 세션 소유권 주장
+#   B5: GET /fix/chat/my/sessions 신규 — 내 세션 목록
 # v1.1.1 (2026-04-15): admin/stats 응답에 프론트 호환 편의 필드 추가
 # v1.1.0 (2026-04-15): 어드민 API 3개 추가 (stats, sessions, session detail)
 # v1.0.1 (2026-04-15): 오타 수정
 # v1.0.0 (2026-04-15): 신규
 import os
 import logging
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import Optional
 
 import httpx
@@ -31,18 +36,16 @@ SYSTEM_PROMPT = """당신은 TAI 산업안전 매칭 전문가입니다.
 # 대화 흐름
 
 1단계 — 의도 파악 (1~2턴)
-  상대방의 첫 말에서 의도를 파악합니다.
   의도: REPAIR(수선) / APPOINTMENT(선임) / DIAGNOSIS(진단) / CONSULTING(컨설팅)
-  의도가 불명확하면 한 번만 더 물어봅니다.
+  의도가 불명확하면 한 번만 더 물어보다.
 
 2단계 — 의도별 정보 수집 (3~5턴)
-  파악된 의도에 맞는 필수 정보만 질문합니다.
   한 턴에 질문은 최대 2개까지만.
-  상대방이 "모르겠다"고 하면 넘어갑니다.
+  "모르곊다"고 하면 넘어간다.
 
 3단계 — 정리 + 연결 제안 (마지막 턴)
   수집된 정보를 정리하여 보여주고,
-  "전문 업체 연결을 도와드릴까요?"로 마무리합니다.
+  "전문 업체 연결을 도와드릴까요?"로 마무리한다.
 
 # 의도별 수집 항목
 
@@ -65,21 +68,10 @@ SYSTEM_PROMPT = """당신은 TAI 산업안전 매칭 전문가입니다.
 # 절대 규칙
 
 1. 해결책을 제시하지 않는다.
-   ❌ "분전반을 차단하고 절연저항을 측정하세요"
-   ✅ "전기안전 전문 업체의 현장 점검이 필요한 상황입니다"
-
 2. 법률 자문을 하지 않는다.
-   "전문가를 통해 확인하시는 게 정확합니다"로 넘긴다.
-
 3. 가격을 말하지 않는다.
-
 4. 주제를 벗어나면 부드럽게 돌린다.
-   "저는 산업안전 분야 매칭 전문가라 그 부분은 도움드리기 어렵습니다.
-    혹시 시설 관련해서 도움이 필요하신 부분이 있으신가요?"
-
-5. 필수 정보가 모이면 즉시 연결 제안한다.
-
-6. 공감하되 길지 않게. "걱정되시겠습니다" 한 줄이면 충분.
+5. 필수 정보가 모이면 즐시 연결 제안한다.
 
 # 마지막 턴 형식
 
@@ -96,9 +88,16 @@ SYSTEM_PROMPT = """당신은 TAI 산업안전 매칭 전문가입니다.
 
 - 존댓말 사용
 - 간결하게 (한 턴 최대 3~4문장)
-- 전문가답되 딱딱하지 않게
+- 전문가답되 딱딩하지 않게
 - 이모지 최소 사용 (📋 정리할 때만)
 """
+
+# 규칙 기반 폴백 응답 (ANTHROPIC_KEY 없을 때)
+_FALLBACK_REPLIES = [
+    "말씀해주신 상황을 파악하고 있습니다. 어떤 시설/설비에서 발생한 문제인가요? 현장 위치도 알려주시면 더 정확한 업체를 연결해드릴 수 있습니다.",
+    "기본적인 상황 파악이 되었습니다. 얼마나 긴급한 상황인가요? (높음/보통/여유) 히망하시는 일정이 있으시면 알려주세요.",
+    "평소 안전 관리를 위해 노력하시는 분이시군요. 지금까지 말씀해주신 정보를 바탕으로 적합한 전문 업체를 매칭해드릴 수 있습니다. 매칭을 진행할까요?",
+]
 
 
 class StartBody(BaseModel):
@@ -111,6 +110,10 @@ class MessageBody(BaseModel):
 
 
 class CompleteBody(BaseModel):
+    session_id: str
+
+
+class ClaimBody(BaseModel):
     session_id: str
 
 
@@ -135,45 +138,59 @@ def _now() -> str:
 
 
 def _require_admin(current_user: dict):
-    """role_code 001이 아니면 403"""
     role = current_user.get("role_code") or current_user.get("role", "")
     if role != "001":
         raise HTTPException(status_code=403, detail="관리자 권한이 필요합니다")
 
 
-async def _call_claude(messages: list) -> tuple[str, int]:
+async def _call_claude(messages: list, turn_index: int = 0) -> tuple:
+    """
+    Claude API 호출. KEY 없으면 규칙 기반 폴백 응답 반환.
+    어떤 경우든 (reply, tokens) 로 돌려줌 — 메시지는 항상 DB에 저장됨.
+    """
+    # B2 수정: KEY 없으면 폴백 응답 (502 에러 리턴 안 함)
     if not ANTHROPIC_KEY:
-        raise HTTPException(status_code=503, detail="ANTHROPIC_API_KEY 미설정")
+        log.warning("[FIX_CHAT] ANTHROPIC_API_KEY 미설정 — 규칙 기반 폴백 응답")
+        idx = min(turn_index, len(_FALLBACK_REPLIES) - 1)
+        return _FALLBACK_REPLIES[idx], 0
 
-    async with httpx.AsyncClient(timeout=30) as client:
-        resp = await client.post(
-            "https://api.anthropic.com/v1/messages",
-            headers={
-                "x-api-key":         ANTHROPIC_KEY,
-                "anthropic-version": "2023-06-01",
-                "content-type":      "application/json",
-            },
-            json={
-                "model":      CLAUDE_MODEL,
-                "max_tokens": MAX_TOKENS,
-                "system":     SYSTEM_PROMPT,
-                "messages":   messages,
-            },
-        )
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                "https://api.anthropic.com/v1/messages",
+                headers={
+                    "x-api-key":         ANTHROPIC_KEY,
+                    "anthropic-version": "2023-06-01",
+                    "content-type":      "application/json",
+                },
+                json={
+                    "model":      CLAUDE_MODEL,
+                    "max_tokens": MAX_TOKENS,
+                    "system":     SYSTEM_PROMPT,
+                    "messages":   messages,
+                },
+            )
 
-    if resp.status_code != 200:
-        log.error(f"[FIX_CHAT] Claude API 오류 {resp.status_code}: {resp.text[:300]}")
-        raise HTTPException(status_code=502, detail="Claude API 호출 실패")
+        if resp.status_code != 200:
+            log.error(f"[FIX_CHAT] Claude API 오류 {resp.status_code}: {resp.text[:300]}")
+            # B2 수정: API 오류 시에도 폴백 응답 (메시지 DB 저장 보장)
+            idx = min(turn_index, len(_FALLBACK_REPLIES) - 1)
+            return _FALLBACK_REPLIES[idx], 0
 
-    data   = resp.json()
-    reply  = data["content"][0]["text"]
-    tokens = data.get("usage", {}).get("output_tokens", 0)
-    return reply, tokens
+        data   = resp.json()
+        reply  = data["content"][0]["text"]
+        tokens = data.get("usage", {}).get("output_tokens", 0)
+        return reply, tokens
+
+    except Exception as e:
+        log.error(f"[FIX_CHAT] Claude API 예외: {e}")
+        idx = min(turn_index, len(_FALLBACK_REPLIES) - 1)
+        return _FALLBACK_REPLIES[idx], 0
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 공개 API (인증 불필요)
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 @router.post("/start")
 def start_chat(body: StartBody):
@@ -226,9 +243,11 @@ async def send_message(body: MessageBody):
     history  = [{"role": m["role"], "content": m["content"]} for m in (msgs_res.data or [])]
     history.append({"role": "user", "content": body.message})
 
-    reply, out_tokens = await _call_claude(history)
+    # B2 수정: _call_claude가 예외 없이 (reply, tokens) 를 로드리 줌
+    reply, out_tokens = await _call_claude(history, turn_index=current_turn)
     new_turn = current_turn + 1
 
+    # 메시지 DB 저장 — 항상 실행
     sb.table("fix_chat_messages").insert([
         {"session_id": body.session_id, "role": "user",      "content": body.message},
         {"session_id": body.session_id, "role": "assistant", "content": reply, "token_count": out_tokens},
@@ -238,7 +257,6 @@ async def send_message(body: MessageBody):
     update_data = {"current_turn": new_turn}
     if is_last:
         update_data["status"] = "COMPLETED"
-    # 의도 파싱 (첫 응답에서 시도)
     if not sess.get("intent") and new_turn >= 1:
         parsed = _parse_intent(reply)
         if parsed:
@@ -251,6 +269,136 @@ async def send_message(body: MessageBody):
         "turn_number":     new_turn,
         "remaining_turns": max(0, max_turns - new_turn),
         "is_last_turn":    is_last,
+    }
+
+
+@router.get("/sessions/{session_id}/messages")
+def get_session_messages(session_id: str):
+    """
+    B3 수정: 이전 메시지 복원 — 인증 불필요 (비회원 접근 허용)
+    새로고침 시 프론트에서 이전 대화를 화면에 다시 렌더링하기 위해 사용
+    """
+    sb = get_supabase()
+
+    sess_res = sb.table("fix_chat_sessions").select(
+        "id, status, user_type, current_turn, max_turns, intent"
+    ).eq("id", session_id).limit(1).execute()
+
+    if not sess_res.data:
+        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다")
+
+    sess = sess_res.data[0]
+
+    msgs_res = sb.table("fix_chat_messages").select(
+        "id, role, content, created_at"
+    ).eq("session_id", session_id).order("id").execute()
+
+    messages = msgs_res.data or []
+
+    return {
+        "session_id":      session_id,
+        "status":          sess["status"],
+        "user_type":       sess["user_type"],
+        "current_turn":    sess["current_turn"],
+        "max_turns":       sess["max_turns"],
+        "remaining_turns": max(0, sess["max_turns"] - sess["current_turn"]),
+        "intent":          sess.get("intent"),
+        "messages":        messages,
+    }
+
+
+@router.post("/claim")
+def claim_session(body: ClaimBody, current_user: dict = Depends(get_current_user)):
+    """
+    B5 수정: 비회원 세션 소유권 주장 — 회원 인증 필수
+    로그인 후 localStorage의 session_id로 이 API를 호출하면:
+    - user_id 연결
+    - GUEST → MEMBER로 업그레이드 (max_turns 10으로 확대)
+    """
+    sb = get_supabase()
+
+    sess_res = sb.table("fix_chat_sessions").select("*").eq("id", body.session_id).limit(1).execute()
+    if not sess_res.data:
+        raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다")
+
+    sess = sess_res.data[0]
+
+    # 이미 다른 사용자에 연결된 세션이면 거부
+    if sess.get("user_id") and sess["user_id"] != current_user["id"]:
+        raise HTTPException(status_code=403, detail="다른 사용자의 세션입니다")
+
+    # 이미 내 세션이면 누멡승리
+    if sess.get("user_id") == current_user["id"]:
+        return {
+            "status":      "already_claimed",
+            "session_id":  body.session_id,
+            "user_type":   sess["user_type"],
+            "max_turns":   sess["max_turns"],
+            "current_turn": sess["current_turn"],
+        }
+
+    # 업그레이드: GUEST → MEMBER, max_turns 10으로 확장
+    new_user_type = "MEMBER" if sess["user_type"] == "GUEST" else sess["user_type"]
+    new_max_turns = USER_TYPE_MAX_TURNS.get(new_user_type, sess["max_turns"])
+
+    # COMPLETED된 세션이면 ACTIVE로 재활성화 (어렵리는 대화 가능하도록)
+    new_status = "ACTIVE" if sess["status"] == "COMPLETED" and sess["user_type"] == "GUEST" else sess["status"]
+
+    update = {
+        "user_id":   current_user["id"],
+        "user_type": new_user_type,
+        "max_turns": new_max_turns,
+        "status":    new_status,
+    }
+    sb.table("fix_chat_sessions").update(update).eq("id", body.session_id).execute()
+
+    return {
+        "status":       "claimed",
+        "session_id":   body.session_id,
+        "user_type":    new_user_type,
+        "max_turns":    new_max_turns,
+        "current_turn": sess["current_turn"],
+        "remaining_turns": max(0, new_max_turns - sess["current_turn"]),
+    }
+
+
+@router.get("/my/sessions")
+def my_sessions(
+    page: int = Query(1, ge=1),
+    size: int = Query(10, ge=1, le=50),
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    B5 수정: 내 세션 목록 — 회원 인증 필수
+    로그인한 사용자의 쿇대화 세션 목록 반환
+    """
+    sb = get_supabase()
+
+    offset = (page - 1) * size
+    res = sb.table("fix_chat_sessions").select(
+        "id, status, user_type, intent, current_turn, max_turns, created_at",
+        count="exact"
+    ).eq("user_id", current_user["id"]).order(
+        "created_at", desc=True
+    ).range(offset, offset + size - 1).execute()
+
+    items = res.data or []
+    total = res.count if res.count is not None else len(items)
+
+    # 첫 메시지 미리보기 추가
+    for it in items:
+        msg_res = sb.table("fix_chat_messages").select("content").eq(
+            "session_id", it["id"]
+        ).eq("role", "user").order("id").limit(1).execute()
+        it["preview"] = msg_res.data[0]["content"][:60] if msg_res.data else ""
+        it["remaining_turns"] = max(0, it["max_turns"] - it["current_turn"])
+
+    return {
+        "items":       items,
+        "total":       total,
+        "page":        page,
+        "size":        size,
+        "total_pages": max(1, (total + size - 1) // size),
     }
 
 
@@ -303,9 +451,9 @@ def complete_chat(body: CompleteBody, current_user: dict = Depends(get_current_u
     return {"status": "success", "request_id": request_id, "summary": last_assistant[:500]}
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 어드민 API (role_code=001 필수)
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 어드민 API (role_code=001 필수) — 변경 금지
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 @router.get("/admin/stats")
 def admin_stats(current_user: dict = Depends(get_current_user)):
@@ -319,45 +467,34 @@ def admin_stats(current_user: dict = Depends(get_current_user)):
     rows = all_res.data or []
     total = len(rows)
 
-    # 상태별
     by_status = {}
     for r in rows:
         s = r.get("status") or "UNKNOWN"
         by_status[s] = by_status.get(s, 0) + 1
 
-    # 의도별
     by_intent = {}
     for r in rows:
         i = r.get("intent") or "UNKNOWN"
         by_intent[i] = by_intent.get(i, 0) + 1
 
-    # 사용자 유형별
     by_user_type = {}
     for r in rows:
         ut = r.get("user_type") or "UNKNOWN"
         by_user_type[ut] = by_user_type.get(ut, 0) + 1
 
-    # 오늘
-    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today_str   = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     today_count = sum(1 for r in rows if (r.get("created_at") or "")[:10] == today_str)
-
-    # 총 턴 수
     total_turns = sum(r.get("current_turn", 0) for r in rows)
 
-    # 토큰 합계
-    token_res = sb.table("fix_chat_messages").select("token_count").not_.is_("token_count", "null").execute()
+    token_res    = sb.table("fix_chat_messages").select("token_count").not_.is_("token_count", "null").execute()
     total_tokens = sum(m.get("token_count", 0) for m in (token_res.data or []))
-
-    # 매칭 연결 수 (request_id가 있는 세션)
-    connected = sum(1 for r in rows if r.get("request_id"))
+    connected    = sum(1 for r in rows if r.get("request_id"))
 
     return {
-        # 프론트 호환 편의 필드
         "total":           total,
         "active":          by_status.get("ACTIVE", 0),
         "completed":       connected,
         "guest":           by_user_type.get("GUEST", 0),
-        # 상세 필드
         "total_sessions":  total,
         "today_sessions":  today_count,
         "total_turns":     total_turns,
@@ -371,9 +508,9 @@ def admin_stats(current_user: dict = Depends(get_current_user)):
 
 @router.get("/admin/sessions")
 def admin_sessions(
-    status:    Optional[str] = Query(None, description="ACTIVE / COMPLETED / EXPIRED"),
-    user_type: Optional[str] = Query(None, description="GUEST / MEMBER / SUBSCRIBER"),
-    intent:    Optional[str] = Query(None, description="REPAIR / APPOINTMENT / DIAGNOSIS / CONSULTING"),
+    status:    Optional[str] = Query(None),
+    user_type: Optional[str] = Query(None),
+    intent:    Optional[str] = Query(None),
     page:      int           = Query(1, ge=1),
     size:      int           = Query(20, ge=1, le=100),
     current_user: dict       = Depends(get_current_user),
@@ -386,32 +523,24 @@ def admin_sessions(
         "id, user_id, user_type, status, intent, current_turn, max_turns, request_id, created_at",
         count="exact"
     )
-
-    if status:
-        q = q.eq("status", status.upper())
-    if user_type:
-        q = q.eq("user_type", user_type.upper())
-    if intent:
-        q = q.eq("intent", intent.upper())
+    if status:    q = q.eq("status",    status.upper())
+    if user_type: q = q.eq("user_type", user_type.upper())
+    if intent:    q = q.eq("intent",    intent.upper())
 
     offset = (page - 1) * size
     q = q.order("created_at", desc=True).range(offset, offset + size - 1)
-
     res = q.execute()
-    items = res.data or []
+    items       = res.data or []
     total_count = res.count if res.count is not None else len(items)
 
-    # 각 세션의 첫 사용자 메시지 가져오기 (미리보기용)
     session_ids = [it["id"] for it in items]
-    previews = {}
+    previews    = {}
     if session_ids:
         for sid in session_ids:
             msg_res = sb.table("fix_chat_messages").select("content").eq(
-                "session_id", sid
-            ).eq("role", "user").order("id").limit(1).execute()
+                "session_id", sid).eq("role", "user").order("id").limit(1).execute()
             if msg_res.data:
                 previews[sid] = msg_res.data[0]["content"][:80]
-
     for it in items:
         it["preview"] = previews.get(it["id"], "")
 
@@ -425,10 +554,7 @@ def admin_sessions(
 
 
 @router.get("/admin/sessions/{session_id}")
-def admin_session_detail(
-    session_id:   str,
-    current_user: dict = Depends(get_current_user),
-):
+def admin_session_detail(session_id: str, current_user: dict = Depends(get_current_user)):
     """상담 세션 상세 + 전체 메시지"""
     _require_admin(current_user)
     sb = get_supabase()
@@ -437,18 +563,13 @@ def admin_session_detail(
     if not sess_res.data:
         raise HTTPException(status_code=404, detail="세션을 찾을 수 없습니다")
 
-    session = sess_res.data[0]
-
+    session  = sess_res.data[0]
     msgs_res = sb.table("fix_chat_messages").select(
         "id, role, content, token_count, created_at"
     ).eq("session_id", session_id).order("id").execute()
-
-    messages = msgs_res.data or []
-
-    # 총 토큰
+    messages     = msgs_res.data or []
     total_tokens = sum(m.get("token_count", 0) for m in messages if m.get("token_count"))
 
-    # 연결된 매칭 요청 정보
     matching_request = None
     if session.get("request_id"):
         mr_res = sb.table("matching_requests").select(
@@ -468,8 +589,8 @@ def admin_session_detail(
 
 def _parse_intent(text: str) -> str:
     t = text.upper()
-    if "REPAIR" in t or "수선" in t or "수리" in t: return "REPAIR"
+    if "REPAIR"      in t or "수선" in t or "수리" in t: return "REPAIR"
     if "APPOINTMENT" in t or "선임" in t or "대행" in t: return "APPOINTMENT"
-    if "DIAGNOSIS" in t or "진단" in t or "검사" in t: return "DIAGNOSIS"
-    if "CONSULTING" in t or "컨설팅" in t or "법령" in t: return "CONSULTING"
+    if "DIAGNOSIS"   in t or "진단" in t or "검사" in t: return "DIAGNOSIS"
+    if "CONSULTING"  in t or "컨설팅" in t or "법령" in t: return "CONSULTING"
     return "REPAIR"


### PR DESCRIPTION
## 변경 사항

### fix_chat.py v1.2.0
- B2: Claude API KEY 없을 때 폴백 응답 (502 대신 정상 응답)
- B3: `GET /fix/chat/sessions/{id}/messages` — 메시지 조회 API 신규
- B5: `POST /fix/chat/claim` — 비회원 세션 소유권 연결 API 신규
- B5: `GET /fix/chat/my/sessions` — 내 세션 목록 API 신규

### 관련 이슈
- closes #12

### 테스트
- API 동작 확인 완료 (/fix/chat/start 200, /fix/chat/message 200)
- DB 저장 확인 (세션 + 메시지 정상 기록)
- ANTHROPIC_API_KEY 정상 등록 확인