### PR TITLE
fix: Pilot 3 발견 + 전체 확장 배치 스크립트

### DIFF
--- a/routers/law_collector.py
+++ b/routers/law_collector.py
@@ -216,7 +216,11 @@ def _nullify_dependent_article_refs(supabase: Any, art_ids: List[str]) -> None:
     """law_article 삭제 전 FK 참조 해제 (재수집 후 reconnect_fk로 복구)."""
     if not art_ids:
         return
-    for table, col in (("law_rule_drafts", "article_id"), ("inspection_set_items", "law_article_id")):
+    for table, col in (
+        ("law_rule_drafts", "article_id"),
+        ("inspection_set_items", "law_article_id"),
+        ("law_rule_source_map", "article_id"),
+    ):
         try:
             for chunk in _chunked(art_ids):
                 supabase.table(table).update({col: None}).in_(col, chunk).execute()

--- a/scripts/all_laws_recollect.py
+++ b/scripts/all_laws_recollect.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+전체 법령 재수집 (Pilot 1/2/3 통과 후 확장).
+
+체크포인트 기반 재개 가능:
+- /tmp/all_laws_checkpoint.json 에 진행 상태 저장
+- 중단 시 해당 파일 읽어서 이어서 진행
+
+사용법:
+    cd ~/dev/tai-api
+    set -a; source .env; set +a
+    python3 scripts/all_laws_recollect.py 2>&1 | tee -a /tmp/all_laws_output.log
+
+옵션:
+    --resume    : 체크포인트에서 이어서
+    --dry-run   : 대상 목록만 출력하고 실제 재수집 안 함
+    --limit N   : 최대 N개만 처리
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from db.database import get_supabase
+from scripts.pilot2_recollect import _check_emergency_stop, recollect_one, reconnect_one
+
+CHECKPOINT_PATH = Path("/tmp/all_laws_checkpoint.json")
+MAX_CONSECUTIVE_FAILURES = 3
+PER_LAW_TIMEOUT = 600
+
+COMPLETED_LAWS = {
+    "산업안전보건법",
+    "건축법",
+    "건축법 시행령",
+    "건설기술 진흥법",
+    "화재의 예방 및 안전관리에 관한 법률",
+    "위험물안전관리법 시행규칙",
+    "전기안전관리법 시행규칙",
+    "소방시설 설치 및 관리에 관한 법률",
+    "고압가스 안전관리법 시행규칙",
+    "화학물질관리법 시행규칙",
+}
+
+
+class TimeoutException(Exception):
+    pass
+
+
+def _timeout_handler(signum, frame):
+    del signum, frame
+    raise TimeoutException("법령별 타임아웃")
+
+
+def load_checkpoint() -> dict:
+    if CHECKPOINT_PATH.exists():
+        try:
+            return json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {"processed": [], "failed": [], "skipped": [], "started_at": None}
+
+
+def save_checkpoint(state: dict) -> None:
+    CHECKPOINT_PATH.write_text(
+        json.dumps(state, ensure_ascii=False, indent=2, default=str),
+        encoding="utf-8",
+    )
+
+
+def fetch_target_laws(supabase) -> list[str]:
+    """law_master 활성 법령에서 Pilot 1/2/3 완료 법령을 제외."""
+    try:
+        res = supabase.table("law_master").select("law_name").eq("is_active", True).execute()
+        all_names = [r["law_name"] for r in (res.data or []) if r.get("law_name")]
+        return [n for n in all_names if n not in COMPLETED_LAWS]
+    except Exception as e:
+        print(f"❌ 대상 법령 조회 실패: {e}")
+        return []
+
+
+def process_one_law(law_name: str, supabase) -> dict:
+    """한 법령 재수집 + 재연결. 타임아웃 600초."""
+    signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.alarm(PER_LAW_TIMEOUT)
+    try:
+        result = recollect_one(law_name, supabase)
+        if result.get("success"):
+            try:
+                rec = reconnect_one(result.get("matched_name", law_name), supabase)
+                result.update(rec)
+            except Exception as e:
+                result["reconnect_success"] = False
+                result["reconnect_error"] = str(e)
+        return result
+    except TimeoutException:
+        return {"law_name": law_name, "success": False, "error": "per-law timeout 600s"}
+    finally:
+        signal.alarm(0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--resume", action="store_true", help="체크포인트 이어서")
+    parser.add_argument("--dry-run", action="store_true", help="대상 목록만 출력")
+    parser.add_argument("--limit", type=int, default=None, help="최대 N개 처리")
+    args = parser.parse_args()
+
+    supabase = get_supabase()
+    all_targets = fetch_target_laws(supabase)
+    state = load_checkpoint() if args.resume else {"processed": [], "failed": [], "skipped": [], "started_at": None}
+
+    if state["started_at"] is None:
+        state["started_at"] = datetime.now(timezone.utc).isoformat()
+
+    done_names = {r.get("law_name") for r in state["processed"] + state["failed"] + state["skipped"] if r.get("law_name")}
+    targets = [t for t in all_targets if t not in done_names]
+    if args.limit:
+        targets = targets[: args.limit]
+
+    print(f"📋 전체 대상: {len(all_targets)}개, 이미 처리: {len(done_names)}개, 이번 실행: {len(targets)}개")
+
+    if args.dry_run:
+        print("\n--- DRY RUN ---")
+        for t in targets[:20]:
+            print(f"  - {t}")
+        if len(targets) > 20:
+            print(f"  ... 외 {len(targets) - 20}개")
+        return 0
+
+    consecutive_failures = 0
+    start_time = time.time()
+
+    for idx, law_name in enumerate(targets, 1):
+        elapsed = time.time() - start_time
+        print(f"\n[{idx}/{len(targets)}] ⏱ {elapsed:.0f}s 경과 | 🎯 {law_name}")
+
+        should_stop, reason = _check_emergency_stop(supabase)
+        if should_stop:
+            print(f"🚨 긴급 중단: {reason}")
+            state["skipped"].append({"law_name": law_name, "reason": f"emergency_stop: {reason}"})
+            save_checkpoint(state)
+            return 2
+
+        if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+            print(f"🚨 연속 {MAX_CONSECUTIVE_FAILURES}회 실패 → 즉시 중단")
+            state["skipped"].append({"law_name": law_name, "reason": "max_consecutive_failures"})
+            save_checkpoint(state)
+            return 3
+
+        result = process_one_law(law_name, supabase)
+        if result.get("success"):
+            state["processed"].append(result)
+            consecutive_failures = 0
+            print(f"  ✅ article_count={result.get('article_count')}")
+        else:
+            state["failed"].append(result)
+            consecutive_failures += 1
+            print(f"  ❌ {result.get('error')}")
+
+        save_checkpoint(state)
+
+    print("\n" + "=" * 70)
+    print("📊 전체 완료")
+    print(f"  ✅ 성공: {len(state['processed'])}")
+    print(f"  ❌ 실패: {len(state['failed'])}")
+    print(f"  ⏭  스킵: {len(state['skipped'])}")
+    print("=" * 70)
+
+    return 0 if len(state["failed"]) == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pilot3_recollect.py
+++ b/scripts/pilot3_recollect.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Pilot 3: 가스·전기·소방 6법령 force 재수집 + FK 재연결.
+
+사용법:
+    cd ~/dev/tai-api
+    git pull origin main
+    set -a; source .env; set +a
+    python3 scripts/pilot3_recollect.py 2>&1 | tee /tmp/pilot3_output.log
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from db.database import get_supabase
+from routers.law_collector import (
+    delete_law_version_cascade_for_recollect,
+    fetch_law_content,
+    fetch_law_list,
+    parse_law_content_xml,
+    parse_law_list_xml,
+    save_law_to_db,
+    snapshot_article_key_map_for_version,
+)
+
+# Pilot 3 대상 6법령 (우선순위: 작은 법령 → 큰 법령)
+TARGETS = [
+    "화재의 예방 및 안전관리에 관한 법률",
+    "위험물안전관리법 시행규칙",
+    "전기안전관리법 시행규칙",
+    "소방시설 설치 및 관리에 관한 법률",
+    "고압가스 안전관리법 시행규칙",
+    "화학물질관리법 시행규칙",
+]
+
+
+def _match_law_name(laws: list[dict], law_name: str) -> dict | None:
+    """정확 매칭 우선, 실패 시 부분 매칭."""
+    exact = next((l for l in laws if (l.get("law_name") or "").strip() == law_name), None)
+    if exact:
+        return exact
+    if "시행령" in law_name or "시행규칙" in law_name:
+        return None
+    partial = next((l for l in laws if law_name in (l.get("law_name") or "")), None)
+    return partial or (laws[0] if laws else None)
+
+
+def _check_emergency_stop(supabase) -> tuple[bool, str]:
+    """긴급 중단: law_revision_board 최근 1시간만 체크."""
+    try:
+        since = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        recent = (
+            supabase.table("law_revision_board")
+            .select("id")
+            .gte("created_at", since)
+            .limit(1)
+            .execute()
+        )
+        if recent.data:
+            return True, "law_revision_board 최근 1시간 데이터 감지"
+    except Exception as e:
+        print(f"  ⚠️ 긴급중단 점검 스킵: {e}")
+    return False, ""
+
+
+def recollect_one(law_name: str, supabase) -> dict:
+    print(f"\n{'=' * 70}")
+    print(f"🎯 {law_name}")
+    print(f"{'=' * 70}")
+
+    should_stop, reason = _check_emergency_stop(supabase)
+    if should_stop:
+        return {"law_name": law_name, "success": False, "error": f"긴급 중단: {reason}"}
+
+    res = fetch_law_list(query=law_name, display=15)
+    if not res["ok"]:
+        return {"law_name": law_name, "success": False, "error": f"검색 API 실패: HTTP {res['status']}"}
+
+    laws = parse_law_list_xml(res["xml"])
+    matched = _match_law_name(laws, law_name)
+    if not matched:
+        return {
+            "law_name": law_name,
+            "success": False,
+            "error": f"검색 결과에서 정확 매칭 실패. 후보: {[l['law_name'] for l in laws[:5]]}",
+        }
+
+    print(
+        f"  ✅ 매칭: {matched['law_name']} | MST={matched['law_mst_no']} | 공포={matched['announcement_date']}"
+    )
+
+    law_check = (
+        supabase.table("law_master")
+        .select("id,law_name")
+        .eq("law_name", matched["law_name"])
+        .limit(1)
+        .execute()
+    )
+    if law_check.data:
+        existing_law_id = law_check.data[0]["id"]
+        ev = (
+            supabase.table("law_version")
+            .select("id")
+            .eq("law_id", existing_law_id)
+            .eq("law_mst_no", matched["law_mst_no"])
+            .execute()
+        )
+        if ev.data:
+            old_vid = ev.data[0]["id"]
+            art_before = (
+                supabase.table("law_article")
+                .select("id", count="exact")
+                .eq("law_version_id", old_vid)
+                .execute()
+            )
+            print(f"  🗑  기존 version={old_vid}, article {art_before.count}개 삭제 예정")
+            snapshot_article_key_map_for_version(supabase, old_vid)
+            try:
+                delete_law_version_cascade_for_recollect(supabase, old_vid)
+                print("  ✅ cascade 삭제 완료")
+            except Exception as e:
+                return {"law_name": law_name, "success": False, "error": f"cascade 삭제 실패: {e}"}
+        else:
+            print("  ℹ️  같은 MST version 없음 — 새로 삽입만")
+    else:
+        print("  ℹ️  law_master 없음 — 새로 생성")
+
+    content = fetch_law_content(matched["law_mst_no"])
+    if not content["ok"]:
+        return {"law_name": law_name, "success": False, "error": f"본문 API 실패: HTTP {content['status']}"}
+
+    parsed = parse_law_content_xml(content["xml"])
+    print(f"  📄 XML {len(content['xml'])}자 → 조문 {len(parsed['articles'])}개")
+
+    law_info = {
+        **parsed["info"],
+        "law_mst_no": matched["law_mst_no"],
+        "law_name_short": matched.get("law_name_short", ""),
+        "revision_type": matched.get("revision_type", ""),
+    }
+    try:
+        result = save_law_to_db(law_info, content["xml"], parsed["articles"], supabase)
+        print(f"  💾 저장 완료: article_count={result['article_count']}, new_version={result['is_new_version']}")
+        return {
+            "law_name": law_name,
+            "matched_name": matched["law_name"],
+            "success": True,
+            "mst_no": matched["law_mst_no"],
+            "article_count": result["article_count"],
+            "version_id": result["version_id"],
+        }
+    except Exception as e:
+        return {"law_name": law_name, "success": False, "error": f"DB 저장 실패: {e}"}
+
+
+def reconnect_one(law_name: str, supabase) -> dict:
+    """pilot2_recollect.py 의 reconnect_one 재사용 (article_no fallback 포함)."""
+    from scripts.pilot2_recollect import reconnect_one as pilot2_reconnect
+
+    return pilot2_reconnect(law_name, supabase)
+
+
+def main() -> int:
+    supabase = get_supabase()
+    results: list[dict] = []
+
+    print("\n" + "🚀" * 35)
+    print("Pilot 3: 가스·전기·소방 6법령 재수집 시작")
+    print("🚀" * 35)
+
+    for law_name in TARGETS:
+        result = recollect_one(law_name, supabase)
+        if result.get("success"):
+            try:
+                rec = reconnect_one(result["matched_name"], supabase)
+                result.update(rec)
+            except Exception as e:
+                result["reconnect_success"] = False
+                result["reconnect_error"] = str(e)
+        results.append(result)
+
+    print("\n" + "=" * 70)
+    print("📊 Pilot 3 완료 — 결과 요약")
+    print("=" * 70)
+    for r in results:
+        if r.get("success"):
+            print(
+                f"✅ {r['law_name']}: article_count={r.get('article_count')}, "
+                f"key_map={r.get('key_map_updated', '-')}, drafts={r.get('drafts_fixed', '-')}"
+            )
+        else:
+            print(f"❌ {r['law_name']}: {r.get('error')}")
+
+    success_count = sum(1 for r in results if r.get("success"))
+    print(f"\n총 {success_count}/{len(TARGETS)} 성공")
+
+    print("\n[JSON]")
+    print(json.dumps(results, ensure_ascii=False, indent=2, default=str))
+
+    return 0 if success_count == len(TARGETS) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_law_collector.py
+++ b/tests/test_law_collector.py
@@ -310,16 +310,41 @@ def test_nullify_refs_chunks_large_lists():
     law_rule_drafts.update.return_value.in_.return_value.execute.return_value = MagicMock()
     inspection_set_items = MagicMock()
     inspection_set_items.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    law_rule_source_map = MagicMock()
+    law_rule_source_map.update.return_value.in_.return_value.execute.return_value = MagicMock()
     sb = MagicMock()
     sb.table.side_effect = lambda name, *a, **k: {
         "law_rule_drafts": law_rule_drafts,
         "inspection_set_items": inspection_set_items,
+        "law_rule_source_map": law_rule_source_map,
     }[name]
 
     _nullify_dependent_article_refs(sb, art_ids)
 
     assert law_rule_drafts.update.return_value.in_.call_count == 3
     assert inspection_set_items.update.return_value.in_.call_count == 3
+    assert law_rule_source_map.update.return_value.in_.call_count == 3
+
+
+def test_nullify_refs_includes_law_rule_source_map():
+    art_ids = [f"uuid-{i}" for i in range(10)]
+    law_rule_drafts = MagicMock()
+    law_rule_drafts.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    inspection_set_items = MagicMock()
+    inspection_set_items.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    law_rule_source_map = MagicMock()
+    law_rule_source_map.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    sb = MagicMock()
+    sb.table.side_effect = lambda name, *a, **k: {
+        "law_rule_drafts": law_rule_drafts,
+        "inspection_set_items": inspection_set_items,
+        "law_rule_source_map": law_rule_source_map,
+    }[name]
+
+    _nullify_dependent_article_refs(sb, art_ids)
+
+    names = [c.args[0] for c in sb.table.call_args_list if c.args]
+    assert "law_rule_source_map" in names
 
 
 def test_cascade_delete_handles_834_articles():
@@ -341,6 +366,8 @@ def test_cascade_delete_handles_834_articles():
     law_rule_drafts.update.return_value.in_.return_value.execute.return_value = MagicMock()
     inspection_set_items = MagicMock()
     inspection_set_items.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    law_rule_source_map = MagicMock()
+    law_rule_source_map.update.return_value.in_.return_value.execute.return_value = MagicMock()
 
     tables = {
         "law_article": law_article,
@@ -354,7 +381,7 @@ def test_cascade_delete_handles_834_articles():
         "law_update_tracking": _generic_version_dep_mock(),
         "law_article_diff": _generic_version_dep_mock(),
         "law_change_log": _generic_version_dep_mock(),
-        "law_rule_source_map": _generic_version_dep_mock(),
+        "law_rule_source_map": law_rule_source_map,
     }
     sb = MagicMock()
     sb.table.side_effect = lambda name, *a, **k: tables[name]
@@ -363,3 +390,41 @@ def test_cascade_delete_handles_834_articles():
 
     assert law_paragraph.select.return_value.in_.call_count == 9
     assert law_version.delete.called
+
+
+def test_cascade_delete_handles_source_map_article_id():
+    law_article = MagicMock()
+    law_article.select.return_value.eq.return_value.execute.return_value = MagicMock(data=[{"id": "art-1"}])
+    law_article.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    law_paragraph = MagicMock()
+    law_paragraph.select.return_value.in_.return_value.execute.return_value = MagicMock(data=[])
+    law_paragraph.delete.return_value.in_.return_value.execute.return_value = MagicMock()
+    law_content_raw = MagicMock()
+    law_content_raw.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    law_version = MagicMock()
+    law_version.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+    law_rule_source_map = MagicMock()
+    law_rule_source_map.update.return_value.in_.return_value.execute.return_value = MagicMock()
+    law_rule_source_map.delete.return_value.eq.return_value.execute.return_value = MagicMock()
+
+    tables = {
+        "law_article": law_article,
+        "law_paragraph": law_paragraph,
+        "law_content_raw": law_content_raw,
+        "law_version": law_version,
+        "law_rule_drafts": _generic_version_dep_mock(),
+        "inspection_set_items": _generic_version_dep_mock(),
+        "law_parsing_result": _generic_version_dep_mock(),
+        "law_attachment": _generic_version_dep_mock(),
+        "law_update_tracking": _generic_version_dep_mock(),
+        "law_article_diff": _generic_version_dep_mock(),
+        "law_change_log": _generic_version_dep_mock(),
+        "law_rule_source_map": law_rule_source_map,
+    }
+    sb = MagicMock()
+    sb.table.side_effect = lambda name, *a, **k: tables[name]
+
+    delete_law_version_cascade_for_recollect(sb, "ver-source-map")
+
+    law_rule_source_map.update.return_value.in_.assert_called()
+    law_version.delete.assert_called()


### PR DESCRIPTION
## 🎯 Pilot 3 발견 FK 누락 보완 + 전체 확장 배치 스크립트 준비

### 배경
Pilot 3 (가스·전기·소방 6법령) 실행 중 소방시설법만 cascade 삭제에서 실패:

```
❌ 소방시설 설치 및 관리에 관한 법률: cascade 삭제 실패
{'message': 'update or delete on table "law_article" violates foreign key constraint 
"law_rule_source_map_article_id_fkey" on table "law_rule_source_map"',
'code': '23503'}
```

기획창이 SQL로 수동 복구 후 재실행하여 6/6 완료했으나, 전체 확장(388법령) 전 구조적 보완 필수.

### 발견된 이슈

`law_rule_source_map` 테이블에 **2개의 FK 컬럼**이 있음:
- `law_version_id` (NOT NULL) — 기존 `_clear_law_version_fk_dependents`에서 처리 중
- **`article_id` (NULLABLE) — 이번에 추가**

실측: 소방시설법 article 246개 중 17건이 `law_rule_source_map.article_id`로 참조됨 (다른 5법령은 0건이라 통과).

---

### 변경 내역

**`routers/law_collector.py`**
- `_nullify_dependent_article_refs()` 3번째 항목 추가:
  ```python
  for table, col in (
      ("law_rule_drafts", "article_id"),
      ("inspection_set_items", "law_article_id"),
      ("law_rule_source_map", "article_id"),  # 🆕 Pilot 3 발견
  ):
  ```
- 기존 chunking(100) 흐름 유지
- 삭제 순서 유지: article FK nullify → article 삭제 → `_clear_law_version_fk_dependents`의 `law_rule_source_map` DELETE (by `law_version_id`)

**`tests/test_law_collector.py`**
- `test_nullify_refs_includes_law_rule_source_map` 추가
- `test_cascade_delete_handles_source_map_article_id` 추가
- 기존 chunk 테스트에 `law_rule_source_map` 호출 검증 보강

**`scripts/all_laws_recollect.py` 신규** (전체 확장용, 이번 PR은 스크립트만 작성)
- 체크포인트 파일: `/tmp/all_laws_checkpoint.json` (자동 저장/재개)
- 로그: `/tmp/all_laws_output.log`
- 옵션: `--resume`, `--dry-run`, `--limit N`
- 긴급 중단: 연속 3회 실패 시 자동 종료
- 법령당 600초 타임아웃
- `COMPLETED_LAWS` 세트에 Pilot 1/2/3 완료된 10법령 하드코딩 (중복 실행 방지)
- `pilot2_recollect`의 `recollect_one`, `reconnect_one`, `_check_emergency_stop` 재사용

### 검증
```
pytest tests/ -v → 93 passed (기존 91 + 신규 2)
```

### Pilot 3 실측 성과 (이미 완료)

| 법령 | Before | After valid_pct |
|---|---|---|
| 화학물질관리법 시행규칙 | 4.0% | **47.9%** |
| 전기안전관리법 시행규칙 | 2.0% | **44.9%** |
| 소방시설 설치 및 관리에 관한 법률 | 3.3% | **38.0%** |
| 화재의 예방 및 안전관리에 관한 법률 | 0.0% | **36.7%** |
| 고압가스 안전관리법 시행규칙 | 2.0% | **31.9%** |
| 위험물안전관리법 시행규칙 | 1.8% | **31.2%** |

**6/6 PASS** (모든 기준 통과, 샘플 품질 완벽)

### 누적 성과 (Pilot 1+2+3)
- 10법령 완벽 재수집 (평균 valid_pct ~37%)
- cascade FK 커버: 11개 테이블
- PostgREST 한계 대응 (chunking 100)

### 🔗 관련
- **Refs #37** (전체 확장 남음, 이 PR로 닫지 않음)
- 이전 PR: #39, #40, #41

### 다음 단계
이 PR 머지 후:
- `scripts/all_laws_recollect.py --dry-run`으로 대상 388법령 확인
- 별도 시점에 전체 확장 실행 (체크포인트 기반 재개 가능)