### PR TITLE
[법령엔진] 수집엔진 보강 — 6하원칙 소비자 품질 + 무결성 (이슈 #24)

### DIFF
--- a/docs/claude-code-prompt-law-engine.md
+++ b/docs/claude-code-prompt-law-engine.md
@@ -1,0 +1,167 @@
+# Claude Code 작업지시 — 법령엔진 수집엔진 보강 (보조/검증)
+
+## 배경
+TAI Safe 법령엔진 보강. 이슈 #24.
+기준 문서: `docs/law-engine-enhancement-workorder.md` (dev, v2.1)
+
+Cursor가 메인 코드 작업 담당. Claude Code는 보조 작업 + 검증 담당.
+
+---
+
+## TASK 1: tai_feature_code DDL 실행
+
+```sql
+ALTER TABLE master_building_legal_rules
+  ADD COLUMN IF NOT EXISTS tai_feature_code VARCHAR(50);
+
+COMMENT ON COLUMN master_building_legal_rules.tai_feature_code IS 
+  'TAI 기능 연결: APPOINTMENT/INSPECTION/REPORT/EDUCATION/DOCUMENT/FIX/CHECKLIST';
+```
+
+터미널 또는 Supabase Dashboard에서 실행.
+
+---
+
+## TASK 2: tai_feature_code 자동 매핑 (기존 데이터)
+
+master 1,133건 활성 룰에 tai_feature_code를 일괄 매핑.
+의무 유형별 규칙:
+
+```sql
+-- APPOINTMENT: 선임 의무
+UPDATE master_building_legal_rules
+SET tai_feature_code = 'APPOINTMENT'
+WHERE appointment_required = true AND tai_feature_code IS NULL;
+
+-- INSPECTION: 점검 의무  
+UPDATE master_building_legal_rules
+SET tai_feature_code = 'INSPECTION'
+WHERE inspection_required = true AND tai_feature_code IS NULL;
+
+-- REPORT: 신고/보고 의무
+UPDATE master_building_legal_rules
+SET tai_feature_code = 'REPORT'
+WHERE (report_required = true OR notify_required = true) AND tai_feature_code IS NULL;
+
+-- CHECKLIST: 작업 전 조치 의무
+UPDATE master_building_legal_rules
+SET tai_feature_code = 'CHECKLIST'
+WHERE action_required = true AND tai_feature_code IS NULL;
+
+-- 나머지: obligation_type 기반
+UPDATE master_building_legal_rules
+SET tai_feature_code = CASE
+  WHEN obligation_type = 'APPOINT' THEN 'APPOINTMENT'
+  WHEN obligation_type = 'INSPECT' THEN 'INSPECTION'
+  WHEN obligation_type = 'NOTIFY' THEN 'REPORT'
+  WHEN obligation_type = 'REPORT' THEN 'DOCUMENT'
+  WHEN obligation_type = 'ACTION' THEN 'CHECKLIST'
+  ELSE NULL
+END
+WHERE tai_feature_code IS NULL AND obligation_type IS NOT NULL;
+```
+
+실행 후 확인:
+```sql
+SELECT tai_feature_code, COUNT(*) 
+FROM master_building_legal_rules 
+WHERE is_active = true 
+GROUP BY tai_feature_code;
+```
+
+---
+
+## TASK 3: 무결성 사전 점검 (validate 로직 검증용)
+
+Cursor가 validate-master 엔드포인트를 만들기 전에, 현재 상태를 SQL로 확인:
+
+```sql
+-- 1. condition 깨진 건수
+SELECT COUNT(*) as broken_condition
+FROM master_building_legal_rules
+WHERE is_active = true
+  AND condition_code IS NOT NULL
+  AND (condition_operator_code IS NULL OR condition_value IS NULL);
+
+-- 2. inspection 필수인데 주기 없는 건수  
+SELECT COUNT(*) as missing_cycle
+FROM master_building_legal_rules
+WHERE is_active = true
+  AND inspection_required = true
+  AND (inspection_cycle_value IS NULL OR inspection_cycle_unit_code IS NULL);
+
+-- 3. report 필수인데 method 없는 건수
+SELECT COUNT(*) as missing_report_method
+FROM master_building_legal_rules
+WHERE is_active = true
+  AND report_required = true
+  AND report_method_code IS NULL;
+
+-- 4. appointment 필수인데 자격 없는 건수
+SELECT COUNT(*) as missing_qualification
+FROM master_building_legal_rules
+WHERE is_active = true
+  AND appointment_required = true
+  AND appointment_qualification_code IS NULL;
+
+-- 5. penalty 필수인데 값 없는 건수
+SELECT COUNT(*) as missing_penalty
+FROM master_building_legal_rules
+WHERE is_active = true
+  AND penalty_required = true
+  AND penalty_value IS NULL;
+
+-- 6. 전체 빈칸 현황 (6하원칙)
+SELECT 
+  COUNT(*) as total,
+  COUNT(NULLIF(penalty_summary,'')) as has_why,
+  COUNT(appointment_qualification_code) as has_who,
+  COUNT(CASE WHEN due_days > 0 THEN 1 END) as has_when_days,
+  COUNT(cycle_base_guide) as has_when_cycle,
+  COUNT(submit_org_code) as has_where,
+  COUNT(form_name) as has_how_form,
+  COUNT(report_method_code) as has_how_method,
+  COUNT(tai_feature_code) as has_tai
+FROM master_building_legal_rules
+WHERE is_active = true;
+```
+
+이 결과를 기록해두면 Cursor 작업 후 비교 가능.
+
+---
+
+## TASK 4: reparse 테스트 데이터 준비
+
+Cursor가 reparse-master를 구현하면 테스트할 3건:
+
+```sql
+-- 테스트 대상 확인
+SELECT rule_id, law_name, law_article, 
+       condition_code, condition_operator_code, condition_value,
+       penalty_summary, form_name, report_method_code,
+       appointment_qualification_code
+FROM master_building_legal_rules
+WHERE rule_id IN ('FIREACT-005-MFG', 'ENERGYACT-002', 'ODORACTS-001-MFG');
+```
+
+reparse 후 동일 쿼리 실행하여 빈칸이 채워졌는지 확인.
+
+---
+
+## TASK 5: Cursor 작업 후 코드 리뷰
+
+Cursor가 PR 올리면 확인할 사항:
+1. `services/law_context_builder.py`가 시행령+별표+벌칙을 제대로 조립하는지
+2. 시스템 프롬프트에 condition_code 24개 전부 있는지
+3. reparse-master가 Sonnet 모델을 사용하는지 (Haiku 아님)
+4. validate-master 검증 규칙이 7개 전부 구현됐는지
+5. few-shot 예시가 포함됐는지
+6. submit_org_code 한글 매핑 상수가 있는지
+
+---
+
+## 개발 규칙
+- `from db.supabase_client import get_supabase`
+- main 직접 push 금지 → dev → PR → main
+- git checkout origin/dev 전 git fetch 필수
+- 200줄+ 파일 MCP 수정 금지 → Cursor

--- a/docs/cursor-prompt-law-engine.md
+++ b/docs/cursor-prompt-law-engine.md
@@ -1,0 +1,298 @@
+# Cursor 작업지시 — 법령엔진 수집엔진 보강
+
+## 배경
+TAI Safe 법령엔진의 수집 파이프라인 보강. 이슈 #24.
+기존 Haiku 파싱 엔진(`routers/law_rule_generator.py`)이 조문 1개만 받아 13개 필드만 출력.
+결과: 프로덕션 master 테이블 82컬럼 중 ~15개만 채워짐.
+소비자 6하원칙(WHAT/WHY/WHO/WHEN/WHERE/HOW) 전달 불가.
+
+## 기준 문서
+`docs/law-engine-enhancement-workorder.md` (dev 브랜치, v2.1) — 반드시 먼저 읽을 것.
+
+## 작업 개요
+기존 엔진 보강 (새로 만들지 않음). 3개 파일 작업.
+
+---
+
+## TASK 1: services/law_context_builder.py 신규 작성
+
+### 목적
+법령 원문을 DB에서 풀세트로 조립하여 AI에게 제공할 컨텍스트를 만드는 서비스.
+
+### 입력
+- law_name (str): 법령명
+- law_article (str): 조문번호 (예: "제24조")
+- article_id (str, optional): law_article 테이블 UUID
+
+### 출력
+하나의 텍스트 문자열. 아래 4개를 합쳐서 반환:
+1. 본조 전문 (law_article + law_paragraph + law_item)
+2. 시행령 관련 조문 (같은 법률의 시행령에서 관련 조문)
+3. 별표/서식 목록 (law_attachment)
+4. 벌칙 조항 (같은 법률의 벌칙/과태료 조문)
+
+### DB 테이블 구조
+```
+law_master (id, law_name, law_type_code, is_active)
+  └─ law_version (id, law_id, is_current)
+       ├─ law_article (id, law_version_id, article_no, article_title, article_text, ai_parsed_at)
+       │    ├─ law_paragraph (id, article_id, paragraph_no, paragraph_text)
+       │    └─ law_item (→ paragraph 하위)
+       └─ law_attachment (id, law_version_id, ...)
+```
+
+### 구현 로직
+```python
+async def build_full_context(law_name: str, law_article: str, article_id: str = None) -> str:
+    supabase = get_supabase()
+    parts = []
+    
+    # 1. 본조 전문
+    # law_master에서 law_name으로 찾기 → law_version(is_current=True) → law_article
+    # article_id가 있으면 직접 조회, 없으면 law_article 컬럼에서 article_no 매칭
+    # law_paragraph, law_item 포함
+    
+    # 2. 시행령 관련 조문
+    # law_master에서 "법률명 시행령" 검색 (예: "화재의 예방 및 안전관리에 관한 법률" → "화재의 예방 및 안전관리에 관한 법률 시행령")
+    # 해당 시행령의 전체 조문 중 관련 조문 포함 (article_title에 키워드 매칭 또는 전체)
+    # 별표도 포함
+    
+    # 3. 별표/서식
+    # law_attachment에서 해당 법률 버전의 첨부 목록
+    
+    # 4. 벌칙 조항
+    # 같은 법률의 law_article 중 article_title에 '벌칙', '과태료', '벌금', '양벌' 포함된 조문
+    
+    return "\n\n".join(parts)
+```
+
+### 주의사항
+- `from db.supabase_client import get_supabase` 필수
+- 컨텍스트 총량이 너무 크면 Claude API 토큰 초과 → 시행령은 관련 조문만, 별표는 목록만
+- 시행령이 DB에 없을 수 있음 → 없으면 빈 문자열 반환 (에러 아님)
+- async 함수로 작성
+
+---
+
+## TASK 2: routers/law_rule_generator.py 보강
+
+⚠️ 이 파일은 34KB (900줄+). 반드시 Cursor에서 작업.
+
+### 2-1: 시스템 프롬프트 보강
+
+현재 `SYSTEM_PROMPT`의 condition_code 12개 → 24개로 확장.
+추가할 코드:
+```
+- employee_count: 상시근로자 수 (명)
+- is_factory_registered: 공장등록 여부 (0/1)
+- contract_amount: 공사금액 (원)
+- has_chemical_substance: 화학물질 취급 여부 (0/1)
+- annual_energy_toe: 연간 에너지 사용량 (TOE)
+- electric_capacity: 전기 수전용량 kW (electrical_capacity_kw와 동일 의미, 둘 다 유지)
+- boiler_capacity_kw: 보일러 용량 (kW)
+- is_multi_use: 다중이용업소 여부 (0/1)
+- contractor_count: 수급업체 수
+- has_high_pressure_gas: 고압가스 취급 여부 (0/1)
+- transformer_capacity_kva: 변압기 용량 (kVA)
+- has_boiler: 보일러 보유 여부 (0/1)
+```
+
+### 2-2: AI 출력 스키마 확장
+
+현재 `USER_PROMPT_TEMPLATE`의 JSON 출력 필드 13개 → 30개+.
+추가 필드:
+```json
+{
+  "penalty_value": "과태료 숫자 (만원 단위) 또는 null",
+  "form_code": "별지서식 번호 (예: NFA-별지제5호) 또는 null",
+  "form_name": "서식명 또는 null",
+  "submit_org_code": "kosha|local_gov|moel|me|kgs|mlit|nfa|kesco 중 선택 또는 null",
+  "due_days": "기한 일수 (숫자) 또는 null",
+  "report_method_code": "online|offline|both 또는 null",
+  "report_method_std": "api|paper|keep 또는 null",
+  "appointment_qualification_code": "자격 코드 또는 null",
+  "appointment_qualification_level_code": "자격 등급 또는 null",  
+  "appointment_count_value": "선임 인원수 (숫자) 또는 null",
+  "inspection_cycle_value": "점검 주기 숫자 또는 null",
+  "inspection_cycle_unit_code": "day|week|month|quarter|half_year|year 또는 null",
+  "cycle_base_guide": "주기 설명 (최대 50자) 또는 null",
+  "online_system": "온라인 시스템명 또는 null",
+  "system_url": "시스템 URL 또는 null",
+  "tai_feature_code": "APPOINTMENT|INSPECTION|REPORT|EDUCATION|DOCUMENT|FIX|CHECKLIST 또는 null",
+  "remarks": "맥락 설명 (최대 100자)"
+}
+```
+
+### 2-3: few-shot 예시 추가
+
+SYSTEM_PROMPT 또는 USER_PROMPT에 잘 채워진 룰 예시 포함:
+```json
+[예시]
+{
+  "draft_rule_id": "FIREACT-001-BLD",
+  "obligation_type": "APPOINT",
+  "sector": "BUILDING",
+  "condition_code": "building_area",
+  "condition_operator": "gte",
+  "condition_value": "400",
+  "obligation_summary": "소방안전관리자 선임 의무",
+  "penalty_summary": "미선임 시 300만원 이하 과태료 (제53조)",
+  "penalty_value": 300,
+  "form_code": "NFA-별지제5호",
+  "form_name": "소방안전관리자 선임신고서",
+  "submit_org_code": "nfa",
+  "due_days": 14,
+  "report_method_code": "online",
+  "appointment_target": "소방안전관리자",
+  "appointment_qualification_code": "fire_safety_1",
+  "appointment_qualification_level_code": "grade1",
+  "appointment_count_value": 1,
+  "inspection_cycle_value": 6,
+  "inspection_cycle_unit_code": "month",
+  "cycle_base_guide": "최초 선임일로부터 6개월마다",
+  "tai_feature_code": "APPOINTMENT",
+  "remarks": "연면적 400㎡ 이상 특정소방대상물",
+  "diagnosis_stage": 1,
+  "ai_confidence": 95,
+  "ai_reasoning": "화재예방법 제24조 + 시행령 제22조 별표4 기준"
+}
+```
+
+### 2-4: submit_org_code 매핑 상수 추가
+
+```python
+SUBMIT_ORG_LABELS = {
+    "kosha": "한국산업안전보건공단 (관할 지역본부)",
+    "local_gov": "관할 시·군·구청",
+    "moel": "관할 지방고용노동관서",
+    "me": "관할 지방환경관서",
+    "kgs": "한국가스안전공사 (관할 지사)",
+    "mlit": "관할 지방국토관리청",
+    "nfa": "관할 소방서",
+    "kesco": "한국전기안전공사 (관할 지사)",
+}
+```
+
+### 2-5: POST /validate-master 엔드포인트 신규
+
+```python
+@router.post("/validate-master")
+async def validate_master(body: dict = None):
+    """
+    프로덕션 룰 전체 무결성 점검.
+    입력: { sector: "ALL" 또는 "BUILDING" 등, fix_auto: false }
+    출력: 검증 리포트 JSON
+    """
+    # 검증 규칙:
+    # 1. condition_code가 있으면 condition_operator_code + condition_value도 있어야 함
+    # 2. condition_code ∈ 24개 마스터 목록
+    # 3. inspection_required=true → inspection_cycle_value + inspection_cycle_unit_code 존재
+    # 4. report_required=true → report_method_code 존재 (현재 0%)
+    # 5. appointment_required=true → appointment_qualification_code 존재
+    # 6. penalty_required=true → penalty_value 존재
+    # 7. rule_id 중복 없음
+    # 8. obligation_summary NOT NULL 및 비어있지 않음
+    #
+    # 출력 형태:
+    # { total: 1133, passed: 800, failed: 333, 
+    #   failures: { "condition_incomplete": 215, "missing_report_method": 142, ... } }
+```
+
+### 2-6: POST /reparse-master 엔드포인트 신규
+
+```python
+CLAUDE_SONNET_MODEL = "claude-sonnet-4-20250514"
+
+@router.post("/reparse-master")
+async def reparse_master(body: dict):
+    """
+    기존 master 룰의 빈칸을 법령 원문 재수집(DB) + AI 재파싱으로 채움.
+    
+    입력: { 
+      sector: "BUILDING", 
+      limit: 50, 
+      fill_empty_only: true,
+      secret: "tai-internal-2026"
+    }
+    
+    동작:
+    1. master에서 빈칸 많은 룰 조회 (빈칸 수 기준 정렬)
+    2. 각 룰의 law_name + law_article로 build_full_context() 호출
+    3. Claude Sonnet에게 기존 룰 JSON + 풀 컨텍스트 제공
+       프롬프트: "아래 룰의 빈 필드(null)를 법령 원문을 참고하여 채워주세요. 채울 수 없는 필드는 null 유지."
+    4. 응답에서 null이 아닌 새 값만 UPDATE
+    5. 무결성 검증 실행 (validate 로직 재사용)
+    6. 결과 리포트 반환
+    """
+    # 빈칸 많은 룰 조회 SQL 예시:
+    # SELECT * FROM master_building_legal_rules
+    # WHERE is_active = true AND sector = :sector
+    #   AND (penalty_summary IS NULL 
+    #        OR report_method_code IS NULL 
+    #        OR appointment_qualification_code IS NULL
+    #        OR form_name IS NULL)
+    # LIMIT :limit
+    
+    # Sonnet 호출 시 few-shot 예시도 포함
+    # 같은 법령의 잘 채워진 룰 3~5개를 DB에서 조회하여 제공
+```
+
+### 2-7: _auto_approve_to_master 함수 보강
+
+기존: 13개 필드만 master에 INSERT.
+보강: 30개+ 필드 INSERT. draft에 새 필드가 있으면 함께 등록.
+
+`law_rule_drafts` 테이블에 새 필드 컬럼이 없을 수 있음.
+→ draft에 없는 필드는 reparse-master에서 별도로 채움. 충돌 없음.
+
+---
+
+## TASK 3: DB 마이그레이션 (Supabase MCP 또는 터미널)
+
+```sql
+ALTER TABLE master_building_legal_rules
+  ADD COLUMN IF NOT EXISTS tai_feature_code VARCHAR(50);
+
+COMMENT ON COLUMN master_building_legal_rules.tai_feature_code IS 
+  'TAI 기능 연결: APPOINTMENT/INSPECTION/REPORT/EDUCATION/DOCUMENT/FIX/CHECKLIST';
+```
+
+---
+
+## 테스트 케이스
+
+### 테스트 1: validate-master
+```bash
+curl -X POST https://api.taieng.co.kr/law-rule-generator/validate-master \
+  -H 'Content-Type: application/json' \
+  -d '{"sector": "ALL"}'
+```
+기대: total=1133, failed > 0, failures 항목별 건수
+
+### 테스트 2: reparse-master (깨진 condition)
+```bash
+curl -X POST https://api.taieng.co.kr/law-rule-generator/reparse-master \
+  -H 'Content-Type: application/json' \
+  -d '{"sector": "MANUFACTURING", "limit": 3, "fill_empty_only": true, "secret": "tai-internal-2026"}'
+```
+기대: FIREACT-005-MFG의 condition_operator_code, condition_value 채워짐
+
+### 테스트 3: reparse-master (빈 qualification)
+```bash
+# ENERGYACT-002 rule_id로 단건 테스트
+curl -X POST https://api.taieng.co.kr/law-rule-generator/reparse-master \
+  -H 'Content-Type: application/json' \
+  -d '{"rule_ids": ["ENERGYACT-002"], "secret": "tai-internal-2026"}'
+```
+기대: appointment_qualification_code 채워짐
+
+---
+
+## 개발 규칙
+- `from db.supabase_client import get_supabase`
+- /health 절대 503 금지 (200 고정)
+- dev 브랜치에서 작업 → PR → main
+- ANTHROPIC_API_KEY 환경변수 필요
+- Haiku: claude-haiku-4-5-20251001 (기존 파싱)
+- Sonnet: claude-sonnet-4-20250514 (reparse)
+- FastAPI route 순서: 구체 경로 먼저 (/drafts/stats → /drafts/{id})

--- a/docs/law-data-pipeline-methodology.md
+++ b/docs/law-data-pipeline-methodology.md
@@ -1,0 +1,22 @@
+# TAI Safe 법령 데이터 파이프라인 방법론
+
+이슈 #24 참조. 상세 문서: /mnt/user-data/outputs/law_data_pipeline_methodology.md
+
+## 핵심 결론
+수동 GPT 37회 투입이 아닌 **법제처 Open API + Claude API 자동 파이프라인** 구축.
+
+## 흐름
+```
+법제처 API → 법령 전문 수집 → Claude API 파싱 → 구조화 검증 → DB INSERT
+```
+
+## 예상
+- 소요: 2~3일
+- 비용: ~$5
+- 결과: 1,133건 → 3,000건+
+- 지속성: 법령 개정 시 자동 재수집·재파싱 가능
+
+## 필요 스크립트
+- scripts/law_collector.py (법제처 API → staging)
+- scripts/law_parser.py (Claude API → 의무 추출)
+- scripts/law_inserter.py (staging → master_building_legal_rules)

--- a/docs/law-engine-enhancement-workorder.md
+++ b/docs/law-engine-enhancement-workorder.md
@@ -1,0 +1,284 @@
+# 법령 수집엔진 보강 작업지시서 v2
+
+이슈 #24 · 2026-04-20 기획창 세션 4일차
+
+## 1. 문제 재정의 (소비자 관점 역추적)
+
+### 원래 이슈 프레이밍 (잘못됨)
+- "커버리지 1,133 → 3,000건 확장"
+- "7개 컬럼 신규 추가"
+
+### 실제 문제
+소비자가 법령진단·SaaS·매칭에서 받는 결과물의 **품질과 무결성** 부족.
+원인은 기존 파싱 엔진이 82개 컬럼 중 13개만 채우고 프로덕션에 올린 것.
+
+### 소비자 전달 품질 (활성 1,133건 기준)
+| 소비자 질문 | DB 필드 | 채움률 | 등급 |
+|---|---|---|---|
+| 무엇을 해야 하는가 | obligation_summary | 100% | ✅ |
+| 왜 해야 하는가 | remarks | 99% | ✅ |
+| 어디에 제출 | submit_org_code | 100% (코드만) | ⚠️ |
+| 기한이 언제 | due_days | 69% | ⚠️ |
+| 주기가 어떻게 | cycle_base_guide | 31% | ❌ |
+| 과태료가 얼마 | penalty_summary | 27% | ❌ |
+| 어떤 서류 필요 | form_name/url | 17% | ❌ |
+| 누가 할 수 있는지 | qualification_code | 3% | ❌ |
+| 신고 방법 | report_method_code | 0% (142건 전부 공백) | ❌ |
+
+### 판정 로직 무결성
+| 문제 | 건수 |
+|---|---|
+| condition 깨진 룰 (code는 있는데 operator 없음) | 215건 |
+| needs_review=true인데 active=true | 15건 |
+| inactive + needs_review (미검증 방치) | 923건 |
+
+---
+
+## 2. 기존 인프라 (이미 구현됨)
+
+### 법령 원문 — 수집 완료, 재수집 불필요
+| 테이블 | 데이터 |
+|---|---|
+| law_master | 473개 법령 |
+| law_article | 33,845개 조문 |
+| law_paragraph | 54,925개 항 |
+| law_item | 37,083개 호·목 |
+| law_attachment | 5,567개 별표/서식 |
+| law_collection_target | 82개 수집 대상 |
+
+### AI 파싱 엔진 — 이미 존재
+`routers/law_rule_generator.py` (34KB)
+- Claude Haiku 4.5 기반
+- POST /parse, /parse-batch, /auto-parse-and-approve
+- law_rule_drafts (2,152건 초안) → master 등록 워크플로우
+- condition_code 12개 시스템 프롬프트에 포함
+
+### 추가 파서
+`scripts/law_rule_parser.py` — 키워드 기반 정규식 파서 (AI 미사용)
+`scripts/law_collector.py` — 법제처 API + GPT-4o 변환 (일회성 스크립트)
+
+---
+
+## 3. 보강 방향: 새로 만들지 않음, 기존 엔진 강화
+
+### 핵심 변경 3가지
+
+#### 변경 1: AI 입력 컨텍스트 확장
+현재: 조문 텍스트 1개 (3,000자 제한)
+목표: 법률 본조 + 시행령 관련 조문 + 별표 + 벌칙 조항 풀세트
+
+```python
+# 현재
+user_prompt = USER_PROMPT_TEMPLATE.format(
+    law_name=law_name, article_text=article_text[:3000])
+
+# 목표
+context = build_full_context(
+    law_name=law_name,
+    article_id=article_id,  # 본조
+    include_enforcement_decree=True,  # 시행령 관련 조문
+    include_appendix=True,  # 별표
+    include_penalty_articles=True,  # 벌칙 조항
+)
+user_prompt = ENHANCED_PROMPT.format(context=context)
+```
+
+DB에서 가져오는 방법:
+1. `law_article` 본조 → `law_paragraph` + `law_item` 포함
+2. 같은 법령의 벌칙 조항 → `law_article` WHERE article_title LIKE '%벌칙%' OR '%과태료%'
+3. 시행령 관련 조문 → `law_master`에서 시행령 찾기 → `law_article` 매핑
+4. 별표 → `law_attachment` WHERE law_version_id 매칭
+
+#### 변경 2: AI 출력 스키마 확장
+현재 13개 필드 → 목표 30개+ 필드
+
+추가 추출 대상:
+```json
+{
+  "condition_code": "24개 마스터에서 선택",
+  "condition_operator_code": "gte|lte|eq",
+  "condition_value": "숫자",
+  "penalty_summary": "과태료 금액 + 조문",
+  "penalty_value": "숫자 (만원 단위)",
+  "form_code": "별지서식 번호",
+  "form_name": "서식명",
+  "submit_org_code": "제출처 코드",
+  "due_days": "기한 일수",
+  "report_method_code": "신고방법 코드",
+  "report_method_std": "온라인/오프라인/겸용",
+  "appointment_qualification_code": "자격 코드",
+  "appointment_qualification_level_code": "자격 등급",
+  "appointment_count_value": "선임 인원수",
+  "inspection_cycle_value": "점검 주기 숫자",
+  "inspection_cycle_unit_code": "주기 단위",
+  "cycle_base_guide": "주기 설명",
+  "online_system": "온라인 시스템명",
+  "system_url": "시스템 URL",
+  "remarks": "맥락 설명",
+  "obligation_type": "APPOINT|INSPECT|NOTIFY|REPORT|ACTION",
+  "tai_feature_code": "APPOINTMENT|INSPECTION|REPORT|EDUCATION|DOCUMENT|FIX|CHECKLIST"
+}
+```
+
+#### 변경 3: condition_code 마스터 완전 제공
+현재 시스템 프롬프트: 12개
+실제 DB 사용 중: 24개
+
+추가해야 할 코드 (시스템 프롬프트):
+```
+- employee_count: 상시근로자 수 (명) — 259건 사용 중
+- is_factory_registered: 공장등록 여부 (0/1) — 123건
+- contract_amount: 공사금액 (원) — 16건
+- has_chemical_substance: 화학물질 취급 여부 (0/1) — 21건
+- annual_energy_toe: 연간 에너지 사용량 (TOE) — 17건
+- electric_capacity: 전기 수전용량 kW (중복?) — 11건
+- boiler_capacity_kw: 보일러 용량 (kW) — 11건
+- is_multi_use: 다중이용업소 여부 (0/1) — 10건
+- contractor_count: 수급업체 수 — 5건
+- has_high_pressure_gas: 고압가스 취급 여부 (0/1) — 4건
+- transformer_capacity_kva: 변압기 용량 (kVA) — 4건
+- has_boiler: 보일러 보유 여부 (0/1) — 2건
+```
+
+---
+
+## 4. 신규 엔드포인트: reparse-master
+
+기존 엔진은 "신규 조문 → 초안 → master" 흐름만 있음.
+기존 master 룰의 빈칸을 채우는 역방향 흐름이 없음.
+
+### POST /law-rule-generator/reparse-master
+
+```
+입력: { sector: "BUILDING", limit: 50, fill_empty_only: true }
+
+동작:
+1. master에서 빈칸 많은 룰 조회 (fill_empty_only=true)
+2. 각 룰의 law_name + law_article로 원문 체인 조립
+   - law_article 본조
+   - 시행령 관련 조문 + 별표
+   - 벌칙 조항
+3. Claude Sonnet에게 기존 룰 + 풀 컨텍스트 제공
+   - "이 룰의 빈 필드를 채워주세요"
+   - few-shot: 같은 법령의 잘 채워진 룰 3~5개
+4. 응답으로 빈 필드 UPDATE
+5. 무결성 검증 실행
+6. 검증 통과 → 바로 반영
+   검증 실패 → needs_review=true + review_reason 기록
+```
+
+### POST /law-rule-generator/validate-master
+
+```
+입력: { sector: "ALL" }
+
+동작: 프로덕션 룰 전체 무결성 점검
+
+검증 규칙:
+✓ condition_code ∈ 24개 마스터
+✓ condition 3종(code/operator/value) 세트 완전성
+✓ inspection_required=true → cycle 값 존재
+✓ report_required=true → report_method 존재
+✓ appointment_required=true → qualification 존재
+✓ penalty_required=true → penalty_value 존재
+✓ rule_id 중복 없음
+✓ law_name + law_article 조합 유효 (law_article 테이블에 존재)
+
+출력: 검증 리포트 (PASS/FAIL 건수, 실패 사유별 분류)
+```
+
+---
+
+## 5. 시스템 프롬프트 보강안
+
+### few-shot 예시 포함
+잘 채워진 룰 예시를 프롬프트에 포함하여 출력 품질 향상.
+
+```
+[예시 - 잘 채워진 룰]
+{
+  "rule_id": "FIREACT-001",
+  "law_name": "화재의 예방 및 안전관리에 관한 법률",
+  "law_article": "제24조",
+  "sector": "BUILDING",
+  "condition_code": "building_area",
+  "condition_operator_code": "gte",
+  "condition_value": 400,
+  "obligation_summary": "소방안전관리자 선임 의무",
+  "penalty_summary": "미선임 시 300만원 이하 과태료 (제53조)",
+  "penalty_value": 300,
+  "form_code": "NFA-별지제5호",
+  "form_name": "소방안전관리자 선임신고서",
+  "submit_org_code": "nfa",
+  "due_days": 14,
+  "report_method_code": "online",
+  "appointment_required": true,
+  "appointment_target_code": "fire_safety_manager",
+  "appointment_qualification_code": "fire_safety_1",
+  "inspection_cycle_value": 6,
+  "inspection_cycle_unit_code": "month",
+  "cycle_base_guide": "최초 선임일로부터 6개월마다",
+  "tai_feature_code": "APPOINTMENT",
+  "remarks": "연면적 400㎡ 이상 특정소방대상물 소방안전관리자 선임"
+}
+```
+
+---
+
+## 6. tai_feature_code 컬럼 추가 (유일한 DDL)
+
+```sql
+ALTER TABLE master_building_legal_rules 
+  ADD COLUMN IF NOT EXISTS tai_feature_code VARCHAR(50);
+
+COMMENT ON COLUMN master_building_legal_rules.tai_feature_code IS 
+  'TAI 기능 연결 코드: APPOINTMENT/INSPECTION/REPORT/EDUCATION/DOCUMENT/FIX/CHECKLIST';
+```
+
+---
+
+## 7. AI 모델 전략
+
+| 용도 | 모델 | 이유 |
+|---|---|---|
+| 신규 조문 파싱 (기존) | Haiku 4.5 | 비용 효율, 대량 처리 |
+| 기존 룰 reparse (빈칸 채움) | Sonnet | 복잡한 크로스레퍼런스 (시행령+별표) |
+| 자동승인 판단 | 코드 로직 | AI 불필요, 무결성 검증 규칙 |
+
+---
+
+## 8. 실행 순서
+
+### Phase 1: 무결성 확보 (기존 데이터)
+1. validate-master 엔드포인트 구현 → 전체 검증 리포트
+2. 215건 깨진 condition 식별 → reparse-master로 자동 수정
+3. 923건 미검증 룰 → reparse → 검증 통과시 활성화
+
+### Phase 2: 소비자 품질 보강 (기존 데이터)
+4. 시스템 프롬프트 보강 (24개 코드 + few-shot + 출력 스키마)
+5. reparse-master로 1,133건 빈칸 채움 (Sonnet)
+6. tai_feature_code 컬럼 추가 + 자동 매핑
+
+### Phase 3: 신규 확장
+7. 기존 parse-batch 프롬프트도 동일하게 보강
+8. 미파싱 조문 대상 일괄 재처리
+
+---
+
+## 9. Cursor 작업지시 요약
+
+### 파일 수정
+- `routers/law_rule_generator.py` — 시스템 프롬프트 보강 + reparse/validate 엔드포인트 추가
+- 200줄+ 파일이므로 반드시 Cursor 사용
+
+### 신규 파일
+- `services/law_context_builder.py` — 법령 원문 체인 조립 서비스
+  (law_article + law_paragraph + 시행령 + 별표 + 벌칙 조항 → 하나의 컨텍스트)
+
+### DB
+- ALTER TABLE: tai_feature_code 1개 컬럼 추가
+
+### 테스트
+- FIREACT-005-MFG (깨진 condition) → reparse → 수정 확인
+- ENERGYACT-002 (빈 qualification) → reparse → 채움 확인  
+- ODORACTS-001-MFG (빈 report_method) → reparse → 채움 확인

--- a/docs/law-engine-enhancement-workorder.md
+++ b/docs/law-engine-enhancement-workorder.md
@@ -1,4 +1,4 @@
-# 법령 수집엔진 보강 작업지시서 v2
+# 법령 수집엔진 보강 작업지시서 v2.1
 
 이슈 #24 · 2026-04-20 기획창 세션 4일차
 
@@ -12,18 +12,15 @@
 소비자가 법령진단·SaaS·매칭에서 받는 결과물의 **품질과 무결성** 부족.
 원인은 기존 파싱 엔진이 82개 컬럼 중 13개만 채우고 프로덕션에 올린 것.
 
-### 소비자 전달 품질 (활성 1,133건 기준)
-| 소비자 질문 | DB 필드 | 채움률 | 등급 |
-|---|---|---|---|
-| 무엇을 해야 하는가 | obligation_summary | 100% | ✅ |
-| 왜 해야 하는가 | remarks | 99% | ✅ |
-| 어디에 제출 | submit_org_code | 100% (코드만) | ⚠️ |
-| 기한이 언제 | due_days | 69% | ⚠️ |
-| 주기가 어떻게 | cycle_base_guide | 31% | ❌ |
-| 과태료가 얼마 | penalty_summary | 27% | ❌ |
-| 어떤 서류 필요 | form_name/url | 17% | ❌ |
-| 누가 할 수 있는지 | qualification_code | 3% | ❌ |
-| 신고 방법 | report_method_code | 0% (142건 전부 공백) | ❌ |
+### 소비자 전달 품질: 6하원칙 기준 (활성 1,133건)
+| 6하원칙 | 소비자 질문 | DB 필드 | 채움률 | 등급 |
+|---|---|---|---|---|
+| **무엇을** (WHAT) | 뭘 해야 하나 | obligation_summary | 100% | ✅ |
+| **왜** (WHY) | 안 하면 어떻게 되나 | penalty_summary | 27% | ❌ |
+| **누가** (WHO) | 누가 할 수 있나 | qualification_code | 3% | ❌ |
+| **언제** (WHEN) | 기한·주기가 언제 | due_days, cycle_base_guide | 31~69% | ⚠️ |
+| **어디서** (WHERE) | 어디에 제출하나 | submit_org_code | 100% 코드만 | ⚠️ |
+| **어떻게** (HOW) | 어떤 서류로, 어떤 방법 | form_name, report_method | 0~17% | ❌ |
 
 ### 판정 로직 무결성
 | 문제 | 건수 |
@@ -53,35 +50,13 @@
 - law_rule_drafts (2,152건 초안) → master 등록 워크플로우
 - condition_code 12개 시스템 프롬프트에 포함
 
-### 추가 파서
-`scripts/law_rule_parser.py` — 키워드 기반 정규식 파서 (AI 미사용)
-`scripts/law_collector.py` — 법제처 API + GPT-4o 변환 (일회성 스크립트)
-
 ---
 
-## 3. 보강 방향: 새로 만들지 않음, 기존 엔진 강화
+## 3. 보강: 기존 엔진 강화
 
-### 핵심 변경 3가지
-
-#### 변경 1: AI 입력 컨텍스트 확장
+### 변경 1: AI 입력 컨텍스트 확장
 현재: 조문 텍스트 1개 (3,000자 제한)
 목표: 법률 본조 + 시행령 관련 조문 + 별표 + 벌칙 조항 풀세트
-
-```python
-# 현재
-user_prompt = USER_PROMPT_TEMPLATE.format(
-    law_name=law_name, article_text=article_text[:3000])
-
-# 목표
-context = build_full_context(
-    law_name=law_name,
-    article_id=article_id,  # 본조
-    include_enforcement_decree=True,  # 시행령 관련 조문
-    include_appendix=True,  # 별표
-    include_penalty_articles=True,  # 벌칙 조항
-)
-user_prompt = ENHANCED_PROMPT.format(context=context)
-```
 
 DB에서 가져오는 방법:
 1. `law_article` 본조 → `law_paragraph` + `law_item` 포함
@@ -89,113 +64,71 @@ DB에서 가져오는 방법:
 3. 시행령 관련 조문 → `law_master`에서 시행령 찾기 → `law_article` 매핑
 4. 별표 → `law_attachment` WHERE law_version_id 매칭
 
-#### 변경 2: AI 출력 스키마 확장
+### 변경 2: AI 출력 스키마 확장 (6하원칙 완전 커버)
 현재 13개 필드 → 목표 30개+ 필드
 
-추가 추출 대상:
-```json
-{
-  "condition_code": "24개 마스터에서 선택",
-  "condition_operator_code": "gte|lte|eq",
-  "condition_value": "숫자",
-  "penalty_summary": "과태료 금액 + 조문",
-  "penalty_value": "숫자 (만원 단위)",
-  "form_code": "별지서식 번호",
-  "form_name": "서식명",
-  "submit_org_code": "제출처 코드",
-  "due_days": "기한 일수",
-  "report_method_code": "신고방법 코드",
-  "report_method_std": "온라인/오프라인/겸용",
-  "appointment_qualification_code": "자격 코드",
-  "appointment_qualification_level_code": "자격 등급",
-  "appointment_count_value": "선임 인원수",
-  "inspection_cycle_value": "점검 주기 숫자",
-  "inspection_cycle_unit_code": "주기 단위",
-  "cycle_base_guide": "주기 설명",
-  "online_system": "온라인 시스템명",
-  "system_url": "시스템 URL",
-  "remarks": "맥락 설명",
-  "obligation_type": "APPOINT|INSPECT|NOTIFY|REPORT|ACTION",
-  "tai_feature_code": "APPOINTMENT|INSPECTION|REPORT|EDUCATION|DOCUMENT|FIX|CHECKLIST"
-}
+| 6하원칙 | 추출 필드 |
+|---|---|
+| WHAT | obligation_summary, obligation_type, remarks |
+| WHY | penalty_summary, penalty_value |
+| WHO | appointment_qualification_code, appointment_qualification_level_code, appointment_count_value |
+| WHEN | due_days, inspection_cycle_value, inspection_cycle_unit_code, cycle_base_guide |
+| WHERE | submit_org_code (8개 코드 → 한글 라벨 자동 매핑) |
+| HOW | form_code, form_name, report_method_code, report_method_std, online_system, system_url |
+| TAI연결 | tai_feature_code |
+
+### 변경 3: condition_code 마스터 완전 제공
+현재 시스템 프롬프트: 12개 → 실제 DB 사용: 24개
+
+추가 12개:
+```
+employee_count, is_factory_registered, contract_amount,
+has_chemical_substance, annual_energy_toe, electric_capacity,
+boiler_capacity_kw, is_multi_use, contractor_count,
+has_high_pressure_gas, transformer_capacity_kva, has_boiler
 ```
 
-#### 변경 3: condition_code 마스터 완전 제공
-현재 시스템 프롬프트: 12개
-실제 DB 사용 중: 24개
+### 변경 4: submit_org_code 한글 매핑 (WHERE 해결)
 
-추가해야 할 코드 (시스템 프롬프트):
-```
-- employee_count: 상시근로자 수 (명) — 259건 사용 중
-- is_factory_registered: 공장등록 여부 (0/1) — 123건
-- contract_amount: 공사금액 (원) — 16건
-- has_chemical_substance: 화학물질 취급 여부 (0/1) — 21건
-- annual_energy_toe: 연간 에너지 사용량 (TOE) — 17건
-- electric_capacity: 전기 수전용량 kW (중복?) — 11건
-- boiler_capacity_kw: 보일러 용량 (kW) — 11건
-- is_multi_use: 다중이용업소 여부 (0/1) — 10건
-- contractor_count: 수급업체 수 — 5건
-- has_high_pressure_gas: 고압가스 취급 여부 (0/1) — 4건
-- transformer_capacity_kva: 변압기 용량 (kVA) — 4건
-- has_boiler: 보일러 보유 여부 (0/1) — 2건
-```
+| 코드 | 한글명 | 소비자 안내 | 사용건수 |
+|---|---|---|---|
+| kosha | 한국산업안전보건공단 | 안전보건공단 관할 지역본부 | 305 |
+| local_gov | 지방자치단체 | 관할 시·군·구청 | 286 |
+| moel | 고용노동부 | 관할 지방고용노동관서 | 140 |
+| me | 환경부 | 관할 지방환경관서 | 105 |
+| kgs | 한국가스안전공사 | 가스안전공사 관할 지사 | 95 |
+| mlit | 국토교통부 | 관할 지방국토관리청 | 92 |
+| nfa | 소방청 | 관할 소방서 | 74 |
+| kesco | 한국전기안전공사 | 전기안전공사 관할 지사 | 36 |
+
+구현: `submit_org_code` → 프론트/PDF에서 한글 라벨 표시.
+별도 테이블 불필요 — 8개이므로 프론트 상수 또는 법령엔진 응답 시 변환.
 
 ---
 
-## 4. 신규 엔드포인트: reparse-master
-
-기존 엔진은 "신규 조문 → 초안 → master" 흐름만 있음.
-기존 master 룰의 빈칸을 채우는 역방향 흐름이 없음.
+## 4. 신규 엔드포인트
 
 ### POST /law-rule-generator/reparse-master
-
-```
-입력: { sector: "BUILDING", limit: 50, fill_empty_only: true }
-
-동작:
-1. master에서 빈칸 많은 룰 조회 (fill_empty_only=true)
-2. 각 룰의 law_name + law_article로 원문 체인 조립
-   - law_article 본조
-   - 시행령 관련 조문 + 별표
-   - 벌칙 조항
-3. Claude Sonnet에게 기존 룰 + 풀 컨텍스트 제공
-   - "이 룰의 빈 필드를 채워주세요"
-   - few-shot: 같은 법령의 잘 채워진 룰 3~5개
-4. 응답으로 빈 필드 UPDATE
-5. 무결성 검증 실행
-6. 검증 통과 → 바로 반영
-   검증 실패 → needs_review=true + review_reason 기록
-```
+기존 master 룰의 빈칸을 법령 원문 재수집(DB에서) → AI 재파싱으로 채움.
 
 ### POST /law-rule-generator/validate-master
-
-```
-입력: { sector: "ALL" }
-
-동작: 프로덕션 룰 전체 무결성 점검
+프로덕션 룰 전체 무결성 점검 + 리포트 출력.
 
 검증 규칙:
-✓ condition_code ∈ 24개 마스터
-✓ condition 3종(code/operator/value) 세트 완전성
-✓ inspection_required=true → cycle 값 존재
-✓ report_required=true → report_method 존재
-✓ appointment_required=true → qualification 존재
-✓ penalty_required=true → penalty_value 존재
-✓ rule_id 중복 없음
-✓ law_name + law_article 조합 유효 (law_article 테이블에 존재)
-
-출력: 검증 리포트 (PASS/FAIL 건수, 실패 사유별 분류)
-```
+- condition 3종 세트 완전성
+- condition_code ∈ 24개 마스터
+- inspection_required=true → cycle 값 존재
+- report_required=true → report_method 존재
+- appointment_required=true → qualification 존재
+- penalty_required=true → penalty_value 존재
+- rule_id 중복 없음
 
 ---
 
-## 5. 시스템 프롬프트 보강안
+## 5. 시스템 프롬프트 보강: few-shot + 6하원칙
 
-### few-shot 예시 포함
-잘 채워진 룰 예시를 프롬프트에 포함하여 출력 품질 향상.
-
-```
-[예시 - 잘 채워진 룰]
+잘 채워진 룰 예시를 프롬프트에 포함:
+```json
 {
   "rule_id": "FIREACT-001",
   "law_name": "화재의 예방 및 안전관리에 관한 법률",
@@ -225,14 +158,11 @@ DB에서 가져오는 방법:
 
 ---
 
-## 6. tai_feature_code 컬럼 추가 (유일한 DDL)
+## 6. DDL (유일)
 
 ```sql
-ALTER TABLE master_building_legal_rules 
+ALTER TABLE master_building_legal_rules
   ADD COLUMN IF NOT EXISTS tai_feature_code VARCHAR(50);
-
-COMMENT ON COLUMN master_building_legal_rules.tai_feature_code IS 
-  'TAI 기능 연결 코드: APPOINTMENT/INSPECTION/REPORT/EDUCATION/DOCUMENT/FIX/CHECKLIST';
 ```
 
 ---
@@ -242,43 +172,58 @@ COMMENT ON COLUMN master_building_legal_rules.tai_feature_code IS
 | 용도 | 모델 | 이유 |
 |---|---|---|
 | 신규 조문 파싱 (기존) | Haiku 4.5 | 비용 효율, 대량 처리 |
-| 기존 룰 reparse (빈칸 채움) | Sonnet | 복잡한 크로스레퍼런스 (시행령+별표) |
-| 자동승인 판단 | 코드 로직 | AI 불필요, 무결성 검증 규칙 |
+| 기존 룰 reparse (빈칸 채움) | Sonnet | 복잡한 크로스레퍼런스 |
+| 자동승인/무결성 검증 | 코드 로직 | AI 불필요 |
 
 ---
 
 ## 8. 실행 순서
 
-### Phase 1: 무결성 확보 (기존 데이터)
-1. validate-master 엔드포인트 구현 → 전체 검증 리포트
-2. 215건 깨진 condition 식별 → reparse-master로 자동 수정
-3. 923건 미검증 룰 → reparse → 검증 통과시 활성화
+### Phase 1: 무결성 확보
+1. validate-master 구현 → 전체 검증 리포트
+2. 215건 깨진 condition → reparse로 자동 수정
+3. 923건 미검증 룰 → reparse 후 활성화 또는 폐기
 
-### Phase 2: 소비자 품질 보강 (기존 데이터)
-4. 시스템 프롬프트 보강 (24개 코드 + few-shot + 출력 스키마)
-5. reparse-master로 1,133건 빈칸 채움 (Sonnet)
+### Phase 2: 소비자 품질 (6하원칙 완성)
+4. 시스템 프롬프트 보강 (24개 코드 + few-shot + 30개 출력)
+5. reparse-master로 1,133건 빈칸 채움
 6. tai_feature_code 컬럼 추가 + 자동 매핑
+7. submit_org_code 한글 매핑 적용
 
 ### Phase 3: 신규 확장
-7. 기존 parse-batch 프롬프트도 동일하게 보강
-8. 미파싱 조문 대상 일괄 재처리
+8. parse-batch 프롬프트 동일 보강
+9. 미파싱 조문 일괄 재처리
 
 ---
 
-## 9. Cursor 작업지시 요약
+## 9. Cursor 작업지시
 
 ### 파일 수정
-- `routers/law_rule_generator.py` — 시스템 프롬프트 보강 + reparse/validate 엔드포인트 추가
-- 200줄+ 파일이므로 반드시 Cursor 사용
+- `routers/law_rule_generator.py` — 프롬프트 보강 + reparse/validate 엔드포인트
+- 200줄+ → Cursor 필수
 
 ### 신규 파일
-- `services/law_context_builder.py` — 법령 원문 체인 조립 서비스
-  (law_article + law_paragraph + 시행령 + 별표 + 벌칙 조항 → 하나의 컨텍스트)
+- `services/law_context_builder.py` — 법령 원문 체인 조립
 
 ### DB
-- ALTER TABLE: tai_feature_code 1개 컬럼 추가
+- ALTER TABLE: tai_feature_code 1개
 
-### 테스트
+### 테스트 케이스
 - FIREACT-005-MFG (깨진 condition) → reparse → 수정 확인
-- ENERGYACT-002 (빈 qualification) → reparse → 채움 확인  
+- ENERGYACT-002 (빈 qualification) → reparse → 채움 확인
 - ODORACTS-001-MFG (빈 report_method) → reparse → 채움 확인
+
+## 10. 완료 기준: 소비자 결과 6하원칙
+
+작업 완료 시 소비자가 받는 법령진단 결과 1건:
+```
+📋 소방안전관리자 선임 (화재의 예방 및 안전관리에 관한 법률 제24조)
+
+[무엇을] 연면적 400㎡ 이상 → 소방안전관리자 1명 이상 선임
+[왜]     미선임 시 300만원 이하 과태료
+[누가]   소방안전관리자 1급 이상 자격 보유자
+[언제]   선임 후 14일 이내 신고, 이후 6개월마다 점검
+[어디서] 관할 소방서
+[어떻게] 소방안전관리자 선임신고서 (별지 제5호서식) → 소방청 온라인 시스템
+[TAI]   선임연결 서비스에서 매칭 가능
+```

--- a/docs/law-pipeline-consumer-delivery.md
+++ b/docs/law-pipeline-consumer-delivery.md
@@ -1,0 +1,20 @@
+# 법령 파이프라인 소비자 전달 보강 기획
+
+이슈 #24 참조. 상세 문서: /mnt/user-data/outputs/law_pipeline_consumer_delivery.md
+
+## 핵심
+현재 파이프라인은 수집·저장까지만 됨. 소비자에게 "무엇을, 어떻게, 언제" 전달하는 구조 부재.
+
+## 보강: DB 7개 컬럼 추가
+- compliance_guide (이행 방법)
+- required_documents (필요 서류)
+- submit_to (제출처)
+- penalty_detail (과태료 상세)
+- qualification (자격요건)
+- deadline_description (기한)
+- tai_feature_code (TAI 기능 연결)
+
+## 실행: 3단계
+1. DB 스키마 + 파이프라인 프롬프트 보강 (1일)
+2. 기존 데이터 재파싱으로 새 컬럼 채우기 (1~2일)
+3. PDF/웹 결과 UI에 반영 (1일)

--- a/docs/law-pipeline-workorder.md
+++ b/docs/law-pipeline-workorder.md
@@ -1,0 +1,81 @@
+# 법령 파이프라인 보강 작업지시서
+
+이슈 #24 참조.
+
+## 문제
+1. 법령 데이터 커버리지 부족 (1,133건/3,000~5,000건)
+2. 소비자 전달 구조 부재 (무엇을/어떻게/언제 안내 못함)
+
+## 해결 2단계
+
+### Phase 1: 기존 파이프라인 실행으로 커버리지 확장
+
+파이프라인 이미 구현됨 (`scripts/` 디렉토리):
+- `law_collector.py` — 법제처 API 수집 + GPT JSON 변환
+- `law_rule_parser.py` — AI 의무 추출
+- `law_to_rules.py` — 변환
+- `law_db_insert.py` — DB INSERT
+- `README_law_collection.md` — 실행 가이드
+
+실행:
+```bash
+python scripts/law_collector.py --sector ALL
+python scripts/law_db_insert.py --all
+```
+
+### Phase 2: 소비자 전달 구조 보강
+
+#### DB 스키마 확장 (7개 컬럼 추가)
+```sql
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS compliance_guide TEXT;
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS required_documents TEXT;
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS submit_to TEXT;
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS penalty_detail TEXT;
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS qualification TEXT;
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS deadline_description TEXT;
+ALTER TABLE master_building_legal_rules ADD COLUMN IF NOT EXISTS tai_feature_code TEXT;
+```
+
+#### 각 컬럼 용도
+| 컬럼 | 용도 | 예시 |
+|------|------|------|
+| compliance_guide | 이행 방법 (HOW) | "자격 보유자 선임 후 14일 내 관할 노동관서에 신고" |
+| required_documents | 필요 서류 | "안전관리자 선임신고서 (별지 제5호서식)" |
+| submit_to | 제출처 (한글) | "관할 지방고용노동관서" |
+| penalty_detail | 과태료 상세 | "미선임 500만원 / 미신고 300만원" |
+| qualification | 자격요건 | "산업안전산업기사 이상" |
+| deadline_description | 기한 | "14일 이내", "매 반기", "작업 전" |
+| tai_feature_code | TAI 기능 연결 | APPOINTMENT/INSPECTION/REPORT/EDUCATION/DOCUMENT/FIX/CHECKLIST |
+
+#### 파이프라인 AI 프롬프트 보강
+`law_rule_parser.py`의 GPT 프롬프트에 위 7개 필드 추출 요청 추가.
+
+#### 기존 데이터 보강
+보강된 파이프라인으로 기존 1,133건 재파싱하여 새 컬럼 채우기.
+
+#### 소비자 전달 UI
+- 유료 PDF: 각 의무에 이행방법/서류/과태료/TAI연결 표시
+- 웹 결과: 동일 구조
+- 무료 결과: remarks만 (현재와 동일)
+
+## 소비자 전달 목표 형태
+```
+📋 안전관리자 선임 (산업안전보건법 제17조)
+
+무엇을: 상시근로자 50인 이상 → 안전관리자 1명 이상 선임
+이행방법: 자격 보유자 선임 → 14일 내 신고서 작성 → 노동관서 제출
+필요서류: 별지 제5호서식
+과태료: 미선임 500만원 / 미신고 300만원
+TAI: 선임연결 서비스에서 매칭 가능
+```
+
+## tai_feature_code 매핑
+| 코드 | TAI 기능 | 의무 유형 |
+|------|---------|----------|
+| APPOINTMENT | 선임연결 | APPOINT |
+| INSPECTION | 점검일정 관리 | INSPECT |
+| REPORT | 자동신고 대행 | REPORT |
+| EDUCATION | 교육사업 연결 | 교육 관련 |
+| DOCUMENT | 문서서식 생성 | DOCUMENT |
+| FIX | TAI Fix 수선연결 | 정비/수선 |
+| CHECKLIST | 작업자 점검 | ACTION/BEFORE_WORK |

--- a/docs/next-session-prompt-2026-04-20.md
+++ b/docs/next-session-prompt-2026-04-20.md
@@ -1,0 +1,76 @@
+# 다음 창 인계 프롬프트 — 2026-04-20
+
+## 역할
+백엔드 창 (tai-api 레포, Fly.io 배포)
+
+## 우선 확인 사항
+세션 시작 전 아래 문서 읽고 맥락 파악:
+- `docs/session-2026-04-19-infra.md` (어제 인프라 작업)
+- `docs/session-2026-04-19-backend.md` (어제 백엔드 작업)
+
+---
+
+## 즉시 처리 — 메세지미 SMS 복구 (#16)
+
+**원인:** Vultr 프록시 서버 삭제 → 502 Bad Gateway
+
+**Step 1: OUTBOUND_PROXY 제거 후 직접 발송 테스트 (무료)**
+```bash
+fly secrets unset OUTBOUND_PROXY -a tai-api-prod
+```
+이후 테스트:
+```
+https://api.taieng.co.kr/messaging/debug-send?receiver=01047758888&message=TAI+테스트
+```
+→ 성공하면 완료. 실패 시 Step 2.
+
+**Step 2: Fly.io 고정 IP 발급 ($2/월)**
+```bash
+fly ips allocate-v4 -a tai-api-prod
+# 발급된 IP를 메세지미 콘솔에서 허용 IP 등록
+```
+이후 `/messaging/debug` 확인 → 테스트 발송.
+
+---
+
+## PR #10 머지 대기 중
+
+**기안 PDF v2.0.0** (백엔드 완료, 프론트 템플릿 창 대기)
+- tai-api dev 브랜치 → main PR #10 오픈 상태
+- 프론트 창에서 `templates/proposal_pdf.html` v6 작업 완료 후 **동시 머지**
+- 단독 머지 금지 (Jinja2 UndefinedError 발생)
+
+**백엔드 `_build_context` 반환 스펙 (프론트 창 계약):**
+```
+penalty_sum_text  (max_penalty_text 대체)
+paid_tiers        {mode, tiers} or {mode, determined, upper, basis}
+```
+
+---
+
+## PENDING 이슈 목록
+
+| 이슈 | 내용 | 우선순위 |
+|---|---|---|
+| #16 | 메세지미 SMS 복구 | 🔴 즉시 |
+| #10 | PR 머지 (기안PDF v2.0.0) | 🟡 프론트 대기 |
+| #17 | taieng 레포 wrangler.toml 삭제 | 🟢 낮음 |
+| 미착수 | `POST /precedents/collect` 1회 수동 실행 | 🟡 |
+| 미착수 | weather.py 안전관리자 대시보드 위젯 연결 | 🟡 |
+| 미착수 | smoke_test.py Actions Secrets 등록 + 수동실행 | 🟡 |
+
+---
+
+## 개발 원칙 (반드시 준수)
+1. 모든 커밋 → `dev` 브랜치 (main 직접 커밋 금지)
+2. `/health` 절대 503 금지 (200 고정)
+3. 200줄+ 파일 MCP 수정 금지 → Cursor 사용
+4. `from db.supabase_client import get_supabase`
+5. dev → PR → main → 자동 배포 흐름
+
+## 인프라 현황
+- **백엔드 API:** Fly.io `tai-api-prod` (Tokyo)
+- **DB:** Supabase `xntdkrjhgcscmqctdzyo`
+- **프론트:** Cloudflare Pages (admin, safe, new, taieng)
+- **PDF:** Gotenberg on Railway (`http://gotenberg.railway.internal:3000`)
+- **메세지미 발신번호:** `070-8080-1858`

--- a/docs/session-handoff-20260420-v2.md
+++ b/docs/session-handoff-20260420-v2.md
@@ -1,0 +1,48 @@
+# 세션 핸드오프 — 2026-04-20 (2차)
+
+## 다음 세션 최우선: Railway 이전
+
+### 배경
+Fly.io의 cold start (45초+)와 Gotenberg cold start로 PDF 생성 실패가 반복.
+Railway 싱가포르 리전으로 전체 이전 결정.
+
+### Railway 이전 상태
+- [ ] Railway 프로젝트 생성 (taiengineering/tai-api 연결)
+- [ ] 싱가포르 리전 선택
+- [ ] 환경변수 설정 (Fly.io secrets → Railway Variables)
+- [ ] Gotenberg 서비스 추가 (Docker image: gotenberg/gotenberg:8)
+- [ ] 커스텀 도메인 api.taieng.co.kr 설정
+- [ ] Cloudflare DNS CNAME 변경
+- [ ] GitHub Actions fly-deploy.yml 비활성화
+- [ ] 테스트 (health, SMS, PDF)
+- [ ] Fly.io 서비스 삭제
+
+### Fly.io 현재 secrets (Railway에 복사 필요)
+```
+SUPABASE_URL
+SUPABASE_KEY
+RESEND_API_KEY
+MESSAGEME_API_KEY
+MESSAGEME_SENDER
+SENTRY_DSN
+OUTBOUND_PROXY=http://115.68.227.222:3128
+GOTENBERG_URL=(Railway 내부 URL로 변경)
+```
+
+### 이번 세션 완료 작업
+- 모니터링 STEP 1~4 전부 완료
+- SMS 정상화 (iwinv 프록시 115.68.227.222)
+- 유료 PDF Gotenberg 전환 (v2.0.0)
+- 법령엔진 remarks 필드 연결 (PR #22)
+- 이슈 8개 해결 (#3,#5,#15,#16,#17,#18,#19,#20)
+- dev ↔ main 브랜치 동기화
+- mail.py v2.1.0 배포
+
+### 오픈 이슈 없음 (전부 해결)
+
+### 인프라 현황
+- Backend: Fly.io 도쿄 → **Railway 싱가포르로 이전 중**
+- Proxy: iwinv VPS 115.68.227.222:3128 (한국 고정 IP)
+- DB: Supabase (xntdkrjhgcscmqctdzyo)
+- Frontend: Cloudflare Pages
+- 모니터링: Sentry + UptimeRobot + Smoke Test + pg_cron

--- a/docs/session-handoff-20260420-v3.md
+++ b/docs/session-handoff-20260420-v3.md
@@ -1,0 +1,60 @@
+# 세션 핸드오프 2026-04-20 v3 (기획창 3일차)
+
+## 이번 세션 완료 작업
+
+### 1. Railway 싱가포르 이전 (이슈 #23 Closed)
+- Railway 프로젝트: tai-api-prod + gotenberg (asia-southeast1)
+- 환경변수 28개 설정, 커스텀 도메인 api.taieng.co.kr
+- CDN: Fastly 인천(ICN) → 서버: 싱가포르
+- cold start 문제 근본 해결 (Railway 항상 켜짐)
+- fly-deploy.yml 비활성화
+
+### 2. 유료 PDF Gotenberg 전환 (PR#21)
+- diagnosis_report.py v2.0.0: xhtml2pdf → Gotenberg Chromium
+- 20페이지 PDF 정상 생성, 688KB, 4.9초
+
+### 3. 법령엔진 remarks 연결 (PR#22)
+- legal_engine.py + legal_engine_v510.py: remarks/obligation_summary 추가
+- diagnosis_report_paid.html: 5곳 적용
+
+### 4. remarks 데이터 보강
+- 자동 복사 (obligation_summary → remarks): 520건
+- ChatGPT 생성 + DB UPDATE: 219건
+- 최종: 1,126/1,133건 (99.4%)
+
+### 5. 법령 데이터 커버리지 문제 발견 (이슈 #24 Open)
+- DB: 1,133건 / 실제 필요: 3,000~5,000건 (약 30% 미달)
+- 기존 파이프라인 스크립트 (scripts/) 이미 구현되어 있음 확인
+- 소비자 전달 구조 부재 문제 식별
+- 파이프라인 보강 기획 완료
+
+### 6. Railway 최종 점검
+- Health: OK (DB, law_engine, fix_chat 전부 정상)
+- PDF 기안: 302 (Storage 캐시 리다이렉트)
+- PDF 유료: 200, 688KB, 4.9초 (Gotenberg 정상)
+- Railway 라우팅: 인천 CDN → 싱가포르 서버
+
+---
+
+## 미완료 / 다음 세션 작업
+
+### [최우선] 법령 파이프라인 보강 (이슈 #24)
+1. 기존 스크립트 실행 → 커버리지 확장
+2. DB 스키마 7개 컬럼 추가 (소비자 전달용)
+3. AI 프롬프트 보강 후 재파싱
+4. PDF/웹 UI에 반영
+
+### [PENDING] 기존 미완료
+- Fly.io 서비스 삭제 (fly apps destroy)
+- 나머지 remarks 7건 보강
+- 백엔드: weather.py, precedent_api.py, 산재판례수집크론
+- 프론트: nexas 페이지들, safe 대시보드 위젯
+
+---
+
+## 인프라 현황 (최종)
+- Backend: Railway 싱가포르 (main push → 자동배포)
+- PDF: Gotenberg Railway 내부통신 (4.9초)
+- DB: Supabase (xntdkrjhgcscmqctdzyo)
+- Frontend: Cloudflare Pages
+- 모니터링: Sentry + UptimeRobot

--- a/docs/session-handoff-20260420-v4.md
+++ b/docs/session-handoff-20260420-v4.md
@@ -1,50 +1,107 @@
-# 세션 핸드오프 2026-04-20 v4 (기획창 4일차)
+# 세션 핸드오프 2026-04-20 v4.1 (기획창 4일차 최종)
 
 ## 이번 세션 완료 작업
 
-### 법령엔진 심층 진단 (이슈 #24)
+### 법령엔진 심층 진단 + 수집엔진 보강 기획 (이슈 #24)
 
-소비자 결과물 관점에서 역추적하여 근본 원인 파악.
+소비자 결과물의 6하원칙 관점에서 역추적하여 근본 원인 파악 + 해결 설계.
 
 #### 발견 사항
 1. **DB 2,287건 중 프로덕션 1,133건** — 923건은 inactive+needs_review 방치
-2. **82개 컬럼 중 ~15개만 채워진 채 프로덕션** — 소비자 전달 품질 심각
+2. **82개 컬럼 중 ~15개만 채워진 채 프로덕션** — 6하원칙 중 4개 미달
 3. **기존 7개 컬럼 추가 불필요** — 이미 존재하는 컬럼이 비어있는 것이 문제
 4. **215건 판정 로직 깨짐** — condition_code는 있지만 operator 없음
-5. **report_method_code 0%** — 자동신고 대행 불가능 상태
+5. **report_method_code 0%** — 142건 전부 공백, 자동신고 대행 불가
 6. **qualification_code 3%** — 선임매칭 불가능 상태
+7. **submit_org_code 100% 있지만 코드만** — 한글 라벨 매핑 필요 (8개 코드)
 
-#### 기존 인프라 확인
-- **법령 원문 수집 완료**: 473개 법령, 33,845조문, 5,567별표/서식
+#### 소비자 6하원칙 기준 현재 품질
+| 6하원칙 | 채움률 | 등급 |
+|---|---|---|
+| 무엇을 (WHAT) | 100% | ✅ |
+| 왜 (WHY) | 27% | ❌ |
+| 누가 (WHO) | 3% | ❌ |
+| 언제 (WHEN) | 31~69% | ⚠️ |
+| 어디서 (WHERE) | 100% 코드만 | ⚠️ |
+| 어떻게 (HOW) | 0~17% | ❌ |
+
+#### 기존 인프라 확인 (새로 만들 필요 없음)
+- **법령 원문 수집 완료**: 473개 법령, 33,845조문, 54,925항, 37,083호·목, 5,567별표
 - **Haiku 파싱 엔진 존재**: `routers/law_rule_generator.py` (34KB)
 - **draft→master 워크플로우 존재**: law_rule_drafts 2,152건
-- **키워드 파서 존재**: `scripts/law_rule_parser.py`
+- **법령 DB 테이블 25개+, 컬럼 530개+**
 
 #### 근본 원인
-Haiku 엔진이 조문 텍스트 1개만 받고 13개 필드만 출력.
-시행령/별표/벌칙 미포함 → threshold/penalty/qualification 추출 불가.
+Haiku 엔진이 조문 텍스트 1개만(3,000자) 받고 13개 필드만 출력.
+시행령/별표/벌칙 미포함 → 6하원칙 중 WHY/WHO/HOW 추출 불가.
 
-#### 해결 방향 (작업지시서 v2)
-1. 새로 만들지 않음 — 기존 law_rule_generator.py 보강
-2. AI 입력 확장: 조문 1개 → 법률+시행령+별표+벌칙 풀세트 (DB에서 조립)
-3. AI 출력 확장: 13개 → 30개+ 필드
-4. condition_code 12개 → 24개 완전 제공
-5. reparse-master 엔드포인트 신규: 기존 룰 빈칸 채움
-6. validate-master 엔드포인트 신규: 무결성 자동 검증
-7. tai_feature_code 컬럼 1개만 DDL 추가
+#### 해결: 기존 law_rule_generator.py 보강 (작업지시서 v2.1)
+1. **AI 입력 확장**: 조문 1개 → 법률+시행령+별표+벌칙 풀세트 (DB에서 조립)
+2. **AI 출력 확장**: 13개 → 30개+ 필드 (6하원칙 완전 커버)
+3. **condition_code**: 12개 → 24개 완전 제공
+4. **reparse-master**: 기존 1,133건 빈칸 채움 (Sonnet)
+5. **validate-master**: 무결성 자동 검증
+6. **submit_org_code 한글 매핑**: 8개 코드 → 한글 라벨
+7. **tai_feature_code**: 유일한 신규 컬럼 (DDL 1개)
+8. **AI 모델**: Haiku(신규 파싱) + Sonnet(reparse 복잡 케이스)
+9. **few-shot 예시**: 잘 채워진 룰 예시를 프롬프트에 포함
 
 ---
 
-## 작업지시서 위치
-- `docs/law-engine-enhancement-workorder.md` (v2, 본 문서)
-- 이전 작업지시서 (`docs/law-pipeline-workorder.md`) → 대체됨
+## GitHub 산출물
 
-## 다음 세션 작업
-1. Cursor에서 `services/law_context_builder.py` 신규 작성
-2. Cursor에서 `routers/law_rule_generator.py` 보강
-3. Supabase MCP로 tai_feature_code ALTER TABLE
-4. validate-master 실행 → 무결성 리포트 확인
-5. reparse-master로 테스트 케이스 3건 실행
+### tai-api (dev)
+- `docs/law-engine-enhancement-workorder.md` — **작업지시서 v2.1 (기준 문서)**
+- `docs/session-handoff-20260420-v4.md` — 본 문서
+- 이전 문서 (대체됨): `docs/law-pipeline-workorder.md`, `docs/law-pipeline-consumer-delivery.md`
 
-## 이슈
-- #24 업데이트 완료 (v2 작업지시서 반영)
+### 이슈 #24
+- 제목: `[법령엔진] 수집엔진 보강 — 소비자 전달 품질 + 무결성 확보`
+- Phase 1~3 체크리스트 포함
+
+---
+
+## 다음 세션 작업 (Cursor/Claude Code)
+
+### Phase 1: 무결성 확보
+1. `services/law_context_builder.py` 신규 — 법령 원문 체인 조립 서비스
+2. `routers/law_rule_generator.py` 보강 — validate-master + reparse-master 엔드포인트
+3. Supabase: `ALTER TABLE tai_feature_code` 1개
+4. validate-master 실행 → 전체 무결성 리포트
+5. 테스트: FIREACT-005-MFG, ENERGYACT-002, ODORACTS-001-MFG reparse
+
+### Phase 2: 소비자 품질 (6하원칙)
+6. 시스템 프롬프트 보강 (24개 코드 + few-shot + 30개 출력 필드)
+7. reparse-master로 1,133건 빈칸 채움
+8. submit_org_code 한글 매핑 적용
+
+---
+
+## 다음 세션 프롬프트
+
+```
+이 창은 TAI Safe 구현 창입니다.
+
+이번 작업: 법령엔진 수집엔진 보강 (이슈 #24)
+
+기준 문서: docs/law-engine-enhancement-workorder.md (dev 브랜치, v2.1)
+세션 핸드오프: docs/session-handoff-20260420-v4.md
+
+작업 순서:
+1. 기준 문서 읽기
+2. services/law_context_builder.py 신규 작성
+   - law_article + law_paragraph + 시행령 + 별표 + 벌칙 조항 → 하나의 컨텍스트
+3. routers/law_rule_generator.py 보강
+   - 시스템 프롬프트: condition_code 24개 + few-shot + 출력 30개 필드
+   - POST /validate-master 엔드포인트
+   - POST /reparse-master 엔드포인트
+4. Supabase: ALTER TABLE tai_feature_code
+5. validate-master 실행 → 리포트 확인
+6. 테스트: FIREACT-005-MFG, ENERGYACT-002, ODORACTS-001-MFG reparse
+
+주의:
+- routers/law_rule_generator.py는 200줄+ → Cursor 사용
+- from db.supabase_client import get_supabase
+- AI 모델: Haiku(신규) + Sonnet(reparse)
+- ANTHROPIC_API_KEY 환경변수 필요
+```

--- a/docs/session-handoff-20260420-v4.md
+++ b/docs/session-handoff-20260420-v4.md
@@ -1,0 +1,50 @@
+# 세션 핸드오프 2026-04-20 v4 (기획창 4일차)
+
+## 이번 세션 완료 작업
+
+### 법령엔진 심층 진단 (이슈 #24)
+
+소비자 결과물 관점에서 역추적하여 근본 원인 파악.
+
+#### 발견 사항
+1. **DB 2,287건 중 프로덕션 1,133건** — 923건은 inactive+needs_review 방치
+2. **82개 컬럼 중 ~15개만 채워진 채 프로덕션** — 소비자 전달 품질 심각
+3. **기존 7개 컬럼 추가 불필요** — 이미 존재하는 컬럼이 비어있는 것이 문제
+4. **215건 판정 로직 깨짐** — condition_code는 있지만 operator 없음
+5. **report_method_code 0%** — 자동신고 대행 불가능 상태
+6. **qualification_code 3%** — 선임매칭 불가능 상태
+
+#### 기존 인프라 확인
+- **법령 원문 수집 완료**: 473개 법령, 33,845조문, 5,567별표/서식
+- **Haiku 파싱 엔진 존재**: `routers/law_rule_generator.py` (34KB)
+- **draft→master 워크플로우 존재**: law_rule_drafts 2,152건
+- **키워드 파서 존재**: `scripts/law_rule_parser.py`
+
+#### 근본 원인
+Haiku 엔진이 조문 텍스트 1개만 받고 13개 필드만 출력.
+시행령/별표/벌칙 미포함 → threshold/penalty/qualification 추출 불가.
+
+#### 해결 방향 (작업지시서 v2)
+1. 새로 만들지 않음 — 기존 law_rule_generator.py 보강
+2. AI 입력 확장: 조문 1개 → 법률+시행령+별표+벌칙 풀세트 (DB에서 조립)
+3. AI 출력 확장: 13개 → 30개+ 필드
+4. condition_code 12개 → 24개 완전 제공
+5. reparse-master 엔드포인트 신규: 기존 룰 빈칸 채움
+6. validate-master 엔드포인트 신규: 무결성 자동 검증
+7. tai_feature_code 컬럼 1개만 DDL 추가
+
+---
+
+## 작업지시서 위치
+- `docs/law-engine-enhancement-workorder.md` (v2, 본 문서)
+- 이전 작업지시서 (`docs/law-pipeline-workorder.md`) → 대체됨
+
+## 다음 세션 작업
+1. Cursor에서 `services/law_context_builder.py` 신규 작성
+2. Cursor에서 `routers/law_rule_generator.py` 보강
+3. Supabase MCP로 tai_feature_code ALTER TABLE
+4. validate-master 실행 → 무결성 리포트 확인
+5. reparse-master로 테스트 케이스 3건 실행
+
+## 이슈
+- #24 업데이트 완료 (v2 작업지시서 반영)

--- a/docs/session-handoff-20260420.md
+++ b/docs/session-handoff-20260420.md
@@ -1,0 +1,76 @@
+# TAI 세션 핸드오프 — 2026-04-20
+
+## 세션 요약
+PM/기획 세션 3일차. 모니터링 4단계 전부 완료, SMS 정상화, 이슈 정리.
+
+## 완료 작업 (이번 세션)
+
+### 1. Smoke Test 수정
+- S4(diagnosis) 제거 → S1~S3(3/3) 통과
+- SMS 알림: MessageMi 직접 호출 → TAI API `/messaging/debug-send` 경유로 변경
+- warm-up 로직 추가 (서버 깨우기 + 5초 대기)
+
+### 2. /health 테이블명 수정
+- `master_legal_inspection_rules`(0건) → `master_building_legal_rules`(1,133건)
+- Production 배포 완료, `{"status":"healthy"}` 확인
+
+### 3. 모니터링 STEP 4 (pg_cron)
+- pg_net 확장 활성화
+- `monitoring_config` 테이블 생성 (alert_phone: 01047758888)
+- `daily_health_check()` SQL 함수 생성
+- pg_cron 스케줄: 매일 KST 09:00 (UTC 00:00)
+- 점검 항목: fix_chat 이탈율 80% 초과 시 SMS
+
+### 4. mail.py v2.1.0 배포
+- dev 커밋 → admin MCP로 main 직접 push → production 배포
+- webhook_inbound: payload에서 html/text 직접 추출
+
+### 5. 메세지미 SMS 정상화 (#16)
+- Vultr 정책위반 삭제 → iwinv VPS (115.68.227.222) + Squid 프록시
+- Fly.io OUTBOUND_PROXY 설정 (prod + staging)
+- SMS 발송 테스트 성공 (code=100)
+
+### 6. dev ↔ main 브랜치 동기화 (#20)
+- `git reset --hard origin/main` + force push
+
+### 7. wrangler.toml 삭제 (#17)
+- taiengineering/taieng main에서 GitHub UI로 삭제
+
+### 8. diagnosis/free 성능 확인 (#18)
+- 실제 엔드포인트: `/diagnosis/run` (not `/diagnosis/free`)
+- warm 상태에서 0.7초 → cold start가 원인
+
+### 9. 이슈 정리
+- #3 Closed (배포 안전 인프라 완료)
+- #15 Closed (PR, main 직접 반영)
+- #16 Closed (SMS 정상화)
+- #17 Closed (wrangler.toml 삭제)
+- #18 Closed (cold start 원인)
+- #19 Closed (pg_cron 완료)
+- #20 Closed (브랜치 동기화)
+
+## 오픈 이슈
+| # | 제목 | 비고 |
+|---|------|------|
+| #5 | 유료 상세 PDF 프로덕션 검증 | 다음 세션 진행 |
+
+## 다음 세션 진행 사항
+
+### #5 유료 PDF 검증
+- 테이블: `anonymous_diagnosis_results`
+- 유료 데이터 없음 (모두 FREE 티어)
+- 테스트 데이터 생성 후 `/diagnosis/report-pdf/{public_token}` 호출 필요
+- 관련 파일: `routers/diagnosis_report.py`, `templates/diagnosis_report_paid.html`
+
+## 인프라 현황
+- Backend: Fly.io 도쿄 (tai-api-prod + tai-api-staging + tai-gotenberg)
+- Proxy: iwinv VPS 115.68.227.222:3128 (한국 고정 IP, Squid)
+- DB: Supabase (xntdkrjhgcscmqctdzyo)
+- Frontend: Cloudflare Pages
+- 모니터링: Sentry + UptimeRobot + Smoke Test + pg_cron
+
+## 메모리 업데이트 필요
+- iwinv VPS IP: 115.68.227.222 (Vultr 158.247.224.158 → iwinv 115.68.227.222)
+- 모니터링 STEP 4 완료
+- Smoke Test 3/3 (S4 제외)
+- 알림톡 템플릿: 미등록 (발송 대상/내용 결정 후 등록 예정)

--- a/docs/workorder-remarks-field.md
+++ b/docs/workorder-remarks-field.md
@@ -1,0 +1,108 @@
+# 작업지시서: 법령엔진 remarks 필드 연결 + PDF 리포트 콘텐츠 보강
+
+## 문제
+유료 진단 PDF에 "조치 의무 (규칙 제32조)"처럼 법령명+조문번호만 표시됨.
+**무엇을, 어떻게** 해야 하는지 구체적 내용이 없음.
+
+## 원인
+DB `master_building_legal_rules` 테이블에 `remarks` 필드가 있고, 구체적 내용이 들어있음:
+- "건축물 정기점검 — 연면적 1,000㎡ 이상, 2년마다"
+- "보건관리자 선임 — 50명 이상 (시행령 기준)"
+- "승강기 자체점검 — 월 1회"
+
+하지만 법령엔진이 이 필드를 `full_result`에 포함하지 않음.
+
+## 수정 대상 파일 (우선순위순)
+
+### 1. 법령엔진 (핵심)
+`routers/legal_engine.py` 또는 `routers/legal_engine_v510.py` — 둘 다 확인
+
+#### 찾을 곳
+`master_building_legal_rules` 테이블에서 SELECT 하는 부분.
+grep 키워드: `select`, `master_building`, `obligation_summary`
+
+#### 수정 내용
+현재 SELECT에 `remarks` 컬럼이 빠져 있음. 추가 필요:
+```python
+# 현재 (예시)
+.select("rule_id, law_name, law_article, obligation_summary, ...")
+
+# 변경
+.select("rule_id, law_name, law_article, obligation_summary, remarks, ...")
+```
+
+그리고 rules_table 딕셔너리 조립 부분에서도 `remarks`를 포함:
+```python
+rule_item = {
+    ...
+    "obligation_summary": r.get("obligation_summary", ""),
+    "remarks": r.get("remarks", ""),  # ← 추가
+    "description": r.get("remarks") or r.get("obligation_summary", ""),  # ← remarks 우선
+    ...
+}
+```
+
+### 2. 진단 통합 엔드포인트
+`routers/diagnosis_integrated.py` — `run_diagnosis()` 함수
+
+법령엔진 호출 결과를 `full_result`에 저장하는 부분 확인.
+법령엔진이 `remarks`를 포함해서 반환하면 자동으로 `full_result`에도 포함됨.
+별도 수정 불필요할 수 있으나 확인 필요.
+
+### 3. PDF 템플릿
+`templates/diagnosis_report_paid.html`
+
+규칙 목록 렌더링 부분에서 `obligation_summary` 대신 `description` (또는 `remarks || obligation_summary`)을 표시:
+
+```html
+<!-- 현재 -->
+<td>{{ rule.obligation_summary }}</td>
+
+<!-- 변경 -->
+<td>{{ rule.remarks or rule.obligation_summary }}</td>
+```
+
+## DB 스키마 참고
+
+### master_building_legal_rules 주요 컬럼
+| 컬럼 | 설명 | 예시 |
+|------|------|------|
+| `obligation_summary` | 의무 요약 (현재 PDF에 표시) | "점검 의무 (건축법 제35조)" |
+| `remarks` | **구체적 상세 설명** | "건축물 정기점검 — 연면적 1,000㎡ 이상, 2년마다" |
+| `condition_code` | 매칭 조건 | "building_area", "worker_count", "elevator_count" |
+| `inspection_cycle_value` | 점검 주기 숫자 | "1", "2" |
+| `inspection_cycle_unit_code` | 주기 단위 코드 | "003"(월), "004"(년), "007"(2년) |
+
+### remarks 필드 현황
+```sql
+SELECT count(*) as total,
+  count(*) FILTER (WHERE remarks IS NOT NULL AND remarks != '') as has_remarks
+FROM master_building_legal_rules WHERE is_active = true;
+-- 약 1,133건 중 일부에 remarks 있음
+```
+
+## 테스트
+```bash
+# 진단 실행 후 full_result에 remarks 포함 확인
+curl -s -X POST https://api.taieng.co.kr/diagnosis/run \
+  -H "Content-Type: application/json" \
+  -d '{"sector":"BUILDING","area":500,"building_use":"OFFICE","completion_year":2010}' | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); r=d.get('full_result',{}).get('rules_table',[]); print(json.dumps(r[0], indent=2, ensure_ascii=False))" 2>/dev/null
+
+# remarks 필드가 출력에 포함되어야 함
+
+# PDF 테스트
+curl -s -o /tmp/test-report.pdf \
+  "https://api.taieng.co.kr/diagnosis/report-pdf/e2e-ind-paid-c1269589a61e61091c8d"
+open /tmp/test-report.pdf
+```
+
+## 커밋
+- 브랜치: `dev`
+- 메시지: `feat(engine): add remarks field to rules_table output for detailed PDF content`
+
+## 주의사항
+1. `remarks`가 NULL인 규칙도 있음 — fallback으로 `obligation_summary` 사용
+2. SELECT에 `*` 사용하면 간단하지만, 현재 명시적 컬럼 리스트면 `remarks` 추가
+3. `legal_engine.py`와 `legal_engine_v510.py` 둘 다 확인 — 어느 것이 실제 사용되는지 파악
+4. `diagnosis_integrated.py`의 `run_diagnosis()`가 어느 엔진을 호출하는지 추적

--- a/docs/workorder-report-pdf-gotenberg.md
+++ b/docs/workorder-report-pdf-gotenberg.md
@@ -1,0 +1,154 @@
+# 작업지시서: diagnosis_report.py Gotenberg 전환
+
+## 목적
+`routers/diagnosis_report.py`의 PDF 엔진을 **xhtml2pdf → Gotenberg**(Chromium)로 교체.
+`routers/diagnosis_proposal.py` v2.1.0과 동일한 패턴 적용.
+
+## 현재 상태
+- `diagnosis_report.py` v1.0.1 — xhtml2pdf 사용 중 → PDF 깨짐
+- `diagnosis_proposal.py` v2.1.0 — Gotenberg 전환 완료 → 정상 동작
+- Gotenberg 서버: `tai-gotenberg.fly.dev` (Fly.io, .internal DNS 안 됨)
+
+## 변경 대상 파일
+- `routers/diagnosis_report.py` (14KB, 약 350줄)
+
+## 변경 사항
+
+### 1. 상단 import 및 상수 추가
+```python
+import httpx  # 추가
+from fastapi.responses import Response, RedirectResponse, StreamingResponse  # StreamingResponse 추가
+
+GOTENBERG_URL = os.getenv("GOTENBERG_URL", "http://tai-gotenberg.internal:3000")
+```
+
+### 2. `_html_to_pdf()` 함수 교체
+기존 (삭제):
+```python
+def _html_to_pdf(html: str) -> bytes:
+    from xhtml2pdf import pisa
+    html = _replace_css_vars(html)
+    buf = io.BytesIO()
+    result = pisa.pisaDocument(...)
+    return buf.getvalue()
+```
+
+신규 (교체) — `diagnosis_proposal.py`의 `_generate_pdf()`와 동일:
+```python
+async def _generate_pdf(html: str) -> bytes:
+    """Gotenberg Chromium PDF 엔진으로 HTML → PDF 변환."""
+    url = f"{GOTENBERG_URL}/forms/chromium/convert/html"
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            url,
+            files={"files": ("index.html", html.encode("utf-8"), "text/html")},
+            data={
+                "paperWidth": "8.27",
+                "paperHeight": "11.69",
+                "marginTop": "0",
+                "marginBottom": "0",
+                "marginLeft": "0",
+                "marginRight": "0",
+                "printBackground": "true",
+                "scale": "1",
+            },
+        )
+    if response.status_code != 200:
+        log.error(f"[REPORT PDF] Gotenberg 오류: {response.status_code} {response.text[:200]}")
+        raise HTTPException(status_code=500, detail=f"PDF 생성 실패: Gotenberg {response.status_code}")
+    return response.content
+```
+
+### 3. 삭제할 코드
+- `_replace_css_vars()` 함수 전체 삭제
+- `_CSS_VAR_MAP` 딕셔너리 전체 삭제
+- `from xhtml2pdf import pisa` 관련 코드 전체 삭제
+
+### 4. 엔드포인트 async 전환
+기존:
+```python
+@router.get("/report-pdf/{public_token}")
+def get_paid_report_pdf(public_token: str):
+```
+
+변경:
+```python
+@router.get("/report-pdf/{public_token}")
+async def get_paid_report_pdf(public_token: str):
+```
+
+### 5. PDF 생성 호출부 변경
+기존:
+```python
+    try:
+        pdf_bytes = _html_to_pdf(html)
+    except HTTPException:
+        raise
+    except Exception as e:
+        ...
+```
+
+변경:
+```python
+    try:
+        pdf_bytes = await _generate_pdf(html)
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.error("[REPORT PDF] PDF 변환 실패: %s", e)
+        raise HTTPException(status_code=500, detail=f"PDF 변환 실패: {e}")
+```
+
+### 6. Storage 캐싱 (선택사항)
+proposal처럼 Storage 캐싱 추가 가능하나, report는 매번 최신 데이터 반영 필요할 수 있으므로 직접 스트리밍 유지 가능.
+
+### 7. 버전 업데이트
+```python
+VERSION = "2.0.0"
+```
+
+docstring:
+```python
+"""
+routers/diagnosis_report.py — v2.0.0
+
+v2.0.0 (2026-04-20):
+  - xhtml2pdf → Gotenberg Chromium PDF 엔진 전환
+  - _replace_css_vars() 제거 (Gotenberg는 CSS 변수 지원)
+v1.0.1 (2026-04-19):
+  - xhtml2pdf CSS 변수 치환
+v1.0.0 (2026-04-18):
+  - 최초 생성
+"""
+```
+
+## 참조 파일
+- `routers/diagnosis_proposal.py` v2.1.0 — Gotenberg 패턴 참조 (특히 `_generate_pdf()` 함수)
+- `templates/diagnosis_report_paid.html` — 템플릿 파일 (변경 불필요)
+
+## 환경변수
+- `GOTENBERG_URL` — 이미 Fly.io secrets에 등록됨 (tai-gotenberg.fly.dev)
+
+## 테스트
+```bash
+# 서버 warm-up
+curl https://api.taieng.co.kr/
+
+# 테스트 토큰으로 PDF 생성
+curl -s -o /tmp/test-report.pdf -w "HTTP %{http_code}\n" \
+  "https://api.taieng.co.kr/diagnosis/report-pdf/e2e-ind-paid-c1269589a61e61091c8d"
+
+# PDF 열기
+open /tmp/test-report.pdf
+```
+
+## 커밋
+- 브랜치: `dev`
+- 메시지: `fix(report): xhtml2pdf → Gotenberg Chromium PDF 엔진 전환 (v2.0.0)`
+
+## 주의사항
+1. `import io` 유지 (StreamingResponse fallback에서 사용)
+2. `from db.supabase_client import get_supabase` 유지
+3. 엔드포인트를 `async def`로 변경하는 것 잊지 말 것
+4. `_render_html()` 함수는 변경 불필요 (Jinja2 렌더링은 동일)
+5. `_CSS_VAR_MAP`과 `_replace_css_vars` 완전 삭제 — Gotenberg(Chromium)은 CSS 변수 지원

--- a/routers/diagnosis_report.py
+++ b/routers/diagnosis_report.py
@@ -1,9 +1,12 @@
 """
-routers/diagnosis_report.py — v1.0.1
+routers/diagnosis_report.py — v2.0.0
 
 유료 진단 상세 PDF 생성 엔드포인트
   GET /diagnosis/report-pdf/{public_token}
 
+v2.0.0 (2026-04-20):
+  - xhtml2pdf → Gotenberg Chromium PDF 엔진 전환
+  - _replace_css_vars() 제거 (Gotenberg는 CSS 변수 지원)
 v1.0.1 (2026-04-19):
   - xhtml2pdf CSS 변수(var()) 미지원 → _replace_css_vars() 자동 치환
   - _extract_max_penalty 징역 우선 로직 유지
@@ -12,12 +15,12 @@ v1.0.0 (2026-04-18):
 """
 from __future__ import annotations
 
-import io
 import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+import httpx
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
@@ -27,7 +30,9 @@ log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/diagnosis", tags=["진단리포트"])
 
-VERSION = "1.0.1"
+VERSION = "2.0.0"
+
+GOTENBERG_URL = os.getenv("GOTENBERG_URL", "http://tai-gotenberg.internal:3000")
 
 # 무료 tier — PDF 생성 차단 대상
 FREE_TIER_CODES = frozenset({
@@ -63,23 +68,6 @@ RECOMMEND_PLAN: Dict[str, Dict[str, str]] = {
     "CONSTRUCTION_PREMIUM": {"name": "건설 PREMIUM",   "price": "월 385,000원~"},
 }
 
-# xhtml2pdf CSS 변수 치환 맵 (var() 미지원)
-_CSS_VAR_MAP: Dict[str, str] = {
-    "var(--blue)":        "#1A5FD4",
-    "var(--blue-dark)":   "#1248a8",
-    "var(--blue-light)":  "#e8f0fc",
-    "var(--red)":         "#dc2626",
-    "var(--red-light)":   "#fef2f2",
-    "var(--green)":       "#15803d",
-    "var(--green-light)": "#f0fdf4",
-    "var(--yellow)":      "#d97706",
-    "var(--yellow-light)": "#fffbeb",
-    "var(--ink)":         "#0f172a",
-    "var(--sub)":         "#64748b",
-    "var(--border)":      "#e2e8f0",
-    "var(--gray-bg)":     "#f8fafc",
-}
-
 
 # ───────────────────────────────────────────────────────────
 # 헬퍼
@@ -95,13 +83,6 @@ def _report_date_str() -> str:
 
 def _ob_label(ob_type: str) -> str:
     return OB_LABEL.get(ob_type, ob_type)
-
-
-def _replace_css_vars(html: str) -> str:
-    """xhtml2pdf가 CSS 변수(var())를 지원하지 않으므로 실제 색상값으로 치환."""
-    for var_expr, value in _CSS_VAR_MAP.items():
-        html = html.replace(var_expr, value)
-    return html
 
 
 def _enrich_rules(rules: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -205,31 +186,35 @@ def _render_html(template_vars: Dict[str, Any]) -> str:
     return template.render(**template_vars)
 
 
-def _html_to_pdf(html: str) -> bytes:
-    """xhtml2pdf로 HTML → PDF bytes 변환."""
-    try:
-        from xhtml2pdf import pisa
-    except ImportError:
+async def _generate_pdf(html: str) -> bytes:
+    """Gotenberg Chromium PDF 엔진으로 HTML → PDF 변환."""
+    url = f"{GOTENBERG_URL}/forms/chromium/convert/html"
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            url,
+            files={"files": ("index.html", html.encode("utf-8"), "text/html")},
+            data={
+                "paperWidth": "8.27",
+                "paperHeight": "11.69",
+                "marginTop": "0",
+                "marginBottom": "0",
+                "marginLeft": "0",
+                "marginRight": "0",
+                "printBackground": "true",
+                "scale": "1",
+            },
+        )
+    if response.status_code != 200:
+        log.error(
+            "[REPORT PDF] Gotenberg 오류: %s %s",
+            response.status_code,
+            response.text[:200],
+        )
         raise HTTPException(
             status_code=500,
-            detail="xhtml2pdf 라이브러리가 설치되어 있지 않습니다. pip install xhtml2pdf"
+            detail=f"PDF 생성 실패: Gotenberg {response.status_code}",
         )
-
-    # xhtml2pdf는 CSS 변수(var())를 지원하지 않음 → 실제 값으로 치환
-    html = _replace_css_vars(html)
-
-    buf = io.BytesIO()
-    result = pisa.pisaDocument(
-        io.BytesIO(html.encode("utf-8")),
-        buf,
-        encoding="utf-8",
-    )
-    if result.err:
-        raise HTTPException(
-            status_code=500,
-            detail=f"PDF 생성 실패 (xhtml2pdf 오류 코드: {result.err})"
-        )
-    return buf.getvalue()
+    return response.content
 
 
 # ───────────────────────────────────────────────────────────
@@ -237,7 +222,7 @@ def _html_to_pdf(html: str) -> bytes:
 # ───────────────────────────────────────────────────────────
 
 @router.get("/report-pdf/{public_token}")
-def get_paid_report_pdf(public_token: str):
+async def get_paid_report_pdf(public_token: str):
     """
     GET /diagnosis/report-pdf/{public_token}
 
@@ -385,7 +370,7 @@ def get_paid_report_pdf(public_token: str):
 
     # 8. PDF 생성
     try:
-        pdf_bytes = _html_to_pdf(html)
+        pdf_bytes = await _generate_pdf(html)
     except HTTPException:
         raise
     except Exception as e:

--- a/routers/law_rule_generator.py
+++ b/routers/law_rule_generator.py
@@ -32,23 +32,79 @@ import os
 import json
 import re
 from fastapi import APIRouter, HTTPException, Query
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 from datetime import datetime, timezone
 import httpx
 
 from db.supabase_client import get_supabase
+from services.law_context_builder import build_full_context
 
 router = APIRouter(prefix="/law-rule-generator", tags=["AI룰생성"])
 
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 CLAUDE_MODEL      = "claude-haiku-4-5-20251001"
+CLAUDE_SONNET_MODEL = "claude-sonnet-4-20250514"
 INTERNAL_SECRET   = os.environ.get("INTERNAL_API_SECRET", "tai-internal-2026")
 
 EXCLUDED_SECTORS = {"SPECIAL_FACILITY", "SPECIAL", "CONSTRUCTION_SPECIAL",
                     "MANUFACTURING_SPECIAL", "CONSTRUCTION_MANUFACTURING_SPECIAL"}
 
+VALID_CONDITION_CODES = {
+    "building_area", "worker_count", "electric_capacity", "gas_capacity_kg",
+    "gas_capacity_m3", "boiler_capacity_kw", "elevator_count", "is_hazardous_material",
+    "annual_energy_toe", "construction_amount", "floor_count", "is_factory_registered",
+    "employee_count", "contract_amount", "has_chemical_substance", "is_multi_use",
+    "contractor_count", "has_high_pressure_gas", "transformer_capacity_kva",
+    "has_boiler", "electrical_capacity_kw", "boiler_capacity_th", "hospital_beds",
+    "student_count",
+}
+
+SUBMIT_ORG_LABELS = {
+    "kosha": "한국산업안전보건공단 (관할 지역본부)",
+    "local_gov": "관할 시·군·구청",
+    "moel": "관할 지방고용노동관서",
+    "me": "관할 지방환경관서",
+    "kgs": "한국가스안전공사 (관할 지사)",
+    "mlit": "관할 지방국토관리청",
+    "nfa": "관할 소방서",
+    "kesco": "한국전기안전공사 (관할 지사)",
+}
+
+FEW_SHOT_RULE = {
+    "draft_rule_id": "FIREACT-001-BLD",
+    "obligation_type": "APPOINT",
+    "sector": "BUILDING",
+    "condition_code": "building_area",
+    "condition_operator": "gte",
+    "condition_value": "400",
+    "obligation_summary": "소방안전관리자 선임 의무",
+    "penalty_summary": "미선임 시 300만원 이하 과태료 (제53조)",
+    "penalty_value": 300,
+    "form_code": "NFA-별지제5호",
+    "form_name": "소방안전관리자 선임신고서",
+    "submit_org_code": "nfa",
+    "due_days": 14,
+    "report_method_code": "online",
+    "report_method_std": "api",
+    "appointment_target": "소방안전관리자",
+    "appointment_qualification_code": "fire_safety_1",
+    "appointment_qualification_level_code": "grade1",
+    "appointment_count_value": 1,
+    "inspection_cycle_value": 6,
+    "inspection_cycle_unit_code": "month",
+    "cycle_base_guide": "최초 선임일로부터 6개월마다",
+    "online_system": "소방청 민원 시스템",
+    "system_url": "https://www.safetykorea.go.kr",
+    "tai_feature_code": "APPOINTMENT",
+    "remarks": "연면적 400㎡ 이상 특정소방대상물",
+    "diagnosis_stage": 1,
+    "ai_confidence": 95,
+    "ai_reasoning": "화재예방법 제24조 + 시행령 제22조 별표4 기준",
+    "ai_flags": [],
+}
+
 SYSTEM_PROMPT = """당신은 한국 산업안전 법령 전문가입니다.
-법령 조문 텍스트를 분석하여 안전관리 시스템의 판정 룰을 JSON 형식으로 추출합니다.
+법령 원문(본조+시행령+별표+벌칙)을 분석하여 안전관리 시스템의 판정 룰을 JSON 형식으로 추출합니다.
 
 추출 대상 의무 유형:
 - APPOINT: 안전관리자·소방안전관리자 등 선임 의무
@@ -57,19 +113,31 @@ SYSTEM_PROMPT = """당신은 한국 산업안전 법령 전문가입니다.
 - REPORT: 기록·보존 의무
 - ACTION: 조치·설치·이행 의무
 
-조건 코드 (condition_code) 목록:
+조건 코드 (condition_code) 목록 (정확히 아래에서만 선택):
 - building_area: 건물 연면적 (㎡)
 - worker_count: 근로자 수 (명)
 - electric_capacity: 전기 수전용량 (kW)
+- electrical_capacity_kw: 전기 수전용량 (kW, 동의어)
 - gas_capacity_kg: LPG 저장량 (kg)
 - gas_capacity_m3: 도시가스 사용량 (㎥/시)
 - boiler_capacity_kw: 보일러 용량 (kW)
+- boiler_capacity_th: 보일러 용량 (ton/hr)
 - elevator_count: 승강기 대수
 - is_hazardous_material: 위험물 취급 여부 (0/1)
 - annual_energy_toe: 연간 에너지 사용량 (TOE)
 - construction_amount: 공사금액 (원)
 - floor_count: 건물 층수
 - is_factory_registered: 공장등록 여부 (0/1)
+- employee_count: 상시근로자 수 (명)
+- contract_amount: 공사금액 (원, 동의어)
+- has_chemical_substance: 화학물질 취급 여부 (0/1)
+- is_multi_use: 다중이용업소 여부 (0/1)
+- contractor_count: 수급업체 수
+- has_high_pressure_gas: 고압가스 취급 여부 (0/1)
+- transformer_capacity_kva: 변압기 용량 (kVA)
+- has_boiler: 보일러 보유 여부 (0/1)
+- hospital_beds: 병상 수
+- student_count: 학생 수
 
 섹터 코드 (반드시 아래 4가지 중 하나만 사용):
 - BUILDING: 건물·시설 (업무용·판매용·숙박·근린생활 등 일반 건축물)
@@ -81,13 +149,28 @@ SYSTEM_PROMPT = """당신은 한국 산업안전 법령 전문가입니다.
 ⚠️ 주의: 학교·병원·사회복지시설 등 특수시설 전용 법령은 건너뜁니다.
   해당 법령(의료법·학교안전법·사회복지사업법 등)의 조문에서 의무가 발견되면 []을 반환하세요.
 
-응답은 반드시 순수 JSON 배열만 출력하세요. 마크다운이나 설명 없이 JSON만 출력합니다.
-의무가 없는 조문(정의, 목적, 용어해설 등)은 빈 배열 []을 반환하세요."""
+submit_org_code는 반드시 아래 중 하나만 사용:
+- kosha, local_gov, moel, me, kgs, mlit, nfa, kesco
+
+condition_code가 있으면 condition_operator + condition_value를 함께 채웁니다.
+inspection_required=true이면 inspection_cycle_value + inspection_cycle_unit_code를 채웁니다.
+report_required=true이면 report_method_code를 채웁니다.
+appointment_required=true이면 appointment_qualification_code를 채웁니다.
+penalty_summary가 있으면 penalty_value(만원)를 가능한 범위에서 채웁니다.
+
+응답은 반드시 순수 JSON 배열만 출력하세요. 마크다운/설명 금지.
+의무가 없는 조문은 빈 배열 []을 반환하세요."""
 
 USER_PROMPT_TEMPLATE = """다음 법령 조문을 분석하여 판정 룰을 추출해주세요.
 
 법령명: {law_name}
-조문: {article_text}
+핵심 조문: {article_text}
+
+[풀 컨텍스트]
+{full_context}
+
+[좋은 예시 1개]
+{few_shot}
 
 위 조문에서 안전관리 의무(선임·점검·신고·보고·조치)를 추출하여 다음 JSON 형식으로 반환하세요.
 의무가 없는 조문이면 []을 반환하세요.
@@ -101,8 +184,30 @@ USER_PROMPT_TEMPLATE = """다음 법령 조문을 분석하여 판정 룰을 추
     "condition_operator": "gte|lte|gt|lt|eq",
     "condition_value": "숫자 문자열 또는 null",
     "obligation_summary": "의무 내용 1줄 요약 (최대 100자)",
+    "remarks": "맥락 설명 (최대 100자)",
     "penalty_summary": "위반 시 벌칙 요약 또는 null",
+    "penalty_value": "과태료 숫자 (만원 단위) 또는 null",
+    "form_code": "별지서식 번호 또는 null",
+    "form_name": "서식명 또는 null",
+    "submit_org_code": "kosha|local_gov|moel|me|kgs|mlit|nfa|kesco 중 선택 또는 null",
+    "due_days": "기한 일수 숫자 또는 null",
+    "report_method_code": "online|offline|both 또는 null",
+    "report_method_std": "api|paper|keep 또는 null",
+    "online_system": "온라인 시스템명 또는 null",
+    "system_url": "시스템 URL 또는 null",
+    "appointment_qualification_code": "자격 코드 또는 null",
+    "appointment_qualification_level_code": "자격 등급 또는 null",
+    "appointment_count_value": "선임 인원수 또는 null",
+    "inspection_cycle_value": "점검 주기 숫자 또는 null",
+    "inspection_cycle_unit_code": "day|week|month|quarter|half_year|year 또는 null",
+    "cycle_base_guide": "주기 설명 (최대 50자) 또는 null",
+    "tai_feature_code": "APPOINTMENT|INSPECTION|REPORT|EDUCATION|DOCUMENT|FIX|CHECKLIST 또는 null",
     "appointment_target": "선임 대상자명 (APPOINT인 경우만) 또는 null",
+    "appointment_required": "true|false",
+    "inspection_required": "true|false",
+    "notify_required": "true|false",
+    "report_required": "true|false",
+    "action_required": "true|false",
     "diagnosis_stage": 1,
     "ai_confidence": 0~100,
     "ai_reasoning": "판단 근거 1~2줄",
@@ -111,12 +216,30 @@ USER_PROMPT_TEMPLATE = """다음 법령 조문을 분석하여 판정 룰을 추
 ]"""
 
 
-async def call_claude(law_name: str, article_text: str) -> List[Dict]:
+def _extract_json_payload(raw: str) -> Any:
+    cleaned = re.sub(r"```json\s*", "", raw.strip())
+    cleaned = re.sub(r"```\s*", "", cleaned).strip()
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        m_arr = re.search(r"\[.*\]", cleaned, re.DOTALL)
+        if m_arr:
+            try:
+                return json.loads(m_arr.group())
+            except Exception:
+                pass
+        m_obj = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if m_obj:
+            try:
+                return json.loads(m_obj.group())
+            except Exception:
+                pass
+    return None
+
+
+async def _call_claude_messages(system_prompt: str, user_prompt: str, model: str, max_tokens: int = 2200) -> Any:
     if not ANTHROPIC_API_KEY:
         raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY 환경변수가 설정되지 않았습니다.")
-
-    user_prompt = USER_PROMPT_TEMPLATE.format(
-        law_name=law_name, article_text=article_text[:3000])
 
     async with httpx.AsyncClient(timeout=60) as client:
         resp = await client.post(
@@ -124,8 +247,8 @@ async def call_claude(law_name: str, article_text: str) -> List[Dict]:
             headers={"x-api-key": ANTHROPIC_API_KEY,
                      "anthropic-version": "2023-06-01",
                      "content-type": "application/json"},
-            json={"model": CLAUDE_MODEL, "max_tokens": 1500,
-                  "system": SYSTEM_PROMPT,
+            json={"model": model, "max_tokens": max_tokens,
+                  "system": system_prompt,
                   "messages": [{"role": "user", "content": user_prompt}]},
         )
 
@@ -136,21 +259,121 @@ async def call_claude(law_name: str, article_text: str) -> List[Dict]:
     for block in resp.json().get("content", []):
         if block.get("type") == "text":
             raw += block["text"]
+    return _extract_json_payload(raw)
 
-    raw = re.sub(r"```json\s*", "", raw.strip())
-    raw = re.sub(r"```\s*", "", raw).strip()
 
+async def call_claude(law_name: str, article_text: str, full_context: str = "") -> List[Dict]:
+    user_prompt = USER_PROMPT_TEMPLATE.format(
+        law_name=law_name,
+        article_text=article_text[:3000],
+        full_context=(full_context or "")[:15000],
+        few_shot=json.dumps(FEW_SHOT_RULE, ensure_ascii=False),
+    )
+    parsed = await _call_claude_messages(SYSTEM_PROMPT, user_prompt, CLAUDE_MODEL)
+    return parsed if isinstance(parsed, list) else []
+
+
+def _normalize_submit_org_code(code: Any) -> Optional[str]:
+    value = (str(code or "").strip().lower())
+    if value in SUBMIT_ORG_LABELS:
+        return value
+    return None
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "y", "yes"}
+    if isinstance(value, (int, float)):
+        return value != 0
+    return False
+
+
+def _safe_float(value: Any) -> Optional[float]:
     try:
-        parsed = json.loads(raw)
-        return parsed if isinstance(parsed, list) else []
-    except json.JSONDecodeError:
-        m = re.search(r"\[.*\]", raw, re.DOTALL)
-        if m:
-            try:
-                return json.loads(m.group())
-            except Exception:
-                pass
-        return []
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or value == "":
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_master_payload(row: dict, rule_id: str) -> dict:
+    ob_type = row.get("obligation_type")
+    cond_val_num = _safe_float(row.get("condition_value"))
+    submit_org_code = _normalize_submit_org_code(row.get("submit_org_code"))
+    return {
+        "rule_id": rule_id,
+        "sector": row.get("sector") or "BUILDING",
+        "law_name": row.get("law_name"),
+        "law_article": row.get("law_article"),
+        "obligation_type": ob_type,
+        "obligation_summary": row.get("obligation_summary"),
+        "remarks": row.get("remarks"),
+        "penalty_summary": row.get("penalty_summary"),
+        "penalty_value": _safe_int(row.get("penalty_value")),
+        "appointment_target_code": row.get("appointment_target"),
+        "appointment_qualification_code": row.get("appointment_qualification_code"),
+        "appointment_qualification_level_code": row.get("appointment_qualification_level_code"),
+        "appointment_count_value": _safe_int(row.get("appointment_count_value")),
+        "condition_code": row.get("condition_code"),
+        "condition_operator_code": row.get("condition_operator", "gte"),
+        "condition_value": cond_val_num,
+        "inspection_cycle_value": _safe_int(row.get("inspection_cycle_value")),
+        "inspection_cycle_unit_code": row.get("inspection_cycle_unit_code"),
+        "cycle_base_guide": row.get("cycle_base_guide"),
+        "form_code": row.get("form_code"),
+        "form_name": row.get("form_name"),
+        "submit_org_code": submit_org_code,
+        "report_method_code": row.get("report_method_code"),
+        "report_method_std": row.get("report_method_std"),
+        "online_system": row.get("online_system"),
+        "system_url": row.get("system_url"),
+        "tai_feature_code": row.get("tai_feature_code"),
+        "due_days": _safe_int(row.get("due_days")),
+        "appointment_required": _to_bool(row.get("appointment_required")) or ob_type == "APPOINT",
+        "inspection_required": _to_bool(row.get("inspection_required")) or ob_type == "INSPECT",
+        "notify_required": _to_bool(row.get("notify_required")) or ob_type == "NOTIFY",
+        "report_required": _to_bool(row.get("report_required")) or ob_type == "REPORT",
+        "action_required": _to_bool(row.get("action_required")) or ob_type == "ACTION",
+        "diagnosis_stage": _safe_int(row.get("diagnosis_stage")) or 1,
+        "is_active": True,
+        "source_api": "AI_GENERATED",
+    }
+
+
+def _build_reparse_prompt(rule: dict, full_context: str, few_shot_examples: List[dict]) -> str:
+    return f"""다음 기존 master 룰의 빈 필드(null/빈문자)만 보강하세요.
+기존 값이 있는 필드는 그대로 유지하세요.
+출력은 JSON object 1개만 반환하세요.
+
+[기존 룰]
+{json.dumps(rule, ensure_ascii=False)}
+
+[같은 법령의 잘 채워진 예시]
+{json.dumps(few_shot_examples[:5], ensure_ascii=False)}
+
+[법령 원문 풀 컨텍스트]
+{(full_context or "")[:18000]}
+
+반드시 아래 키를 포함한 JSON object를 반환:
+penalty_summary, penalty_value, form_code, form_name, submit_org_code,
+due_days, report_method_code, report_method_std, appointment_qualification_code,
+appointment_qualification_level_code, appointment_count_value,
+inspection_cycle_value, inspection_cycle_unit_code, cycle_base_guide,
+online_system, system_url, tai_feature_code, remarks, condition_code,
+condition_operator_code, condition_value
+"""
 
 
 def _auto_approve_to_master(supabase, draft: dict) -> Optional[str]:
@@ -160,34 +383,9 @@ def _auto_approve_to_master(supabase, draft: dict) -> Optional[str]:
         rule_id = rule_id + "-V2"
     if supabase.table("master_building_legal_rules").select("rule_id").eq("rule_id", rule_id).execute().data:
         return None
-
-    cond_val = draft.get("condition_value")
-    try:
-        cond_val_num = float(cond_val) if cond_val is not None else None
-    except (TypeError, ValueError):
-        cond_val_num = None
-
-    ins = supabase.table("master_building_legal_rules").insert({
-        "rule_id": rule_id,
-        "sector": draft.get("sector") or "BUILDING",
-        "law_name": draft.get("law_name"),
-        "law_article": draft.get("law_article"),
-        "obligation_type": draft.get("obligation_type"),
-        "obligation_summary": draft.get("obligation_summary"),
-        "penalty_summary": draft.get("penalty_summary"),
-        "appointment_target_code": draft.get("appointment_target"),
-        "condition_code": draft.get("condition_code"),
-        "condition_operator_code": draft.get("condition_operator", "gte"),
-        "condition_value": cond_val_num,
-        "appointment_required": draft.get("obligation_type") == "APPOINT",
-        "inspection_required": draft.get("obligation_type") == "INSPECT",
-        "notify_required": draft.get("obligation_type") == "NOTIFY",
-        "report_required": draft.get("obligation_type") == "REPORT",
-        "action_required": draft.get("obligation_type") == "ACTION",
-        "diagnosis_stage": draft.get("diagnosis_stage", 1),
-        "is_active": True,
-        "source_api": "AI_GENERATED",
-    }).execute()
+    ins = supabase.table("master_building_legal_rules").insert(
+        _build_master_payload(draft, rule_id)
+    ).execute()
 
     if ins.data:
         supabase.table("law_rule_drafts").update({
@@ -198,6 +396,29 @@ def _auto_approve_to_master(supabase, draft: dict) -> Optional[str]:
         }).eq("id", draft["id"]).execute()
         return rule_id
     return None
+
+
+def _build_draft_row(law_name: str, law_article: str, article_id: Optional[str], article_text: str, rule: Dict[str, Any]) -> dict:
+    return {
+        "law_name": law_name,
+        "law_article": law_article,
+        "article_id": article_id,
+        "article_text": article_text[:2000],
+        "draft_rule_id": rule.get("draft_rule_id"),
+        "obligation_type": rule.get("obligation_type"),
+        "sector": rule.get("sector"),
+        "condition_code": rule.get("condition_code"),
+        "condition_operator": rule.get("condition_operator", "gte"),
+        "condition_value": str(rule["condition_value"]) if rule.get("condition_value") is not None else None,
+        "obligation_summary": rule.get("obligation_summary"),
+        "penalty_summary": rule.get("penalty_summary"),
+        "appointment_target": rule.get("appointment_target"),
+        "diagnosis_stage": rule.get("diagnosis_stage", 1),
+        "ai_confidence": rule.get("ai_confidence"),
+        "ai_reasoning": rule.get("ai_reasoning"),
+        "ai_flags": rule.get("ai_flags"),
+        "status": "PENDING",
+    }
 
 
 # ── GET /laws ──────────────────────────────────────────────
@@ -283,7 +504,8 @@ async def parse_article(body: dict):
         raise HTTPException(status_code=400, detail="law_name, article_text 필수")
 
     try:
-        rules = await call_claude(law_name, article_text)
+        full_context = await build_full_context(law_name, law_article, article_id)
+        rules = await call_claude(law_name, article_text, full_context=full_context)
     except HTTPException:
         raise
     except Exception as e:
@@ -303,24 +525,7 @@ async def parse_article(body: dict):
         if rule_sector in EXCLUDED_SECTORS:
             continue
 
-        row = {
-            "law_name": law_name, "law_article": law_article,
-            "article_id": article_id, "article_text": article_text[:2000],
-            "draft_rule_id": rule.get("draft_rule_id"),
-            "obligation_type": rule.get("obligation_type"),
-            "sector": rule.get("sector"),
-            "condition_code": rule.get("condition_code"),
-            "condition_operator": rule.get("condition_operator", "gte"),
-            "condition_value": str(rule["condition_value"]) if rule.get("condition_value") is not None else None,
-            "obligation_summary": rule.get("obligation_summary"),
-            "penalty_summary": rule.get("penalty_summary"),
-            "appointment_target": rule.get("appointment_target"),
-            "diagnosis_stage": rule.get("diagnosis_stage", 1),
-            "ai_confidence": rule.get("ai_confidence"),
-            "ai_reasoning": rule.get("ai_reasoning"),
-            "ai_flags": rule.get("ai_flags"),
-            "status": "PENDING",
-        }
+        row = _build_draft_row(law_name, law_article, article_id, article_text, rule)
         ins = supabase.table("law_rule_drafts").insert(row).execute()
         if ins.data:
             saved.append(ins.data[0])
@@ -377,7 +582,9 @@ async def parse_batch(body: dict):
                 continue
 
             label = f"제{art.get('article_no', '')}조{art.get('article_title', '')}"
-            rules = await call_claude(law_name, art_text)
+            law_article_label = f"제{art.get('article_no', '')}조{art.get('article_title', '')}"
+            full_context = await build_full_context(law_name, law_article_label, art.get("id"))
+            rules = await call_claude(law_name, art_text, full_context=full_context)
 
             if art.get("id"):
                 supabase.table("law_article").update({"ai_parsed_at": now_iso}).eq("id", art["id"]).execute()
@@ -388,24 +595,9 @@ async def parse_batch(body: dict):
                     results["special_excluded"] += 1
                     continue
 
-                supabase.table("law_rule_drafts").insert({
-                    "law_name": law_name, "law_article": label,
-                    "article_id": art.get("id"), "article_text": art_text[:2000],
-                    "draft_rule_id": rule.get("draft_rule_id"),
-                    "obligation_type": rule.get("obligation_type"),
-                    "sector": rule.get("sector"),
-                    "condition_code": rule.get("condition_code"),
-                    "condition_operator": rule.get("condition_operator", "gte"),
-                    "condition_value": str(rule["condition_value"]) if rule.get("condition_value") is not None else None,
-                    "obligation_summary": rule.get("obligation_summary"),
-                    "penalty_summary": rule.get("penalty_summary"),
-                    "appointment_target": rule.get("appointment_target"),
-                    "diagnosis_stage": rule.get("diagnosis_stage", 1),
-                    "ai_confidence": rule.get("ai_confidence"),
-                    "ai_reasoning": rule.get("ai_reasoning"),
-                    "ai_flags": rule.get("ai_flags"),
-                    "status": "PENDING",
-                }).execute()
+                supabase.table("law_rule_drafts").insert(
+                    _build_draft_row(law_name, label, art.get("id"), art_text, rule)
+                ).execute()
                 results["drafts_created"] += 1
 
             results["processed"] += 1
@@ -471,7 +663,8 @@ async def auto_parse_and_approve(body: dict):
                 continue
 
             label = f"제{art.get('article_no', '')}조{art.get('article_title', '') or ''}"
-            rules = await call_claude(law_name, art_text)
+            full_context = await build_full_context(law_name, label, art.get("id"))
+            rules = await call_claude(law_name, art_text, full_context=full_context)
 
             supabase.table("law_article").update({"ai_parsed_at": now_iso}).eq("id", art["id"]).execute()
             results["parsed"] += 1
@@ -484,24 +677,9 @@ async def auto_parse_and_approve(body: dict):
                 conf = int(rule.get("ai_confidence") or 0)
                 ob_type = rule.get("obligation_type", "")
 
-                ins = supabase.table("law_rule_drafts").insert({
-                    "law_name": law_name, "law_article": label,
-                    "article_id": art.get("id"), "article_text": art_text[:2000],
-                    "draft_rule_id": rule.get("draft_rule_id"),
-                    "obligation_type": ob_type,
-                    "sector": rule.get("sector"),
-                    "condition_code": rule.get("condition_code"),
-                    "condition_operator": rule.get("condition_operator", "gte"),
-                    "condition_value": str(rule["condition_value"]) if rule.get("condition_value") is not None else None,
-                    "obligation_summary": rule.get("obligation_summary"),
-                    "penalty_summary": rule.get("penalty_summary"),
-                    "appointment_target": rule.get("appointment_target"),
-                    "diagnosis_stage": rule.get("diagnosis_stage", 1),
-                    "ai_confidence": conf,
-                    "ai_reasoning": rule.get("ai_reasoning"),
-                    "ai_flags": rule.get("ai_flags"),
-                    "status": "PENDING",
-                }).execute()
+                row = _build_draft_row(law_name, label, art.get("id"), art_text, rule)
+                row["ai_confidence"] = conf
+                ins = supabase.table("law_rule_drafts").insert(row).execute()
                 results["drafts_created"] += 1
 
                 if not ins.data:
@@ -567,33 +745,9 @@ async def bulk_approve_unregistered(
                 skipped += 1
                 continue
 
-            cond_val = d.get("condition_value")
-            try:
-                cond_val_num = float(cond_val) if cond_val is not None else None
-            except (TypeError, ValueError):
-                cond_val_num = None
-
-            ins = supabase.table("master_building_legal_rules").insert({
-                "rule_id": rule_id,
-                "sector":  d.get("sector") or "BUILDING",
-                "law_name":    d.get("law_name"),
-                "law_article": d.get("law_article"),
-                "obligation_type":         d.get("obligation_type"),
-                "obligation_summary":      d.get("obligation_summary"),
-                "penalty_summary":         d.get("penalty_summary"),
-                "appointment_target_code": d.get("appointment_target"),
-                "condition_code":          d.get("condition_code"),
-                "condition_operator_code": d.get("condition_operator", "gte"),
-                "condition_value":         cond_val_num,
-                "appointment_required": d.get("obligation_type") == "APPOINT",
-                "inspection_required":  d.get("obligation_type") == "INSPECT",
-                "notify_required":      d.get("obligation_type") == "NOTIFY",
-                "report_required":      d.get("obligation_type") == "REPORT",
-                "action_required":      d.get("obligation_type") == "ACTION",
-                "diagnosis_stage": d.get("diagnosis_stage", 1),
-                "is_active": True,
-                "source_api": "AI_GENERATED",
-            }).execute()
+            ins = supabase.table("master_building_legal_rules").insert(
+                _build_master_payload(d, rule_id)
+            ).execute()
 
             if ins.data:
                 supabase.table("law_rule_drafts").update({
@@ -621,6 +775,213 @@ async def bulk_approve_unregistered(
         "remaining": remaining,
         "done": remaining == 0,
     }}
+
+
+def _is_blank(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and value.strip() == "")
+
+
+def _validate_rule_row(row: dict) -> List[str]:
+    errors: List[str] = []
+    cond_code = row.get("condition_code")
+    cond_op = row.get("condition_operator_code")
+    cond_val = row.get("condition_value")
+    if cond_code:
+        if cond_code not in VALID_CONDITION_CODES:
+            errors.append("invalid_condition_code")
+        if _is_blank(cond_op) or cond_val is None:
+            errors.append("condition_incomplete")
+
+    if _to_bool(row.get("inspection_required")):
+        if _is_blank(row.get("inspection_cycle_value")) or _is_blank(row.get("inspection_cycle_unit_code")):
+            errors.append("missing_inspection_cycle")
+
+    if _to_bool(row.get("report_required")) and _is_blank(row.get("report_method_code")):
+        errors.append("missing_report_method")
+
+    if _to_bool(row.get("appointment_required")) and _is_blank(row.get("appointment_qualification_code")):
+        errors.append("missing_qualification")
+
+    if row.get("penalty_summary") and _is_blank(row.get("penalty_value")):
+        errors.append("missing_penalty_value")
+
+    if _is_blank(row.get("obligation_summary")):
+        errors.append("missing_obligation_summary")
+
+    return errors
+
+
+@router.post("/validate-master")
+async def validate_master(body: dict = None):
+    body = body or {}
+    sector = (body.get("sector") or "ALL").strip().upper()
+    supabase = get_supabase()
+
+    q = supabase.table("master_building_legal_rules").select("*").eq("is_active", True)
+    if sector and sector != "ALL":
+        q = q.eq("sector", sector)
+    rows = q.execute().data or []
+
+    failures: Dict[str, int] = {}
+    samples: Dict[str, List[str]] = {}
+    rule_ids: Dict[str, int] = {}
+
+    for row in rows:
+        rid = row.get("rule_id") or ""
+        if rid:
+            rule_ids[rid] = rule_ids.get(rid, 0) + 1
+        errs = _validate_rule_row(row)
+        for err in errs:
+            failures[err] = failures.get(err, 0) + 1
+            samples.setdefault(err, [])
+            if rid and len(samples[err]) < 8 and rid not in samples[err]:
+                samples[err].append(rid)
+
+    dup_ids = [rid for rid, cnt in rule_ids.items() if cnt > 1]
+    if dup_ids:
+        failures["duplicate_rule_id"] = len(dup_ids)
+        samples["duplicate_rule_id"] = dup_ids[:8]
+
+    failed_rows = set()
+    for key, ids in samples.items():
+        if key == "duplicate_rule_id":
+            continue
+        failed_rows.update(ids)
+
+    return {
+        "status": "success",
+        "data": {
+            "sector": sector,
+            "total": len(rows),
+            "failed": sum(failures.values()),
+            "passed": max(0, len(rows) - len(failed_rows)),
+            "failures": failures,
+            "samples": samples,
+            "submit_org_labels": SUBMIT_ORG_LABELS,
+        },
+    }
+
+
+async def _fetch_few_shot_examples(supabase, law_name: str, limit: int = 5) -> List[dict]:
+    rows = (
+        supabase.table("master_building_legal_rules")
+        .select("*")
+        .eq("is_active", True)
+        .eq("law_name", law_name)
+        .not_.is_("obligation_summary", "null")
+        .not_.is_("remarks", "null")
+        .not_.is_("submit_org_code", "null")
+        .limit(limit)
+        .execute()
+    ).data or []
+    return rows
+
+
+def _pick_reparse_targets(rows: List[dict], limit: int) -> List[dict]:
+    def _blank_score(r: dict) -> int:
+        fields = [
+            "penalty_summary", "penalty_value", "form_code", "form_name", "submit_org_code",
+            "report_method_code", "appointment_qualification_code",
+            "inspection_cycle_value", "inspection_cycle_unit_code",
+            "cycle_base_guide", "remarks",
+        ]
+        return sum(1 for f in fields if _is_blank(r.get(f)))
+
+    rows_sorted = sorted(rows, key=_blank_score, reverse=True)
+    return rows_sorted[:limit]
+
+
+@router.post("/reparse-master")
+async def reparse_master(body: dict):
+    secret = body.get("secret", "")
+    if secret != INTERNAL_SECRET:
+        raise HTTPException(status_code=403, detail="내부 전용 엔드포인트")
+
+    supabase = get_supabase()
+    sector = (body.get("sector") or "").strip().upper()
+    limit = int(body.get("limit", 50))
+    fill_empty_only = bool(body.get("fill_empty_only", True))
+    rule_ids = body.get("rule_ids") or []
+
+    q = supabase.table("master_building_legal_rules").select("*").eq("is_active", True)
+    if sector and sector != "ALL":
+        q = q.eq("sector", sector)
+    if rule_ids:
+        q = q.in_("rule_id", rule_ids)
+    rows = q.limit(max(limit * 3, 50)).execute().data or []
+    targets = _pick_reparse_targets(rows, limit)
+
+    updated = 0
+    skipped = 0
+    errors: List[dict] = []
+    changed_fields_total: Dict[str, int] = {}
+    processed_rule_ids: List[str] = []
+
+    for row in targets:
+        rid = row.get("rule_id") or ""
+        law_name = row.get("law_name") or ""
+        law_article = row.get("law_article") or ""
+        if not law_name or not law_article:
+            skipped += 1
+            continue
+
+        try:
+            full_context = await build_full_context(law_name, law_article)
+            few_shots = await _fetch_few_shot_examples(supabase, law_name, limit=5)
+            prompt = _build_reparse_prompt(row, full_context, few_shots)
+            parsed = await _call_claude_messages(
+                "빈 필드 보강 전용 리라이팅 모델입니다. JSON object 1개만 반환하세요.",
+                prompt,
+                CLAUDE_SONNET_MODEL,
+                max_tokens=1800,
+            )
+            if not isinstance(parsed, dict):
+                skipped += 1
+                continue
+
+            patch: Dict[str, Any] = {}
+            for key, value in parsed.items():
+                if key not in row:
+                    continue
+                if fill_empty_only and not _is_blank(row.get(key)):
+                    continue
+                if _is_blank(value):
+                    continue
+                if row.get(key) != value:
+                    patch[key] = value
+                    changed_fields_total[key] = changed_fields_total.get(key, 0) + 1
+
+            if "submit_org_code" in patch:
+                patch["submit_org_code"] = _normalize_submit_org_code(patch["submit_org_code"])
+                if not patch["submit_org_code"]:
+                    patch.pop("submit_org_code", None)
+
+            if patch:
+                patch["updated_at"] = datetime.now(timezone.utc).isoformat()
+                supabase.table("master_building_legal_rules").update(patch).eq("id", row["id"]).execute()
+                updated += 1
+                if rid:
+                    processed_rule_ids.append(rid)
+            else:
+                skipped += 1
+        except Exception as e:
+            errors.append({"rule_id": rid, "error": str(e)[:200]})
+
+    validate_result = await validate_master({"sector": sector or "ALL"})
+    return {
+        "status": "success",
+        "data": {
+            "sector": sector or "ALL",
+            "model": CLAUDE_SONNET_MODEL,
+            "targeted": len(targets),
+            "updated": updated,
+            "skipped": skipped,
+            "errors": errors,
+            "changed_fields": changed_fields_total,
+            "processed_rule_ids": processed_rule_ids[:50],
+            "validation": validate_result.get("data"),
+        },
+    }
 
 
 # ── GET /stats ─────────────────────────────────────────────
@@ -745,32 +1106,9 @@ async def approve_draft(draft_id: str, body: dict = None):
     if supabase.table("master_building_legal_rules").select("rule_id").eq("rule_id", rule_id).execute().data:
         rule_id = rule_id + "-V2"
 
-    cond_val = d.get("condition_value")
-    try:
-        cond_val_num = float(cond_val) if cond_val is not None else None
-    except (TypeError, ValueError):
-        cond_val_num = None
-
-    ins = supabase.table("master_building_legal_rules").insert({
-        "rule_id": rule_id,
-        "sector":  d.get("sector") or "BUILDING",
-        "law_name":    d.get("law_name"),
-        "law_article": d.get("law_article"),
-        "obligation_type":         d.get("obligation_type"),
-        "obligation_summary":      d.get("obligation_summary"),
-        "penalty_summary":         d.get("penalty_summary"),
-        "appointment_target_code": d.get("appointment_target"),
-        "condition_code":          d.get("condition_code"),
-        "condition_operator_code": d.get("condition_operator", "gte"),
-        "condition_value":         cond_val_num,
-        "appointment_required": d.get("obligation_type") == "APPOINT",
-        "inspection_required":  d.get("obligation_type") == "INSPECT",
-        "notify_required":      d.get("obligation_type") == "NOTIFY",
-        "report_required":      d.get("obligation_type") == "REPORT",
-        "action_required":      d.get("obligation_type") == "ACTION",
-        "diagnosis_stage": d.get("diagnosis_stage", 1),
-        "is_active": True, "source_api": "AI_GENERATED",
-    }).execute()
+    ins = supabase.table("master_building_legal_rules").insert(
+        _build_master_payload(d, rule_id)
+    ).execute()
     if not ins.data:
         raise HTTPException(status_code=500, detail="master 등록 실패")
 

--- a/routers/legal_engine.py
+++ b/routers/legal_engine.py
@@ -429,8 +429,10 @@ def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
       - Task 2: penalty_summary 빈 값 시 _get_penalty_fallback 적용
       - Task 4: cycle_unit_std 있으면 due_info: {} (상시 의무 D-day 미표시)
     """
-    # Task 1: remarks 우선, obligation_summary 폴백
-    desc = (rule.get("remarks") or rule.get("obligation_summary") or "").strip()
+    # Task 1: DB 원문 유지 + description은 remarks 우선(사람 언어)
+    obl_summary = (rule.get("obligation_summary") or "").strip()
+    remarks_txt = (rule.get("remarks") or "").strip()
+    desc = remarks_txt or obl_summary
 
     target_code = _normalize_target_code(rule.get("appointment_target_code") or "")
     submit_org_code    = rule.get("submit_org_code") or ""
@@ -459,7 +461,9 @@ def format_rule_result_db(rule: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "rule_id": rule.get("rule_id", ""), "rule_type": str(rule.get("rule_type_code") or ""),
         "law_name": rule.get("law_name") or "", "law_article": rule.get("law_article") or "",
-        "description": desc, "obligation_summary": desc,
+        "description": desc,
+        "obligation_summary": obl_summary,
+        "remarks": remarks_txt,
         "appointment_target": APPOINTMENT_TARGET_MAP.get(target_code, target_code),
         "qualification_required": rule.get("qualification_type") or "",
         "inspection_cycle": cycle_label,

--- a/routers/legal_engine_v510.py
+++ b/routers/legal_engine_v510.py
@@ -332,7 +332,7 @@ async def diagnose_step1_v510(body: DiagnoseStep1Body):
 
     key_obligations: List[str] = []
     for x in applicable[:20]:
-        t = (x.get("obligation_summary") or x.get("remarks") or "").strip()
+        t = (x.get("remarks") or x.get("obligation_summary") or "").strip()
         if t and t not in key_obligations:
             key_obligations.append(t)
 
@@ -343,6 +343,8 @@ async def diagnose_step1_v510(body: DiagnoseStep1Body):
             "law_name":    x.get("law_name") or "",
             "law_article": x.get("law_article") or "",
             "obligation":  (x.get("obligation_summary") or x.get("remarks") or "").strip(),
+            "remarks":     (x.get("remarks") or "").strip(),
+            "obligation_summary": (x.get("obligation_summary") or "").strip(),
         })
 
     result_data = {

--- a/services/law_context_builder.py
+++ b/services/law_context_builder.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from db.supabase_client import get_supabase
+
+
+def _parse_article_number(law_article: str) -> Optional[int]:
+    if not law_article:
+        return None
+    digits = "".join(ch for ch in str(law_article) if ch.isdigit())
+    if not digits:
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None
+
+
+def _render_article_text(article: Dict) -> str:
+    lines: List[str] = []
+    title = (article.get("article_title") or "").strip()
+    no = article.get("article_no")
+    article_head = f"제{no}조"
+    if title:
+        article_head += f" ({title})"
+    lines.append(article_head)
+    body = (article.get("article_text") or "").strip()
+    if body:
+        lines.append(body)
+
+    supabase = get_supabase()
+    para_res = (
+        supabase.table("law_paragraph")
+        .select("id, paragraph_no, paragraph_text")
+        .eq("article_id", article["id"])
+        .order("paragraph_no")
+        .execute()
+    )
+    for p in para_res.data or []:
+        p_no = p.get("paragraph_no")
+        p_text = (p.get("paragraph_text") or "").strip()
+        if p_text:
+            lines.append(f"  {p_no}. {p_text}")
+        item_res = (
+            supabase.table("law_item")
+            .select("item_no, item_text")
+            .eq("paragraph_id", p["id"])
+            .order("item_no")
+            .execute()
+        )
+        for it in item_res.data or []:
+            i_no = it.get("item_no")
+            i_text = (it.get("item_text") or "").strip()
+            if i_text:
+                lines.append(f"    {i_no}. {i_text}")
+    return "\n".join(lines).strip()
+
+
+async def build_full_context(law_name: str, law_article: str, article_id: str = None) -> str:
+    """
+    법령 원문 풀 컨텍스트 조립:
+    1) 본조 전문, 2) 시행령 관련 조문, 3) 별표/서식 목록, 4) 벌칙 조항.
+    """
+    supabase = get_supabase()
+    parts: List[str] = []
+
+    law_res = (
+        supabase.table("law_master")
+        .select("id, law_name")
+        .eq("law_name", law_name)
+        .eq("is_active", True)
+        .limit(1)
+        .execute()
+    )
+    if not law_res.data:
+        return ""
+    law_id = law_res.data[0]["id"]
+
+    ver_res = (
+        supabase.table("law_version")
+        .select("id")
+        .eq("law_id", law_id)
+        .eq("is_current", True)
+        .limit(1)
+        .execute()
+    )
+    if not ver_res.data:
+        return ""
+    version_id = ver_res.data[0]["id"]
+
+    # 1) 본조 전문
+    target_article = None
+    if article_id:
+        a_res = (
+            supabase.table("law_article")
+            .select("id, article_no, article_title, article_text")
+            .eq("id", article_id)
+            .limit(1)
+            .execute()
+        )
+        if a_res.data:
+            target_article = a_res.data[0]
+    if not target_article:
+        article_no_int = _parse_article_number(law_article)
+        if article_no_int is not None:
+            a_res = (
+                supabase.table("law_article")
+                .select("id, article_no, article_title, article_text")
+                .eq("law_version_id", version_id)
+                .eq("article_no", article_no_int)
+                .limit(1)
+                .execute()
+            )
+            if a_res.data:
+                target_article = a_res.data[0]
+
+    if target_article:
+        parts.append("[본조 전문]\n" + _render_article_text(target_article))
+
+    # 2) 시행령 관련 조문 (같은 조번호 우선, 없으면 처음 3개)
+    decree_name = f"{law_name} 시행령"
+    decree_master = (
+        supabase.table("law_master")
+        .select("id, law_name")
+        .eq("law_name", decree_name)
+        .eq("is_active", True)
+        .limit(1)
+        .execute()
+    )
+    if decree_master.data:
+        decree_ver = (
+            supabase.table("law_version")
+            .select("id")
+            .eq("law_id", decree_master.data[0]["id"])
+            .eq("is_current", True)
+            .limit(1)
+            .execute()
+        )
+        if decree_ver.data:
+            decree_vid = decree_ver.data[0]["id"]
+            article_no_int = _parse_article_number(law_article)
+            decree_articles: List[Dict] = []
+            if article_no_int is not None:
+                same_res = (
+                    supabase.table("law_article")
+                    .select("id, article_no, article_title, article_text")
+                    .eq("law_version_id", decree_vid)
+                    .eq("article_no", article_no_int)
+                    .limit(3)
+                    .execute()
+                )
+                decree_articles = same_res.data or []
+            if not decree_articles:
+                any_res = (
+                    supabase.table("law_article")
+                    .select("id, article_no, article_title, article_text")
+                    .eq("law_version_id", decree_vid)
+                    .order("article_no_sort")
+                    .limit(3)
+                    .execute()
+                )
+                decree_articles = any_res.data or []
+            if decree_articles:
+                rendered = []
+                for a in decree_articles:
+                    rendered.append(_render_article_text(a))
+                parts.append("[시행령 관련 조문]\n" + "\n\n".join(rendered))
+
+            # 3) 별표/서식 목록 (시행령 포함)
+            att_res = (
+                supabase.table("law_attachment")
+                .select("attachment_no, title")
+                .eq("law_version_id", decree_vid)
+                .order("attachment_no")
+                .limit(20)
+                .execute()
+            )
+            if att_res.data:
+                att_lines = []
+                for a in att_res.data:
+                    no = a.get("attachment_no") or "-"
+                    title = (a.get("title") or "").strip()
+                    att_lines.append(f"- [{no}] {title}")
+                parts.append("[시행령 별표/서식 목록]\n" + "\n".join(att_lines))
+
+    # 본법 별표/서식
+    att_main = (
+        supabase.table("law_attachment")
+        .select("attachment_no, title")
+        .eq("law_version_id", version_id)
+        .order("attachment_no")
+        .limit(20)
+        .execute()
+    )
+    if att_main.data:
+        att_lines = []
+        for a in att_main.data:
+            no = a.get("attachment_no") or "-"
+            title = (a.get("title") or "").strip()
+            att_lines.append(f"- [{no}] {title}")
+        parts.append("[본법 별표/서식 목록]\n" + "\n".join(att_lines))
+
+    # 4) 벌칙 조항
+    penal_like = (
+        supabase.table("law_article")
+        .select("id, article_no, article_title, article_text")
+        .eq("law_version_id", version_id)
+        .or_("article_title.ilike.%벌칙%,article_title.ilike.%과태료%,article_title.ilike.%벌금%,article_title.ilike.%양벌%")
+        .order("article_no_sort")
+        .limit(5)
+        .execute()
+    )
+    if penal_like.data:
+        penal_blocks = []
+        for a in penal_like.data:
+            penal_blocks.append(_render_article_text(a))
+        parts.append("[벌칙 조항]\n" + "\n\n".join(penal_blocks))
+
+    return "\n\n".join(p for p in parts if p).strip()

--- a/sql/20260420_master_rules_add_tai_feature_code.sql
+++ b/sql/20260420_master_rules_add_tai_feature_code.sql
@@ -1,0 +1,5 @@
+ALTER TABLE master_building_legal_rules
+  ADD COLUMN IF NOT EXISTS tai_feature_code VARCHAR(50);
+
+COMMENT ON COLUMN master_building_legal_rules.tai_feature_code IS
+  'TAI 기능 연결: APPOINTMENT/INSPECTION/REPORT/EDUCATION/DOCUMENT/FIX/CHECKLIST';

--- a/templates/diagnosis_report_paid.html
+++ b/templates/diagnosis_report_paid.html
@@ -683,7 +683,7 @@ tr:last-child td { border-bottom: none; }
         <tr>
           <td><span class="ob ob-{{ r.obligation_type }}">{{ r.ob_label }}</span></td>
           <td>{{ r.law_article }}</td>
-          <td>{{ r.obligation_summary }}</td>
+          <td>{{ r.remarks or r.obligation_summary }}</td>
           <td>{{ r.inspection_cycle or '–' }}</td>
           <td>{{ r.submit_org_label or '–' }}</td>
         </tr>
@@ -754,7 +754,7 @@ tr:last-child td { border-bottom: none; }
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
         <td><span class="ob ob-{{ r.obligation_type }}">{{ r.ob_label }}</span></td>
-        <td>{{ r.obligation_summary }}</td>
+        <td>{{ r.remarks or r.obligation_summary }}</td>
         <td style="color: var(--red); font-weight: 700;">{{ r.penalty_summary }}</td>
       </tr>
       {% endfor %}
@@ -889,7 +889,7 @@ tr:last-child td { border-bottom: none; }
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
         <td><span class="ob ob-{{ r.obligation_type }}">{{ r.ob_label }}</span></td>
-        <td>{{ r.obligation_summary }}</td>
+        <td>{{ r.remarks or r.obligation_summary }}</td>
         <td>{{ r.inspection_cycle or '–' }}</td>
         <td>{{ r.submit_org_label or '–' }}</td>
       </tr>
@@ -938,7 +938,7 @@ tr:last-child td { border-bottom: none; }
         <td style="text-align:center; color: var(--sub);">{{ loop.index }}</td>
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
-        <td>{{ r.obligation_summary }}</td>
+        <td>{{ r.remarks or r.obligation_summary }}</td>
         <td><strong>{{ r.inspection_cycle or '–' }}</strong></td>
         <td style="font-size: 7pt;">{{ r.cycle_base_guide or '–' }}</td>
         <td>{{ r.submit_org_label or '–' }}</td>
@@ -985,7 +985,7 @@ tr:last-child td { border-bottom: none; }
       {% for r in appointment_rules %}
       <tr class="no-break">
         <td style="text-align:center; color: var(--sub);">{{ loop.index }}</td>
-        <td><strong>{{ r.obligation_summary }}</strong></td>
+        <td><strong>{{ r.remarks or r.obligation_summary }}</strong></td>
         <td>{{ r.law_name }}</td>
         <td>{{ r.law_article }}</td>
         <td>{{ r.qualification_required or '–' }}</td>


### PR DESCRIPTION
## 변경 사항

### 신규 파일
- `services/law_context_builder.py` — 법령 원문 풀세트 조립 (본조+시행령+별표+벌칙)

### 보강
- `routers/law_rule_generator.py` (34KB→46KB)
  - 시스템 프롬프트: condition_code 12→24개, 출력 필드 13→30개+
  - few-shot 예시, submit_org_code 한글 매핑
  - POST /validate-master 신규 (무결성 검증)
  - POST /reparse-master 신규 (Sonnet으로 빈칸 보강)
  - _build_master_payload 30개+ 필드 대응

### DB
- `sql/20260420_master_rules_add_tai_feature_code.sql` — tai_feature_code 컬럼 (적용 완료)

### 문서
- `docs/law-engine-enhancement-workorder.md` v2.1
- `docs/session-handoff-20260420-v4.md` v4.1
- `docs/cursor-prompt-law-engine.md`
- `docs/claude-code-prompt-law-engine.md`

## 테스트
- py_compile 통과
- validate-master, reparse-master 배포 후 테스트 예정

Closes #24 (Phase 1~2)