### PR TITLE
fix: cascade 삭제 FK 누락 보완 (Pilot 1 발견)

### DIFF
--- a/routers/law_collector.py
+++ b/routers/law_collector.py
@@ -214,6 +214,53 @@ def _nullify_dependent_article_refs(supabase: Any, art_ids: List[str]) -> None:
             print(f"[law_collector] {table}.{col} nullify skip: {e}")
 
 
+def _clear_law_version_fk_dependents(supabase: Any, version_id: str) -> None:
+    """law_version 삭제 직전: 해당 version_id 를 참조하는 테이블 정리 (환경별 스키마 차이는 try/except)."""
+    try:
+        supabase.table("law_parsing_result").delete().eq("law_version_id", version_id).execute()
+    except Exception as e:
+        print(f"[law_collector] law_parsing_result delete skip: {e}")
+
+    try:
+        supabase.table("law_attachment").delete().eq("law_version_id", version_id).execute()
+    except Exception as e:
+        print(f"[law_collector] law_attachment delete skip: {e}")
+
+    try:
+        supabase.table("law_update_tracking").update({
+            "last_collected_version_id": None,
+        }).eq("last_collected_version_id", version_id).execute()
+    except Exception as e:
+        print(f"[law_collector] law_update_tracking nullify skip: {e}")
+
+    try:
+        supabase.table("law_article_diff").delete().eq("new_version_id", version_id).execute()
+    except Exception as e:
+        print(f"[law_collector] law_article_diff delete new_version_id skip: {e}")
+    try:
+        supabase.table("law_article_diff").delete().eq("old_version_id", version_id).execute()
+    except Exception as e:
+        print(f"[law_collector] law_article_diff delete old_version_id skip: {e}")
+
+    try:
+        supabase.table("law_change_log").update({"new_version_id": None}).eq(
+            "new_version_id", version_id
+        ).execute()
+    except Exception as e:
+        print(f"[law_collector] law_change_log new_version_id nullify skip: {e}")
+    try:
+        supabase.table("law_change_log").update({"old_version_id": None}).eq(
+            "old_version_id", version_id
+        ).execute()
+    except Exception as e:
+        print(f"[law_collector] law_change_log old_version_id nullify skip: {e}")
+
+    try:
+        supabase.table("law_rule_source_map").delete().eq("law_version_id", version_id).execute()
+    except Exception as e:
+        print(f"[law_collector] law_rule_source_map delete skip: {e}")
+
+
 def delete_law_version_cascade_for_recollect(supabase: Any, version_id: str) -> None:
     """force 재수집: 버전 하위 전부 삭제 후 law_version 행 제거."""
     arts = supabase.table("law_article").select("id").eq("law_version_id", version_id).execute().data or []
@@ -232,6 +279,7 @@ def delete_law_version_cascade_for_recollect(supabase: Any, version_id: str) -> 
             supabase.table("law_item").delete().in_("paragraph_id", para_ids).execute()
         supabase.table("law_paragraph").delete().in_("article_id", art_ids).execute()
         supabase.table("law_article").delete().eq("law_version_id", version_id).execute()
+    _clear_law_version_fk_dependents(supabase, version_id)
     supabase.table("law_content_raw").delete().eq("law_version_id", version_id).execute()
     supabase.table("law_version").delete().eq("id", version_id).execute()
 

--- a/scripts/reconnect_fk.py
+++ b/scripts/reconnect_fk.py
@@ -10,7 +10,7 @@
   2) 현행 law_version id 조회
   3) map 행별로 new_article_id 가 비어 있으면, 동일 article_internal_key 의
      현행 버전 law_article id 를 찾아 채움
-  4) law_rule_drafts.article_id, inspection_set_items.law_article_id 업데이트
+  4) law_rule_drafts.article_id 업데이트 (inspection_set_items.law_article_id 는 스키마에 없을 수 있어 try/except)
 """
 from __future__ import annotations
 
@@ -52,8 +52,13 @@ def reconnect_for_law(law_name: str) -> dict:
         sb.table("law_article_key_map").update({"new_article_id": new_id}).eq("id", row["id"]).execute()
         d = sb.table("law_rule_drafts").update({"article_id": new_id}).eq("article_id", old_id).execute()
         updated_drafts += len(d.data or [])
-        i = sb.table("inspection_set_items").update({"law_article_id": new_id}).eq("law_article_id", old_id).execute()
-        updated_items += len(i.data or [])
+        try:
+            i = sb.table("inspection_set_items").update({"law_article_id": new_id}).eq(
+                "law_article_id", old_id
+            ).execute()
+            updated_items += len(i.data or [])
+        except Exception:
+            pass
 
     return {
         "law_name": law_name,

--- a/tests/test_law_collector.py
+++ b/tests/test_law_collector.py
@@ -12,6 +12,13 @@ from routers.law_collector import (
 )
 
 
+def _generic_version_dep_mock() -> MagicMock:
+    m = MagicMock()
+    m.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    m.update.return_value.eq.return_value.execute.return_value = MagicMock()
+    return m
+
+
 SAMPLE_XML_CLEAN = """<?xml version="1.0" encoding="UTF-8"?>
 <법령>
   <기본정보>
@@ -204,6 +211,12 @@ def test_force_recollect_deletes_existing_articles():
         "law_version": law_version,
         "law_rule_drafts": law_rule_drafts,
         "inspection_set_items": inspection_set_items,
+        "law_parsing_result": _generic_version_dep_mock(),
+        "law_attachment": _generic_version_dep_mock(),
+        "law_update_tracking": _generic_version_dep_mock(),
+        "law_article_diff": _generic_version_dep_mock(),
+        "law_change_log": _generic_version_dep_mock(),
+        "law_rule_source_map": _generic_version_dep_mock(),
     }
     sb = MagicMock()
     sb.table.side_effect = lambda name, *a, **k: tables[name]
@@ -215,10 +228,11 @@ def test_force_recollect_deletes_existing_articles():
     assert "law_paragraph" in names
     assert "law_version" in names
     assert "law_content_raw" in names
+    assert "law_parsing_result" in names
+    assert "law_attachment" in names
 
 
 def test_delete_cascade_no_articles():
-    sb = MagicMock()
     law_article = MagicMock()
     law_article.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
     law_content_raw = MagicMock()
@@ -229,7 +243,61 @@ def test_delete_cascade_no_articles():
         "law_article": law_article,
         "law_content_raw": law_content_raw,
         "law_version": law_version,
+        "law_parsing_result": _generic_version_dep_mock(),
+        "law_attachment": _generic_version_dep_mock(),
+        "law_update_tracking": _generic_version_dep_mock(),
+        "law_article_diff": _generic_version_dep_mock(),
+        "law_change_log": _generic_version_dep_mock(),
+        "law_rule_source_map": _generic_version_dep_mock(),
     }
+    sb = MagicMock()
     sb.table.side_effect = lambda name, *a, **k: tables[name]
     delete_law_version_cascade_for_recollect(sb, "ver-empty")
     assert law_version.delete.called
+
+
+def test_cascade_delete_handles_law_parsing_result():
+    law_parsing_result = MagicMock()
+    law_parsing_result.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    law_attachment = _generic_version_dep_mock()
+    law_article = MagicMock()
+    law_article.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    tables = {
+        "law_article": law_article,
+        "law_parsing_result": law_parsing_result,
+        "law_attachment": law_attachment,
+        "law_update_tracking": _generic_version_dep_mock(),
+        "law_article_diff": _generic_version_dep_mock(),
+        "law_change_log": _generic_version_dep_mock(),
+        "law_rule_source_map": _generic_version_dep_mock(),
+        "law_content_raw": _generic_version_dep_mock(),
+        "law_version": _generic_version_dep_mock(),
+    }
+    sb = MagicMock()
+    sb.table.side_effect = lambda name, *a, **k: tables[name]
+    delete_law_version_cascade_for_recollect(sb, "vid-parsing")
+    law_parsing_result.delete.assert_called()
+    law_parsing_result.delete.return_value.eq.assert_called_with("law_version_id", "vid-parsing")
+
+
+def test_cascade_delete_handles_law_attachment():
+    law_attachment = MagicMock()
+    law_attachment.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    law_article = MagicMock()
+    law_article.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[])
+    tables = {
+        "law_article": law_article,
+        "law_parsing_result": _generic_version_dep_mock(),
+        "law_attachment": law_attachment,
+        "law_update_tracking": _generic_version_dep_mock(),
+        "law_article_diff": _generic_version_dep_mock(),
+        "law_change_log": _generic_version_dep_mock(),
+        "law_rule_source_map": _generic_version_dep_mock(),
+        "law_content_raw": _generic_version_dep_mock(),
+        "law_version": _generic_version_dep_mock(),
+    }
+    sb = MagicMock()
+    sb.table.side_effect = lambda name, *a, **k: tables[name]
+    delete_law_version_cascade_for_recollect(sb, "vid-attach")
+    law_attachment.delete.assert_called()
+    law_attachment.delete.return_value.eq.assert_called_with("law_version_id", "vid-attach")


### PR DESCRIPTION
## 🎯 Pilot 1 실행 중 발견된 cascade 삭제 FK 누락 보완

### 배경
Pilot 1 (산업안전보건법) 재수집 실행 중, `delete_law_version_cascade_for_recollect()`가 **6개 FK 테이블을 놓쳐서** `law_version` 삭제 실패. 수동 복구로 Pilot 1 완료했으나, Pilot 2 (건설 3법령 재수집)에서 같은 에러 반복 방지를 위해 구조적 보완.

### 발견된 FK 6개 (실측)

| 테이블 | 컬럼 | NULL 가능 | 처리 방식 |
|---|---|---|---|
| `law_parsing_result` | `law_version_id` | NOT NULL | DELETE (재수집 후 재생성) |
| `law_attachment` | `law_version_id` | NOT NULL | DELETE (현재 orphan 파편) |
| `law_update_tracking` | `last_collected_version_id` | YES | UPDATE SET NULL (tracking 유지) |
| `law_article_diff` | `new_version_id`, `old_version_id` | - | DELETE (방어적) |
| `law_change_log` | `new_version_id`, `old_version_id` | - | UPDATE SET NULL (history 보존) |
| `law_rule_source_map` | `law_version_id` | - | DELETE |

또한 `scripts/reconnect_fk.py`가 `inspection_set_items.law_article_id` 컬럼을 참조하나 실제 DB 스키마에 해당 컬럼이 없어 `PGRST204` 에러 발생 → try/except로 skip 처리.

### 변경 내역

**`routers/law_collector.py`**:
- 새 함수 `_clear_law_version_fk_dependents(supabase, version_id)` 추가
  - 위 6개 테이블 모두 try/except로 안전 처리
  - 환경별 스키마 차이에 방어
- `delete_law_version_cascade_for_recollect()` 흐름 변경:
  ```
  law_article + 하위 삭제 → _clear_law_version_fk_dependents → law_content_raw → law_version
  ```

**`scripts/reconnect_fk.py`**:
- `inspection_set_items` 블록 try/except로 감싸 컬럼 부재 시 조용히 skip

**`tests/test_law_collector.py`**:
- `_generic_version_dep_mock()` 헬퍼 추가 (cascade 경로 전체 mock)
- `test_cascade_delete_handles_law_parsing_result` 추가
- `test_cascade_delete_handles_law_attachment` 추가
- `test_force_recollect_deletes_existing_articles` 업데이트

### 검증
```
pytest tests/ → 89 passed (기존 87 + 신규 2)
소요 시간: 약 101s
```

### Pilot 1 성과 기록 (참고)
산업안전보건법 재수집 결과:
- valid_pct: **33.5%** (68/203, 기준 ≥30%)
- article_rows: **203** (dedupe로 208→203)
- article_internal_key: **203개 전부 고유** (완벽 dedupe)
- drafts FK 무결성: 48/48 복구
- 법령개정 알림 파이프라인 영향: 0건
- **6/6 Go/No-Go 기준 통과**

### 🔗 관련
- **Refs #37** (Pilot 1 후속 보완 — 이 PR로 닫지 않음. Pilot 2, 3 남음)
- 이전 PR: #39 (Pilot 1 초기 구현)

### 다음 단계
이 PR 머지 후 → Pilot 2 (건축법/건축법 시행령/건설기술 진흥법 재수집) 진입