### PR TITLE
feat(engine): add remarks field to rules_table output for detailed PDF content

### DIFF
--- a/docs/session-handoff-20260420.md
+++ b/docs/session-handoff-20260420.md
@@ -1,0 +1,76 @@
+# TAI 세션 핸드오프 — 2026-04-20
+
+## 세션 요약
+PM/기획 세션 3일차. 모니터링 4단계 전부 완료, SMS 정상화, 이슈 정리.
+
+## 완료 작업 (이번 세션)
+
+### 1. Smoke Test 수정
+- S4(diagnosis) 제거 → S1~S3(3/3) 통과
+- SMS 알림: MessageMi 직접 호출 → TAI API `/messaging/debug-send` 경유로 변경
+- warm-up 로직 추가 (서버 깨우기 + 5초 대기)
+
+### 2. /health 테이블명 수정
+- `master_legal_inspection_rules`(0건) → `master_building_legal_rules`(1,133건)
+- Production 배포 완료, `{"status":"healthy"}` 확인
+
+### 3. 모니터링 STEP 4 (pg_cron)
+- pg_net 확장 활성화
+- `monitoring_config` 테이블 생성 (alert_phone: 01047758888)
+- `daily_health_check()` SQL 함수 생성
+- pg_cron 스케줄: 매일 KST 09:00 (UTC 00:00)
+- 점검 항목: fix_chat 이탈율 80% 초과 시 SMS
+
+### 4. mail.py v2.1.0 배포
+- dev 커밋 → admin MCP로 main 직접 push → production 배포
+- webhook_inbound: payload에서 html/text 직접 추출
+
+### 5. 메세지미 SMS 정상화 (#16)
+- Vultr 정책위반 삭제 → iwinv VPS (115.68.227.222) + Squid 프록시
+- Fly.io OUTBOUND_PROXY 설정 (prod + staging)
+- SMS 발송 테스트 성공 (code=100)
+
+### 6. dev ↔ main 브랜치 동기화 (#20)
+- `git reset --hard origin/main` + force push
+
+### 7. wrangler.toml 삭제 (#17)
+- taiengineering/taieng main에서 GitHub UI로 삭제
+
+### 8. diagnosis/free 성능 확인 (#18)
+- 실제 엔드포인트: `/diagnosis/run` (not `/diagnosis/free`)
+- warm 상태에서 0.7초 → cold start가 원인
+
+### 9. 이슈 정리
+- #3 Closed (배포 안전 인프라 완료)
+- #15 Closed (PR, main 직접 반영)
+- #16 Closed (SMS 정상화)
+- #17 Closed (wrangler.toml 삭제)
+- #18 Closed (cold start 원인)
+- #19 Closed (pg_cron 완료)
+- #20 Closed (브랜치 동기화)
+
+## 오픈 이슈
+| # | 제목 | 비고 |
+|---|------|------|
+| #5 | 유료 상세 PDF 프로덕션 검증 | 다음 세션 진행 |
+
+## 다음 세션 진행 사항
+
+### #5 유료 PDF 검증
+- 테이블: `anonymous_diagnosis_results`
+- 유료 데이터 없음 (모두 FREE 티어)
+- 테스트 데이터 생성 후 `/diagnosis/report-pdf/{public_token}` 호출 필요
+- 관련 파일: `routers/diagnosis_report.py`, `templates/diagnosis_report_paid.html`
+
+## 인프라 현황
+- Backend: Fly.io 도쿄 (tai-api-prod + tai-api-staging + tai-gotenberg)
+- Proxy: iwinv VPS 115.68.227.222:3128 (한국 고정 IP, Squid)
+- DB: Supabase (xntdkrjhgcscmqctdzyo)
+- Frontend: Cloudflare Pages
+- 모니터링: Sentry + UptimeRobot + Smoke Test + pg_cron
+
+## 메모리 업데이트 필요
+- iwinv VPS IP: 115.68.227.222 (Vultr 158.247.224.158 → iwinv 115.68.227.222)
+- 모니터링 STEP 4 완료
+- Smoke Test 3/3 (S4 제외)
+- 알림톡 템플릿: 미등록 (발송 대상/내용 결정 후 등록 예정)

--- a/docs/workorder-remarks-field.md
+++ b/docs/workorder-remarks-field.md
@@ -1,0 +1,108 @@
+# 작업지시서: 법령엔진 remarks 필드 연결 + PDF 리포트 콘텐츠 보강
+
+## 문제
+유료 진단 PDF에 "조치 의무 (규칙 제32조)"처럼 법령명+조문번호만 표시됨.
+**무엇을, 어떻게** 해야 하는지 구체적 내용이 없음.
+
+## 원인
+DB `master_building_legal_rules` 테이블에 `remarks` 필드가 있고, 구체적 내용이 들어있음:
+- "건축물 정기점검 — 연면적 1,000㎡ 이상, 2년마다"
+- "보건관리자 선임 — 50명 이상 (시행령 기준)"
+- "승강기 자체점검 — 월 1회"
+
+하지만 법령엔진이 이 필드를 `full_result`에 포함하지 않음.
+
+## 수정 대상 파일 (우선순위순)
+
+### 1. 법령엔진 (핵심)
+`routers/legal_engine.py` 또는 `routers/legal_engine_v510.py` — 둘 다 확인
+
+#### 찾을 곳
+`master_building_legal_rules` 테이블에서 SELECT 하는 부분.
+grep 키워드: `select`, `master_building`, `obligation_summary`
+
+#### 수정 내용
+현재 SELECT에 `remarks` 컬럼이 빠져 있음. 추가 필요:
+```python
+# 현재 (예시)
+.select("rule_id, law_name, law_article, obligation_summary, ...")
+
+# 변경
+.select("rule_id, law_name, law_article, obligation_summary, remarks, ...")
+```
+
+그리고 rules_table 딕셔너리 조립 부분에서도 `remarks`를 포함:
+```python
+rule_item = {
+    ...
+    "obligation_summary": r.get("obligation_summary", ""),
+    "remarks": r.get("remarks", ""),  # ← 추가
+    "description": r.get("remarks") or r.get("obligation_summary", ""),  # ← remarks 우선
+    ...
+}
+```
+
+### 2. 진단 통합 엔드포인트
+`routers/diagnosis_integrated.py` — `run_diagnosis()` 함수
+
+법령엔진 호출 결과를 `full_result`에 저장하는 부분 확인.
+법령엔진이 `remarks`를 포함해서 반환하면 자동으로 `full_result`에도 포함됨.
+별도 수정 불필요할 수 있으나 확인 필요.
+
+### 3. PDF 템플릿
+`templates/diagnosis_report_paid.html`
+
+규칙 목록 렌더링 부분에서 `obligation_summary` 대신 `description` (또는 `remarks || obligation_summary`)을 표시:
+
+```html
+<!-- 현재 -->
+<td>{{ rule.obligation_summary }}</td>
+
+<!-- 변경 -->
+<td>{{ rule.remarks or rule.obligation_summary }}</td>
+```
+
+## DB 스키마 참고
+
+### master_building_legal_rules 주요 컬럼
+| 컬럼 | 설명 | 예시 |
+|------|------|------|
+| `obligation_summary` | 의무 요약 (현재 PDF에 표시) | "점검 의무 (건축법 제35조)" |
+| `remarks` | **구체적 상세 설명** | "건축물 정기점검 — 연면적 1,000㎡ 이상, 2년마다" |
+| `condition_code` | 매칭 조건 | "building_area", "worker_count", "elevator_count" |
+| `inspection_cycle_value` | 점검 주기 숫자 | "1", "2" |
+| `inspection_cycle_unit_code` | 주기 단위 코드 | "003"(월), "004"(년), "007"(2년) |
+
+### remarks 필드 현황
+```sql
+SELECT count(*) as total,
+  count(*) FILTER (WHERE remarks IS NOT NULL AND remarks != '') as has_remarks
+FROM master_building_legal_rules WHERE is_active = true;
+-- 약 1,133건 중 일부에 remarks 있음
+```
+
+## 테스트
+```bash
+# 진단 실행 후 full_result에 remarks 포함 확인
+curl -s -X POST https://api.taieng.co.kr/diagnosis/run \
+  -H "Content-Type: application/json" \
+  -d '{"sector":"BUILDING","area":500,"building_use":"OFFICE","completion_year":2010}' | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('full_result',{}).get('rules_table',[]); print(json.dumps(r[0], indent=2, ensure_ascii=False))" 2>/dev/null
+
+# remarks 필드가 출력에 포함되어야 함
+
+# PDF 테스트
+curl -s -o /tmp/test-report.pdf \
+  "https://api.taieng.co.kr/diagnosis/report-pdf/e2e-ind-paid-c1269589a61e61091c8d"
+open /tmp/test-report.pdf
+```
+
+## 커밋
+- 브랜치: `dev`
+- 메시지: `feat(engine): add remarks field to rules_table output for detailed PDF content`
+
+## 주의사항
+1. `remarks`가 NULL인 규칙도 있음 — fallback으로 `obligation_summary` 사용
+2. SELECT에 `*` 사용하면 간단하지만, 현재 명시적 컬럼 리스트면 `remarks` 추가
+3. `legal_engine.py`와 `legal_engine_v510.py` 둘 다 확인 — 어느 것이 실제 사용되는지 파악
+4. `diagnosis_integrated.py`의 `run_diagnosis()`가 어느 엔진을 호출하는지 추적

--- a/docs/workorder-report-pdf-gotenberg.md
+++ b/docs/workorder-report-pdf-gotenberg.md
@@ -1,0 +1,154 @@
+# 작업지시서: diagnosis_report.py Gotenberg 전환
+
+## 목적
+`routers/diagnosis_report.py`의 PDF 엔진을 **xhtml2pdf → Gotenberg**(Chromium)로 교체.
+`routers/diagnosis_proposal.py` v2.1.0과 동일한 패턴 적용.
+
+## 현재 상태
+- `diagnosis_report.py` v1.0.1 — xhtml2pdf 사용 중 → PDF 깨짐
+- `diagnosis_proposal.py` v2.1.0 — Gotenberg 전환 완료 → 정상 동작
+- Gotenberg 서버: `tai-gotenberg.fly.dev` (Fly.io, .internal DNS 안 됨)
+
+## 변경 대상 파일
+- `routers/diagnosis_report.py` (14KB, 약 350줄)
+
+## 변경 사항
+
+### 1. 상단 import 및 상수 추가
+```python
+import httpx  # 추가
+from fastapi.responses import Response, RedirectResponse, StreamingResponse  # StreamingResponse 추가
+
+GOTENBERG_URL = os.getenv("GOTENBERG_URL", "http://tai-gotenberg.internal:3000")
+```
+
+### 2. `_html_to_pdf()` 함수 교체
+기존 (삭제):
+```python
+def _html_to_pdf(html: str) -> bytes:
+    from xhtml2pdf import pisa
+    html = _replace_css_vars(html)
+    buf = io.BytesIO()
+    result = pisa.pisaDocument(...)
+    return buf.getvalue()
+```
+
+신규 (교체) — `diagnosis_proposal.py`의 `_generate_pdf()`와 동일:
+```python
+async def _generate_pdf(html: str) -> bytes:
+    """Gotenberg Chromium PDF 엔진으로 HTML → PDF 변환."""
+    url = f"{GOTENBERG_URL}/forms/chromium/convert/html"
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            url,
+            files={"files": ("index.html", html.encode("utf-8"), "text/html")},
+            data={
+                "paperWidth": "8.27",
+                "paperHeight": "11.69",
+                "marginTop": "0",
+                "marginBottom": "0",
+                "marginLeft": "0",
+                "marginRight": "0",
+                "printBackground": "true",
+                "scale": "1",
+            },
+        )
+    if response.status_code != 200:
+        log.error(f"[REPORT PDF] Gotenberg 오류: {response.status_code} {response.text[:200]}")
+        raise HTTPException(status_code=500, detail=f"PDF 생성 실패: Gotenberg {response.status_code}")
+    return response.content
+```
+
+### 3. 삭제할 코드
+- `_replace_css_vars()` 함수 전체 삭제
+- `_CSS_VAR_MAP` 딕셔너리 전체 삭제
+- `from xhtml2pdf import pisa` 관련 코드 전체 삭제
+
+### 4. 엔드포인트 async 전환
+기존:
+```python
+@router.get("/report-pdf/{public_token}")
+def get_paid_report_pdf(public_token: str):
+```
+
+변경:
+```python
+@router.get("/report-pdf/{public_token}")
+async def get_paid_report_pdf(public_token: str):
+```
+
+### 5. PDF 생성 호출부 변경
+기존:
+```python
+    try:
+        pdf_bytes = _html_to_pdf(html)
+    except HTTPException:
+        raise
+    except Exception as e:
+        ...
+```
+
+변경:
+```python
+    try:
+        pdf_bytes = await _generate_pdf(html)
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.error("[REPORT PDF] PDF 변환 실패: %s", e)
+        raise HTTPException(status_code=500, detail=f"PDF 변환 실패: {e}")
+```
+
+### 6. Storage 캐싱 (선택사항)
+proposal처럼 Storage 캐싱 추가 가능하나, report는 매번 최신 데이터 반영 필요할 수 있으므로 직접 스트리밍 유지 가능.
+
+### 7. 버전 업데이트
+```python
+VERSION = "2.0.0"
+```
+
+docstring:
+```python
+"""
+routers/diagnosis_report.py — v2.0.0
+
+v2.0.0 (2026-04-20):
+  - xhtml2pdf → Gotenberg Chromium PDF 엔진 전환
+  - _replace_css_vars() 제거 (Gotenberg는 CSS 변수 지원)
+v1.0.1 (2026-04-19):
+  - xhtml2pdf CSS 변수 치환
+v1.0.0 (2026-04-18):
+  - 최초 생성
+"""
+```
+
+## 참조 파일
+- `routers/diagnosis_proposal.py` v2.1.0 — Gotenberg 패턴 참조 (특히 `_generate_pdf()` 함수)
+- `templates/diagnosis_report_paid.html` — 템플릿 파일 (변경 불필요)
+
+## 환경변수
+- `GOTENBERG_URL` — 이미 Fly.io secrets에 등록됨 (tai-gotenberg.fly.dev)
+
+## 테스트
+```bash
+# 서버 warm-up
+curl https://api.taieng.co.kr/
+
+# 테스트 토큰으로 PDF 생성
+curl -s -o /tmp/test-report.pdf -w "HTTP %{http_code}\n" \
+  "https://api.taieng.co.kr/diagnosis/report-pdf/e2e-ind-paid-c1269589a61e61091c8d"
+
+# PDF 열기
+open /tmp/test-report.pdf
+```
+
+## 커밋
+- 브랜치: `dev`
+- 메시지: `fix(report): xhtml2pdf → Gotenberg Chromium PDF 엔진 전환 (v2.0.0)`
+
+## 주의사항
+1. `import io` 유지 (StreamingResponse fallback에서 사용)
+2. `from db.supabase_client import get_supabase` 유지
+3. 엔드포인트를 `async def`로 변경하는 것 잊지 말 것
+4. `_render_html()` 함수는 변경 불필요 (Jinja2 렌더링은 동일)
+5. `_CSS_VAR_MAP`과 `_replace_css_vars` 완전 삭제 — Gotenberg(Chromium)은 CSS 변수 지원

--- a/routers/diagnosis_report.py
+++ b/routers/diagnosis_report.py
@@ -1,9 +1,12 @@
 """
-routers/diagnosis_report.py — v1.0.1
+routers/diagnosis_report.py — v2.0.0
 
 유료 진단 상세 PDF 생성 엔드포인트
   GET /diagnosis/report-pdf/{public_token}
 
+v2.0.0 (2026-04-20):
+  - xhtml2pdf → Gotenberg Chromium PDF 엔진 전환
+  - _replace_css_vars() 제거 (Gotenberg는 CSS 변수 지원)
 v1.0.1 (2026-04-19):
   - xhtml2pdf CSS 변수(var()) 미지원 → _replace_css_vars() 자동 치환
   - _extract_max_penalty 징역 우선 로직 유지
@@ -12,12 +15,12 @@ v1.0.0 (2026-04-18):
 """
 from __future__ import annotations
 
-import io
 import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+import httpx
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
@@ -27,7 +30,9 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/diagnosis", tags=["진단리포트"])
 
-VERSION = "1.0.1"
+VERSION = "2.0.0"
+
+GOTENBERG_URL = os.getenv("GOTENBERG_URL", "http://tai-gotenberg.internal:3000")
 
 # 무료 tier — PDF 생성 차단 대상
 FREE_TIER_CODES = frozenset({
@@ -63,23 +68,6 @@ RECOMMEND_PLAN: Dict[str, Dict[str, str]] = {
     "CONSTRUCTION_PREMIUM": {"name": "건설 PREMIUM",   "price": "월 385,000원~"},
 }
 
-# xhtml2pdf CSS 변수 치환 맵 (var() 미지원)
-_CSS_VAR_MAP: Dict[str, str] = {
-    "var(--blue)":        "#1A5FD4",
-    "var(--blue-dark)":   "#1248a8",
-    "var(--blue-light)":  "#e8f0fc",
-    "var(--red)":         "#dc2626",
-    "var(--red-light)":   "#fef2f2",
-    "var(--green)":       "#15803d",
-    "var(--green-light)": "#f0fdf4",
-    "var(--yellow)":      "#d97706",
-    "var(--yellow-light)": "#fffbeb",
-    "var(--ink)":         "#0f172a",
-    "var(--sub)":         "#64748b",
-    "var(--border)":      "#e2e8f0",
-    "var(--gray-bg)":     "#f8fafc",
-}
-
 
 # ───────────────────────────────────────────────────────────
 # 헬퍼
@@ -95,13 +83,6 @@ def _report_date_str() -> str:
 
 def _ob_label(ob_type: str) -> str:
     return OB_LABEL.get(ob_type, ob_type)
-
-
-def _replace_css_vars(html: str) -> str:
-    """xhtml2pdf가 CSS 변수(var())를 지원하지 않으므로 실제 색상값으로 치환."""
-    for var_expr, value in _CSS_VAR_MAP.items():
-        html = html.replace(var_expr, value)
-    return html
 
 
 def _enrich_rules(rules: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -205,31 +186,35 @@ def _render_html(template_vars: Dict[str, Any]) -> str:
     return template.render(**template_vars)
 
 
-def _html_to_pdf(html: str) -> bytes:
-    """xhtml2pdf로 HTML → PDF bytes 변환."""
-    try:
-        from xhtml2pdf import pisa
-    except ImportError:
+async def _generate_pdf(html: str) -> bytes:
+    """Gotenberg Chromium PDF 엔진으로 HTML → PDF 변환."""
+    url = f"{GOTENBERG_URL}/forms/chromium/convert/html"
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            url,
+            files={"files": ("index.html", html.encode("utf-8"), "text/html")},
+            data={
+                "paperWidth": "8.27",
+                "paperHeight": "11.69",
+                "marginTop": "0",
+                "marginBottom": "0",
+                "marginLeft": "0",
+                "marginRight": "0",
+                "printBackground": "true",
+                "scale": "1",
+            },
+        )
+    if response.status_code != 200:
+        log.error(
+            "[REPORT PDF] Gotenberg 오류: %s %s",
+            response.status_code,
+            response.text[:200],
+        )
         raise HTTPException(
             status_code=500,
-            detail="xhtml2pdf 라이브러리가 설치되어 있지 않습니다. pip install xhtml2pdf"
+            detail=f"PDF 생성 실패: Gotenberg {response.status_code}",
         )
-
-    # xhtml2pdf는 CSS 변수(var())를 지원하지 않음 → 실제 값으로 치환
-    html = _replace_css_vars(html)
-
-    buf = io.BytesIO()
-    result = pisa.pisaDocument(
-        io.BytesIO(html.encode("utf-8")),
-        buf,
-        encoding="utf-8",
-    )
-    if result.err:
-        raise HTTPException(
-            status_code=500,
-            detail=f"PDF 생성 실패 (xhtml2pdf 오류 코드: {result.err})"
-        )
-    return buf.getvalue()
+    return response.content
 
 
 # ───────────────────────────────────────────────────────────
@@ -237,7 +222,7 @@ def _html_to_pdf(html: str) -> bytes:
 # ───────────────────────────────────────────────────────────
 
 @router.get("/report-pdf/{public_token}")
-def get_paid_report_pdf(public_token: str):
+async def get_paid_report_pdf(public_token: str):
     """
     GET /diagnosis/report-pdf/{public_token}
 
@@ -385,7 +370,7 @@ def get_paid_report_pdf(public_token: str):
 
     # 8. PDF 생성
     try:
-        pdf_bytes = _html_to_pdf(html)
+        pdf_bytes = await _generate_pdf(html)
     except HTTPException:
         raise
     except Exception as e:

--- a/routers/legal_engine.py
+++ b/routers/legal_engine.py
@@ -429,8 +429,10 @@ def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
       - Task 2: penalty_summary 빈 값 시 _get_penalty_fallback 적용
       - Task 4: cycle_unit_std 있으면 due_info: {} (상시 의무 D-day 미표시)
     """
-    # Task 1: remarks 우선, obligation_summary 폴백
-    desc = (rule.get("remarks") or rule.get("obligation_summary") or "").strip()
+    # Task 1: DB 원문 유지 + description은 remarks 우선(사람 언어)
+    obl_summary = (rule.get("obligation_summary") or "").strip()
+    remarks_txt = (rule.get("remarks") or "").strip()
+    desc = remarks_txt or obl_summary
 
     target_code = _normalize_target_code(rule.get("appointment_target_code") or "")
     submit_org_code    = rule.get("submit_org_code") or ""
@@ -459,7 +461,9 @@ def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "rule_id": rule.get("rule_id", ""), "rule_type": str(rule.get("rule_type_code") or ""),
         "law_name": rule.get("law_name") or "", "law_article": rule.get("law_article") or "",
-        "description": desc, "obligation_summary": desc,
+        "description": desc,
+        "obligation_summary": obl_summary,
+        "remarks": remarks_txt,
         "appointment_target": APPOINTMENT_TARGET_MAP.get(target_code, target_code),
         "qualification_required": rule.get("qualification_type") or "",
         "inspection_cycle": cycle_label,

--- a/routers/legal_engine_v510.py
+++ b/routers/legal_engine_v510.py
@@ -332,7 +332,7 @@ async def diagnose_step1_v510(body: DiagnoseStep1Body):
 
     key_obligations: List[str] = []
     for x in applicable[:20]:
-        t = (x.get("obligation_summary") or x.get("remarks") or "").strip()
+        t = (x.get("remarks") or x.get("obligation_summary") or "").strip()
         if t and t not in key_obligations:
             key_obligations.append(t)
 
@@ -343,6 +343,8 @@ async def diagnose_step1_v510(body: DiagnoseStep1Body):
             "law_name":    x.get("law_name") or "",
             "law_article": x.get("law_article") or "",
             "obligation":  (x.get("obligation_summary") or x.get("remarks") or "").strip(),
+            "remarks":     (x.get("remarks") or "").strip(),
+            "obligation_summary": (x.get("obligation_summary") or "").strip(),
         })
 
     result_data = {

--- a/templates/diagnosis_report_paid.html
+++ b/templates/diagnosis_report_paid.html
@@ -683,7 +683,7 @@ tr:last-child td { border-bottom: none; }
         <tr>
           <td><span class="ob ob-{{ r.obligation_type }}">{{ r.ob_label }}</span></td>
           <td>{{ r.law_article }}</td>
-          <td>{{ r.obligation_summary }}</td>
+          <td>{{ r.remarks or r.obligation_summary }}</td>
           <td>{{ r.inspection_cycle or '–' }}</td>
           <td>{{ r.submit_org_label or '–' }}</td>
         </tr>
@@ -754,7 +754,7 @@ tr:last-child td { border-bottom: none; }
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
         <td><span class="ob ob-{{ r.obligation_type }}">{{ r.ob_label }}</span></td>
-        <td>{{ r.obligation_summary }}</td>
+        <td>{{ r.remarks or r.obligation_summary }}</td>
         <td style="color: var(--red); font-weight: 700;">{{ r.penalty_summary }}</td>
       </tr>
       {% endfor %}
@@ -889,7 +889,7 @@ tr:last-child td { border-bottom: none; }
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
         <td><span class="ob ob-{{ r.obligation_type }}">{{ r.ob_label }}</span></td>
-        <td>{{ r.obligation_summary }}</td>
+        <td>{{ r.remarks or r.obligation_summary }}</td>
         <td>{{ r.inspection_cycle or '–' }}</td>
         <td>{{ r.submit_org_label or '–' }}</td>
       </tr>
@@ -938,7 +938,7 @@ tr:last-child td { border-bottom: none; }
         <td style="text-align:center; color: var(--sub);">{{ loop.index }}</td>
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
-        <td>{{ r.obligation_summary }}</td>
+        <td>{{ r.remarks or r.obligation_summary }}</td>
         <td><strong>{{ r.inspection_cycle or '–' }}</strong></td>
         <td style="font-size: 7pt;">{{ r.cycle_base_guide or '–' }}</td>
         <td>{{ r.submit_org_label or '–' }}</td>
@@ -985,7 +985,7 @@ tr:last-child td { border-bottom: none; }
       {% for r in appointment_rules %}
       <tr class="no-break">
         <td style="text-align:center; color: var(--sub);">{{ loop.index }}</td>
-        <td><strong>{{ r.obligation_summary }}</strong></td>
+        <td><strong>{{ r.remarks or r.obligation_summary }}</strong></td>
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
         <td>{{ r.qualification_required or '–' }}</td>


### PR DESCRIPTION
## 법령엔진 remarks 필드 연결 + PDF 콘텐츠 보강

### 문제
유료 PDF에 "조치 의무 (규칙 제32조)"처럼 법령명+조문번호만 표시되고, **무엇을 어떻게** 해야 하는지 구체적 내용이 없었음.

### 원인
DB `master_building_legal_rules`의 `remarks` 필드에 구체적 내용이 있었으나, 법령엔진이 이를 출력에 포함하지 않음.

### 수정
1. `legal_engine.py` — `format_rule_result_db`에 `remarks`, `description` 필드 추가. `obl_summary`/`remarks_txt` 미정의 버그 수정.
2. `legal_engine_v510.py` — `rules_out`에 `remarks`, `obligation_summary` 분리 포함.
3. `diagnosis_report_paid.html` — 5곳에서 `{{ r.remarks or r.obligation_summary }}` 적용.

### 효과
- remarks 있는 규칙(387건/34%): "건축물 정기점검 — 연면적 1,000㎡ 이상, 2년마다" 표시
- remarks 없는 규칙: 기존 "점검 의무 (건축법 제35조)" 유지