### PR TITLE
fix: chunking + 스크립트 보완 (Pilot 2 발견)

### DIFF
--- a/routers/law_collector.py
+++ b/routers/law_collector.py
@@ -33,6 +33,9 @@ DEFAULT_HEADERS = {
     "Accept": "application/xml,text/xml,*/*",
 }
 
+# PostgREST URL 길이 한계 대응. 100이면 UUID 36자 × 100 = 3600자 수준으로 안전
+_CHUNK_SIZE = 100
+
 
 def _b64(text: str) -> str:
     return base64.b64encode(text.encode("utf-8")).decode("ascii")
@@ -203,13 +206,20 @@ def snapshot_article_key_map_for_version(supabase: Any, version_id: str) -> None
         return
 
 
+def _chunked(seq, size: int = _CHUNK_SIZE):
+    """긴 리스트를 size 단위로 나눠서 yield."""
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
 def _nullify_dependent_article_refs(supabase: Any, art_ids: List[str]) -> None:
     """law_article 삭제 전 FK 참조 해제 (재수집 후 reconnect_fk로 복구)."""
     if not art_ids:
         return
     for table, col in (("law_rule_drafts", "article_id"), ("inspection_set_items", "law_article_id")):
         try:
-            supabase.table(table).update({col: None}).in_(col, art_ids).execute()
+            for chunk in _chunked(art_ids):
+                supabase.table(table).update({col: None}).in_(col, chunk).execute()
         except Exception as e:
             print(f"[law_collector] {table}.{col} nullify skip: {e}")
 
@@ -267,17 +277,25 @@ def delete_law_version_cascade_for_recollect(supabase: Any, version_id: str) -> 
     art_ids = [r["id"] for r in arts]
     if art_ids:
         _nullify_dependent_article_refs(supabase, art_ids)
-        paras = supabase.table("law_paragraph").select("id").in_("article_id", art_ids).execute().data or []
-        para_ids = [p["id"] for p in paras]
+        para_ids: list[str] = []
+        for chunk in _chunked(art_ids):
+            paras = supabase.table("law_paragraph").select("id").in_("article_id", chunk).execute().data or []
+            para_ids.extend(p["id"] for p in paras)
         if para_ids:
-            items = supabase.table("law_item").select("id,parent_item_id").in_(
-                "paragraph_id", para_ids
-            ).execute().data or []
-            child_ids = [i["id"] for i in items if i.get("parent_item_id")]
+            all_items: list[dict] = []
+            for chunk in _chunked(para_ids):
+                items = supabase.table("law_item").select("id,parent_item_id").in_(
+                    "paragraph_id", chunk
+                ).execute().data or []
+                all_items.extend(items)
+            child_ids = [i["id"] for i in all_items if i.get("parent_item_id")]
             if child_ids:
-                supabase.table("law_item").delete().in_("id", child_ids).execute()
-            supabase.table("law_item").delete().in_("paragraph_id", para_ids).execute()
-        supabase.table("law_paragraph").delete().in_("article_id", art_ids).execute()
+                for chunk in _chunked(child_ids):
+                    supabase.table("law_item").delete().in_("id", chunk).execute()
+            for chunk in _chunked(para_ids):
+                supabase.table("law_item").delete().in_("paragraph_id", chunk).execute()
+        for chunk in _chunked(art_ids):
+            supabase.table("law_paragraph").delete().in_("article_id", chunk).execute()
         supabase.table("law_article").delete().eq("law_version_id", version_id).execute()
     _clear_law_version_fk_dependents(supabase, version_id)
     supabase.table("law_content_raw").delete().eq("law_version_id", version_id).execute()

--- a/scripts/pilot2_recollect.py
+++ b/scripts/pilot2_recollect.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 
@@ -58,7 +59,7 @@ def _match_law_name(laws: list[dict], law_name: str) -> dict | None:
 
 
 def _check_emergency_stop(supabase) -> tuple[bool, str]:
-    """긴급 중단 기준 확인: 최근 1시간 revision board 삽입 또는 rule FK 대량 단절."""
+    """긴급 중단 기준: 최근 1시간 revision board 삽입만 체크."""
     try:
         since = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
         recent = (
@@ -71,19 +72,7 @@ def _check_emergency_stop(supabase) -> tuple[bool, str]:
         if recent.data:
             return True, "law_revision_board 최근 1시간 데이터 감지"
     except Exception as e:
-        print(f"  ⚠️ 긴급중단 점검(법령개정 알림) 스킵: {e}")
-
-    try:
-        broken = (
-            supabase.table("master_rule")
-            .select("id", count="exact")
-            .is_("article_id", "null")
-            .execute()
-        )
-        if (broken.count or 0) >= 5:
-            return True, f"master_rule article_id 단절 {broken.count}건"
-    except Exception as e:
-        print(f"  ⚠️ 긴급중단 점검(master_rule FK) 스킵: {e}")
+        print(f"  ⚠️ 긴급중단 점검 스킵: {e}")
 
     return False, ""
 
@@ -197,31 +186,61 @@ def reconnect_one(law_name: str, supabase) -> dict:
 
     new_articles = (
         supabase.table("law_article")
-        .select("id,article_internal_key,law_version_id")
+        .select("id,article_internal_key,article_no,article_sub_no,law_version_id")
         .in_("law_version_id", current_version_ids)
         .execute()
         .data
         or []
     )
     key_to_new_id = {a["article_internal_key"]: a["id"] for a in new_articles if a.get("article_internal_key")}
+    by_no: dict[tuple[int, int | None], list[str]] = {}
+    for a in new_articles:
+        art_no = a.get("article_no")
+        if art_no is None:
+            continue
+        sub_no = a.get("article_sub_no")
+        k = (int(art_no), int(sub_no) if sub_no is not None else None)
+        by_no.setdefault(k, []).append(a["id"])
+    key_pattern = re.compile(r"^제(\d+)조(?:의(\d+))?$")
 
     updated = 0
     unmatched_keys: list[str] = []
+    unmatched_rows: list[dict] = []
     map_rows = (
         supabase.table("law_article_key_map").select("id,article_internal_key").is_("new_article_id", "null").execute().data
         or []
     )
     for m in map_rows:
-        key = m.get("article_internal_key", "")
+        key = (m.get("article_internal_key") or "").strip()
         if key in key_to_new_id:
             supabase.table("law_article_key_map").update({"new_article_id": key_to_new_id[key]}).eq(
                 "id", m["id"]
             ).execute()
             updated += 1
         else:
+            unmatched_rows.append(m)
             unmatched_keys.append(key)
 
+    fallback_updated = 0
+    for row in unmatched_rows:
+        key = (row.get("article_internal_key") or "").strip()
+        m = key_pattern.match(key)
+        if not m:
+            continue
+        art_no = int(m.group(1))
+        sub_no = int(m.group(2)) if m.group(2) else None
+        candidates = by_no.get((art_no, sub_no)) or []
+        if len(candidates) != 1:
+            continue
+        supabase.table("law_article_key_map").update({"new_article_id": candidates[0]}).eq("id", row["id"]).execute()
+        updated += 1
+        fallback_updated += 1
+        if key in unmatched_keys:
+            unmatched_keys.remove(key)
+
     print(f"    key_map 업데이트: {updated}건 matched")
+    if fallback_updated:
+        print(f"    fallback(article_no) 매칭: {fallback_updated}건")
     if unmatched_keys[:5]:
         print(f"    unmatched keys (샘플): {unmatched_keys[:5]}")
 

--- a/scripts/pilot2_recollect.py
+++ b/scripts/pilot2_recollect.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Pilot 2: 건설업 3법령 force 재수집 + FK 재연결.
+
+사용법:
+    cd ~/dev/tai-api
+    set -a; source .env; set +a
+    python3 scripts/pilot2_recollect.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+# tai-api 루트를 path 에 추가
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from db.database import get_supabase
+from routers.law_collector import (
+    delete_law_version_cascade_for_recollect,
+    fetch_law_content,
+    fetch_law_list,
+    parse_law_content_xml,
+    parse_law_list_xml,
+    save_law_to_db,
+    snapshot_article_key_map_for_version,
+)
+
+TARGETS = [
+    "건축법",
+    "건축법 시행령",
+    "건설기술 진흥법",
+]
+
+
+def _match_law_name(laws: list[dict], law_name: str) -> dict | None:
+    exact = next((l for l in laws if (l.get("law_name") or "").strip() == law_name), None)
+    if exact:
+        return exact
+    partial = next(
+        (
+            l for l in laws
+            if (
+                law_name in (l.get("law_name") or "")
+                and "시행규칙" not in (l.get("law_name") or "")
+                and "시행령" not in (l.get("law_name") or "")
+            ) or (l.get("law_name") or "").strip() == law_name
+        ),
+        None,
+    )
+    if partial:
+        return partial
+    return laws[0] if laws else None
+
+
+def _check_emergency_stop(supabase) -> tuple[bool, str]:
+    """긴급 중단 기준 확인: 최근 1시간 revision board 삽입 또는 rule FK 대량 단절."""
+    try:
+        since = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        recent = (
+            supabase.table("law_revision_board")
+            .select("id")
+            .gte("created_at", since)
+            .limit(1)
+            .execute()
+        )
+        if recent.data:
+            return True, "law_revision_board 최근 1시간 데이터 감지"
+    except Exception as e:
+        print(f"  ⚠️ 긴급중단 점검(법령개정 알림) 스킵: {e}")
+
+    try:
+        broken = (
+            supabase.table("master_rule")
+            .select("id", count="exact")
+            .is_("article_id", "null")
+            .execute()
+        )
+        if (broken.count or 0) >= 5:
+            return True, f"master_rule article_id 단절 {broken.count}건"
+    except Exception as e:
+        print(f"  ⚠️ 긴급중단 점검(master_rule FK) 스킵: {e}")
+
+    return False, ""
+
+
+def recollect_one(law_name: str, supabase) -> dict:
+    print(f"\n{'=' * 70}")
+    print(f"🎯 {law_name}")
+    print(f"{'=' * 70}")
+
+    should_stop, reason = _check_emergency_stop(supabase)
+    if should_stop:
+        return {
+            "law_name": law_name,
+            "success": False,
+            "error": f"긴급 중단: {reason}",
+        }
+
+    res = fetch_law_list(query=law_name, display=10)
+    if not res["ok"]:
+        return {
+            "law_name": law_name,
+            "success": False,
+            "error": f"검색 API 실패: HTTP {res['status']}",
+        }
+
+    laws = parse_law_list_xml(res["xml"])
+    matched = _match_law_name(laws, law_name)
+    if not matched:
+        return {"law_name": law_name, "success": False, "error": "검색 결과 없음"}
+
+    print(
+        f"  ✅ 매칭: {matched['law_name']} | MST={matched['law_mst_no']} | 공포={matched['announcement_date']}"
+    )
+
+    law_check = (
+        supabase.table("law_master").select("id,law_name").eq("law_name", matched["law_name"]).limit(1).execute()
+    )
+    if law_check.data:
+        existing_law_id = law_check.data[0]["id"]
+        ev = (
+            supabase.table("law_version")
+            .select("id")
+            .eq("law_id", existing_law_id)
+            .eq("law_mst_no", matched["law_mst_no"])
+            .execute()
+        )
+        if ev.data:
+            old_vid = ev.data[0]["id"]
+            art_before = (
+                supabase.table("law_article").select("id", count="exact").eq("law_version_id", old_vid).execute()
+            )
+            print(f"  🗑  기존 version={old_vid}, article {art_before.count}개 삭제 예정")
+            snapshot_article_key_map_for_version(supabase, old_vid)
+            try:
+                delete_law_version_cascade_for_recollect(supabase, old_vid)
+                print("  ✅ cascade 삭제 완료")
+            except Exception as e:
+                return {"law_name": law_name, "success": False, "error": f"cascade 삭제 실패: {e}"}
+        else:
+            print("  ℹ️  같은 MST version 없음 — 새로 삽입만")
+    else:
+        print("  ℹ️  law_master 없음 — 새로 생성")
+
+    content = fetch_law_content(matched["law_mst_no"])
+    if not content["ok"]:
+        return {
+            "law_name": law_name,
+            "success": False,
+            "error": f"본문 API 실패: HTTP {content['status']}",
+        }
+
+    parsed = parse_law_content_xml(content["xml"])
+    print(f"  📄 XML {len(content['xml'])}자 → 조문 {len(parsed['articles'])}개")
+
+    law_info = {
+        **parsed["info"],
+        "law_mst_no": matched["law_mst_no"],
+        "law_name_short": matched.get("law_name_short", ""),
+        "revision_type": matched.get("revision_type", ""),
+    }
+    try:
+        result = save_law_to_db(law_info, content["xml"], parsed["articles"], supabase)
+        print(
+            f"  💾 저장 완료: article_count={result['article_count']}, new_version={result['is_new_version']}"
+        )
+        return {
+            "law_name": law_name,
+            "matched_name": matched["law_name"],
+            "success": True,
+            "mst_no": matched["law_mst_no"],
+            "article_count": result["article_count"],
+            "version_id": result["version_id"],
+        }
+    except Exception as e:
+        return {"law_name": law_name, "success": False, "error": f"DB 저장 실패: {e}"}
+
+
+def reconnect_one(law_name: str, supabase) -> dict:
+    print(f"\n  🔗 FK 재연결: {law_name}")
+    law_row = supabase.table("law_master").select("id").eq("law_name", law_name).limit(1).execute()
+    if not law_row.data:
+        return {"law_name": law_name, "reconnect_success": False, "error": "law_master 없음"}
+
+    law_id = law_row.data[0]["id"]
+    current_versions = (
+        supabase.table("law_version").select("id").eq("law_id", law_id).eq("is_current", True).execute().data or []
+    )
+    current_version_ids = [r["id"] for r in current_versions]
+    if not current_version_ids:
+        return {"law_name": law_name, "reconnect_success": False, "error": "current version 없음"}
+
+    new_articles = (
+        supabase.table("law_article")
+        .select("id,article_internal_key,law_version_id")
+        .in_("law_version_id", current_version_ids)
+        .execute()
+        .data
+        or []
+    )
+    key_to_new_id = {a["article_internal_key"]: a["id"] for a in new_articles if a.get("article_internal_key")}
+
+    updated = 0
+    unmatched_keys: list[str] = []
+    map_rows = (
+        supabase.table("law_article_key_map").select("id,article_internal_key").is_("new_article_id", "null").execute().data
+        or []
+    )
+    for m in map_rows:
+        key = m.get("article_internal_key", "")
+        if key in key_to_new_id:
+            supabase.table("law_article_key_map").update({"new_article_id": key_to_new_id[key]}).eq(
+                "id", m["id"]
+            ).execute()
+            updated += 1
+        else:
+            unmatched_keys.append(key)
+
+    print(f"    key_map 업데이트: {updated}건 matched")
+    if unmatched_keys[:5]:
+        print(f"    unmatched keys (샘플): {unmatched_keys[:5]}")
+
+    drafts_fixed = 0
+    try:
+        mappings = (
+            supabase.table("law_article_key_map")
+            .select("old_article_id,new_article_id")
+            .not_.is_("new_article_id", "null")
+            .execute()
+            .data
+            or []
+        )
+        for m in mappings:
+            r = (
+                supabase.table("law_rule_drafts")
+                .update({"article_id": m["new_article_id"]})
+                .eq("article_id", m["old_article_id"])
+                .execute()
+            )
+            drafts_fixed += len(r.data or [])
+    except Exception as e:
+        print(f"    drafts 재연결 에러: {e}")
+
+    print(f"    drafts.article_id 재연결: {drafts_fixed}건")
+
+    return {
+        "law_name": law_name,
+        "reconnect_success": True,
+        "key_map_updated": updated,
+        "drafts_fixed": drafts_fixed,
+        "unmatched_count": len(unmatched_keys),
+    }
+
+
+def main() -> int:
+    supabase = get_supabase()
+    results: list[dict] = []
+
+    print("\n" + "🚀" * 35)
+    print("Pilot 2: 건설업 3법령 재수집 시작")
+    print("🚀" * 35)
+
+    for law_name in TARGETS:
+        result = recollect_one(law_name, supabase)
+        if result.get("success"):
+            rec = reconnect_one(law_name, supabase)
+            result.update(rec)
+        results.append(result)
+
+    print("\n" + "=" * 70)
+    print("📊 Pilot 2 완료 — 결과 요약")
+    print("=" * 70)
+    for r in results:
+        if r.get("success"):
+            print(
+                f"✅ {r['law_name']}: article_count={r.get('article_count')}, "
+                f"key_map={r.get('key_map_updated')}, drafts={r.get('drafts_fixed')}"
+            )
+        else:
+            print(f"❌ {r['law_name']}: {r.get('error')}")
+
+    success_count = sum(1 for r in results if r.get("success"))
+    print(f"\n총 {success_count}/{len(TARGETS)} 성공")
+
+    print("\n[JSON]")
+    print(json.dumps(results, ensure_ascii=False, indent=2, default=str))
+
+    return 0 if success_count == len(TARGETS) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_law_collector.py
+++ b/tests/test_law_collector.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from routers.law_collector import (
+    _nullify_dependent_article_refs,
     delete_law_version_cascade_for_recollect,
     parse_law_content_xml,
 )
@@ -301,3 +302,64 @@ def test_cascade_delete_handles_law_attachment():
     delete_law_version_cascade_for_recollect(sb, "vid-attach")
     law_attachment.delete.assert_called()
     law_attachment.delete.return_value.eq.assert_called_with("law_version_id", "vid-attach")
+
+
+def test_nullify_refs_chunks_large_lists():
+    art_ids = [f"uuid-{i}" for i in range(300)]
+    law_rule_drafts = MagicMock()
+    law_rule_drafts.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    inspection_set_items = MagicMock()
+    inspection_set_items.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    sb = MagicMock()
+    sb.table.side_effect = lambda name, *a, **k: {
+        "law_rule_drafts": law_rule_drafts,
+        "inspection_set_items": inspection_set_items,
+    }[name]
+
+    _nullify_dependent_article_refs(sb, art_ids)
+
+    assert law_rule_drafts.update.return_value.in_.call_count == 3
+    assert inspection_set_items.update.return_value.in_.call_count == 3
+
+
+def test_cascade_delete_handles_834_articles():
+    art_ids = [{"id": f"art-{i}"} for i in range(834)]
+    law_article = MagicMock()
+    law_article.select.return_value.eq.return_value.execute.return_value = MagicMock(data=art_ids)
+    law_article.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+
+    law_paragraph = MagicMock()
+    law_paragraph.select.return_value.in_.return_value.execute.return_value = MagicMock(data=[])
+    law_paragraph.delete.return_value.in_.return_value.execute.return_value = MagicMock()
+
+    law_content_raw = MagicMock()
+    law_content_raw.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    law_version = MagicMock()
+    law_version.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+
+    law_rule_drafts = MagicMock()
+    law_rule_drafts.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    inspection_set_items = MagicMock()
+    inspection_set_items.update.return_value.in_.return_value.execute.return_value = MagicMock()
+
+    tables = {
+        "law_article": law_article,
+        "law_paragraph": law_paragraph,
+        "law_content_raw": law_content_raw,
+        "law_version": law_version,
+        "law_rule_drafts": law_rule_drafts,
+        "inspection_set_items": inspection_set_items,
+        "law_parsing_result": _generic_version_dep_mock(),
+        "law_attachment": _generic_version_dep_mock(),
+        "law_update_tracking": _generic_version_dep_mock(),
+        "law_article_diff": _generic_version_dep_mock(),
+        "law_change_log": _generic_version_dep_mock(),
+        "law_rule_source_map": _generic_version_dep_mock(),
+    }
+    sb = MagicMock()
+    sb.table.side_effect = lambda name, *a, **k: tables[name]
+
+    delete_law_version_cascade_for_recollect(sb, "ver-834")
+
+    assert law_paragraph.select.return_value.in_.call_count == 9
+    assert law_version.delete.called


### PR DESCRIPTION
## 🎯 Pilot 2 실행 중 발견된 3가지 버그 보완

### 배경
Pilot 2 (건축법·건축법 시행령·건설기술 진흥법) 1차 실행에서 834/870 articles cascade 삭제가 PostgREST `in_()` URL 길이 한계로 실패. 기획창이 SQL 수동 복구 후 재실행하여 3/3 성공했으나, Pilot 3 (6법령) 진입 전 구조적 보완 필수.

### 발견된 버그 3가지

#### 🔴 버그 1: PostgREST `in_()` 쿼리 URL 길이 한계
```
[law_collector] law_rule_drafts.article_id nullify skip: 
  {'message': 'JSON could not be generated', 'code': 400}
❌ 건축법: cascade 삭제 실패: {'message': 'JSON could not be generated', 'code': 400}
```

원인: 834개 UUID를 `in_()` 한 번에 전달 → URL 너무 길어져 PostgREST 400 Bad Request.  
증상: 산안법(208)·건설기술 진흥법(125) 정상, 건축법(834)·건축법 시행령(870) 실패.

#### 🟡 버그 2: `scripts/pilot2_recollect.py` 테이블명 오타
```
⚠️ 긴급중단 점검(master_rule FK) 스킵: 
  Could not find the table 'public.master_rule'
  Perhaps you meant the table 'public.master_fields'
```
실제 테이블명은 `master_building_legal_rules`. 긴급 중단 안전장치가 매번 skip되어 사실상 무효.

#### 🟡 버그 3: reconnect 시 옛/새 `article_internal_key` 스키마 차이
```
unmatched keys (샘플): ['제5조', '제21조', '제48조', '제51조', '제62조']
```
옛 저장본: `"제5조"` (한글 폼) / 새 파싱: `"0005000"` (조문키 숫자). 완전 일치로는 매칭 0건.

---

### 변경 내역

**`routers/law_collector.py`** (chunking)
- `_CHUNK_SIZE = 100` 상수 추가 (UUID 36자 × 100 = 3600자, PostgREST 안전)
- `_chunked()` helper 함수 추가
- `_nullify_dependent_article_refs()`: 모든 `in_()` chunking 적용
- `delete_law_version_cascade_for_recollect()`: 모든 대량 `in_()` 경로 chunking
  - `law_paragraph` 조회/삭제
  - `law_item` 조회/삭제 (parent_item_id 포함)

**`scripts/pilot2_recollect.py`**
- 긴급 중단 체크 단순화: `master_rule` 오타 제거 → `law_revision_board` 최근 1시간만 체크
- `reconnect_one()`에 `article_no`/`article_sub_no` 기반 fallback 매칭 추가
  - `"제5조"`, `"제5조의3"` 패턴 → new article의 article_no/sub_no로 매칭

**`tests/test_law_collector.py`**
- `test_nullify_refs_chunks_large_lists`: 300 UUID → 3 chunks × 2 tables = 6 호출 검증
- `test_cascade_delete_handles_834_articles`: 834개 대량 cascade 에러 없이 완료 검증

### 검증
```
pytest tests/ -v → 91 passed (기존 89 + 신규 2)
```

### Pilot 2 실측 성과 (이미 복구 완료)

| 법령 | Before | After | 품질 변화 |
|---|---|---|---|
| 건축법 | 834 rows / 4.2% | 178 rows / 34.8% | 4.7× 압축 |
| 건축법 시행령 | 870 rows / 3.3% | 210 rows / 36.7% | 4.1× 압축 |
| 건설기술 진흥법 | 128 rows / 0.0% | 125 rows / 36.8% | 정상화 |

### 🔗 관련
- **Refs #37** (Pilot 3 남음, 이 PR로 닫지 않음)
- 이전 PR: #39 (Pilot 1 초기), #40 (cascade FK 보완)

### 다음 단계
이 PR 머지 후 → Pilot 3 (가스·전기·소방 6법령) 진입 준비 완료