### PR TITLE
feat(billing): Phase 2 — BillKey issuance + recurring charge + cancel endpoints (#45)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-# main.py — v5.34.0
+# main.py — v5.35.0
+# v5.35.0: payment_billing 라우터 등록 (POST /payments/inicis/billing/*, /payments/subscriptions/{id}/cancel)
 # v5.34.0: Sentry 복원 + /health 개선 (항상 200 반환) + diagram_proxy 복원
 # v5.33.0: Sentry 에러 모니터링 (SENTRY_DSN 환경 변수 시 초기화)
 # v5.32.0: diagram_proxy 라우터 등록 (GET /api/v1/diagrams/{number}) — Supabase Storage 한글 SVG 우회
@@ -97,6 +98,7 @@ from routers.tbm_templates           import router as tbm_templates_router
 from routers.safety_meetings         import router as safety_meetings_router
 from routers.risk_assessments        import router as risk_assessments_router
 from routers.payment                 import router as payment_router
+from routers.payment_billing         import router as payment_billing_router   # v5.35.0 정기결제
 from routers.corrective_actions      import router as corrective_actions_router
 from routers.messaging               import router as messaging_router
 from routers.fcm                     import router as fcm_router
@@ -129,7 +131,7 @@ from routers.diagram_proxy           import router as diagram_proxy_router      
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "5.34.0"
+APP_VERSION = "5.35.0"
 
 
 @asynccontextmanager
@@ -278,6 +280,7 @@ app.include_router(tbm_templates_router)
 app.include_router(safety_meetings_router)
 app.include_router(risk_assessments_router)
 app.include_router(payment_router)
+app.include_router(payment_billing_router)                                        # v5.35.0 정기결제
 app.include_router(corrective_actions_router)
 app.include_router(messaging_router)
 app.include_router(fcm_router)

--- a/routers/payment.py
+++ b/routers/payment.py
@@ -1,5 +1,11 @@
 """
-이니시스 INIStdPay 표준결제 라우터 — v3.3.0
+이니시스 INIStdPay 표준결제 라우터 — v3.4.0
+
+v3.4.0 (2026-04-23)
+  [FEAT] /payments/billing/terms — 구독 이용 안내 페이지 추가 (이니시스 심사용)
+         - 공개 HTML 페이지 (로그인 불필요)
+         - 결제 주기/해지 방법/환불 정책/문의처 명시
+         - /payments/pricing?type=billing 배너에서 링크
 
 v3.3.0 (2026-04-23)
   [FEAT] /payments/pricing 에 단건/정기 토글 추가 (?type=billing)
@@ -283,6 +289,11 @@ _PRICING_HTML = """<!doctype html>
     <div>
       <strong>매월 자동 결제</strong>로 진행됩니다. 첫 결제는 즉시 이루어지며, 이후 매월 같은 날짜에 자동 청구됩니다.
       등록한 카드는 안전하게 이니시스에 저장되고, 언제든 구독을 해지할 수 있습니다.
+      <div class="mt-2">
+        <a href="/payments/billing/terms" target="_blank" style="color:#1e40af;font-weight:600;text-decoration:underline;">
+          <i class="ti ti-file-text me-1"></i>구독 이용 안내 전문 보기
+        </a>
+      </div>
     </div>
   </div>
 
@@ -1254,3 +1265,181 @@ def get_vbank_status(payment_id: str):
             "confirmed_at":     p.get("vbank_confirmed_at"),
         },
     }
+
+
+# ════════════════════════════════════════════════════════════════════════
+# 구독 이용 안내 페이지 — 이니시스 정기결제 심사용 (v3.4.0)
+# ════════════════════════════════════════════════════════════════════════
+
+_BILLING_TERMS_HTML = """<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>구독 이용 안내 | TAI Safe</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.19.0/dist/tabler-icons.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <style>
+    * { font-family: 'Noto Sans KR', sans-serif; }
+    body { background:#f8fafc; color:#1f2937; line-height:1.7; }
+    .page-hero { background:linear-gradient(135deg,#1a1f36 0%,#0d6efd 60%,#0a58ca 100%); color:#fff; padding:2.5rem 0; text-align:center; }
+    .page-hero h1 { font-size:1.8rem; font-weight:800; margin-bottom:.25rem; }
+    .page-hero p  { opacity:.85; margin-bottom:0; font-size:.95rem; }
+    .content-card { background:#fff; border-radius:1rem; box-shadow:0 6px 30px rgba(0,0,0,.06); padding:2rem 2.2rem; margin-bottom:1rem; }
+    section h2 { font-size:1.15rem; font-weight:800; color:#0d6efd; margin-top:1.75rem; margin-bottom:.75rem; display:flex; align-items:center; gap:.5rem; }
+    section h2:first-of-type { margin-top:0; }
+    section h2 .num { display:inline-flex; align-items:center; justify-content:center; width:28px; height:28px; border-radius:50%; background:#eff6ff; color:#0d6efd; font-size:.85rem; font-weight:800; }
+    .kv-table { width:100%; border-collapse:collapse; margin:.5rem 0; }
+    .kv-table th, .kv-table td { border-bottom:1px solid #f0f0f0; padding:.65rem .5rem; text-align:left; vertical-align:top; font-size:.93rem; }
+    .kv-table th { width:32%; color:#6b7280; font-weight:600; background:#fafafa; }
+    .callout { background:#eff6ff; border-left:4px solid #0d6efd; border-radius:.5rem; padding:.85rem 1rem; margin:.75rem 0; font-size:.92rem; color:#1e40af; }
+    .callout.warn { background:#fff7ed; border-left-color:#f59e0b; color:#9a3412; }
+    ul.plain { padding-left:1.2rem; }
+    ul.plain li { margin:.3rem 0; font-size:.93rem; }
+    .contact-box { background:#f8fafc; border-radius:.75rem; padding:1.25rem; text-align:center; margin-top:1rem; }
+    .contact-box .email { font-size:1.05rem; font-weight:700; color:#0d6efd; }
+    .footer-nav { text-align:center; padding:1.5rem 0 2rem; }
+    .footer-nav a { color:#6b7280; font-size:.88rem; text-decoration:none; margin:0 .5rem; }
+    .footer-nav a:hover { color:#0d6efd; text-decoration:underline; }
+    .updated-at { color:#9ca3af; font-size:.82rem; text-align:right; margin-bottom:1rem; }
+  </style>
+</head>
+<body>
+
+<div class="page-hero">
+  <div class="container">
+    <div class="badge bg-white bg-opacity-25 text-white mb-2" style="font-size:.78rem;padding:.35em .9em;">
+      <i class="ti ti-file-text me-1"></i>TAI Safe 정기결제
+    </div>
+    <h1>구독 이용 안내</h1>
+    <p>매월 자동결제 서비스 이용 전 꼭 확인해 주세요.</p>
+  </div>
+</div>
+
+<div class="container py-4" style="max-width:820px">
+  <div class="updated-at">최종 업데이트: 2026년 4월 23일</div>
+
+  <div class="content-card">
+
+    <section>
+      <h2><span class="num">1</span>서비스 개요</h2>
+      <p>
+        <strong>TAI Safe</strong>는 주식회사 타이엔지니어링(이하 '회사')이 제공하는 산업안전 관리 SaaS 서비스입니다.
+        본 페이지는 정기결제(자동결제) 방식으로 TAI Safe를 이용하실 경우의 결제·해지·환불에 관한 안내입니다.
+      </p>
+    </section>
+
+    <section>
+      <h2><span class="num">2</span>상품 및 요금</h2>
+      <table class="kv-table">
+        <tr><th>상품명</th><td>TAI Safe 베이직 / 프리미엄</td></tr>
+        <tr><th>결제 금액</th><td>베이직 월 79,000원 / 프리미엄 월 149,000원 <span style="color:#6b7280;font-size:.85rem;">(부가세 포함)</span></td></tr>
+        <tr><th>결제 주기</th><td>매월 1회 자동 결제</td></tr>
+        <tr><th>결제 수단</th><td>신용카드 / 체크카드 (KG이니시스 빌링키 방식)</td></tr>
+      </table>
+      <div class="callout">
+        표시된 금액은 고지 시점의 가격이며, 추후 요금 변경 시 최소 30일 전에 이메일 및 서비스 내 공지로 안내합니다.
+        변경된 요금에 동의하지 않으실 경우 다음 결제일 전까지 해지하시면 추가 결제가 발생하지 않습니다.
+      </div>
+    </section>
+
+    <section>
+      <h2><span class="num">3</span>결제 방식 및 자동 갱신</h2>
+      <ul class="plain">
+        <li><strong>최초 결제</strong>: 결제 페이지에서 카드 등록을 완료하시면 즉시 첫 달 요금이 결제되며, 서비스가 즉시 시작됩니다.</li>
+        <li><strong>자동 갱신</strong>: 최초 결제일을 기준으로 <strong>매월 같은 날짜</strong>에 등록된 카드로 동일 금액이 자동 결제됩니다.</li>
+        <li><strong>결제 실패 시</strong>: 카드 한도 초과·유효기간 만료 등으로 결제가 실패할 경우 최대 3회 재시도하며, 그래도 실패하면 서비스가 일시 정지됩니다. 고객님께는 이메일로 별도 안내드립니다.</li>
+        <li><strong>영수증</strong>: 결제 완료 시 등록된 이메일로 전자영수증이 발송됩니다.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2><span class="num">4</span>카드 정보 보관</h2>
+      <p>
+        고객님의 카드 정보는 <strong>회사 서버에 저장되지 않으며</strong>,
+        전자금융거래법 및 관련 규정에 따라 전자지급결제대행사(PG)인 <strong>KG이니시스</strong>의
+        PCI-DSS 인증 시스템에 안전하게 보관됩니다.
+        회사는 KG이니시스가 발급한 빌링키(BillKey)만을 보유하며, 이 빌링키로 정기 결제를 진행합니다.
+      </p>
+    </section>
+
+    <section>
+      <h2><span class="num">5</span>구독 해지 방법</h2>
+      <div class="callout">
+        구독은 <strong>언제든지 해지</strong> 가능하며, 해지 위약금이나 추가 비용은 발생하지 않습니다.
+      </div>
+      <p><strong>해지 절차</strong>:</p>
+      <ul class="plain">
+        <li>아래 고객센터로 <strong>해지 요청 이메일</strong>을 보내주세요.</li>
+        <li>영업일 기준 1–2일 내에 확인 후 처리해 드립니다.</li>
+        <li>해지 완료 시 결제 이메일로 해지 확인 안내를 발송합니다.</li>
+        <li>해지 이후 <strong>차월부터 자동 결제가 즉시 중단</strong>됩니다.</li>
+      </ul>
+      <div class="callout warn">
+        다음 결제일 이전에 해지하시면 다음 달 요금은 청구되지 않습니다.
+        이미 결제된 당월 요금은 이용기간 일할 기준에 따라 환불 여부가 결정됩니다. (아래 '6. 환불 정책' 참고)
+      </div>
+    </section>
+
+    <section>
+      <h2><span class="num">6</span>환불 정책</h2>
+      <ul class="plain">
+        <li><strong>원칙</strong>: 이미 결제된 요금은 <strong>이용기간 일할 계산</strong>하여, 이용하지 않은 잔여 기간에 대해 환불해 드립니다.</li>
+        <li><strong>계산 방식</strong>: (월 결제금액 ÷ 해당 월 일수) × (해지일 이후 잔여 일수)</li>
+        <li><strong>환불 기간</strong>: 해지 확인 후 영업일 기준 5–7일 이내에 결제 카드로 부분 취소 처리됩니다.</li>
+        <li><strong>환불 예외</strong>: 서비스 이용약관 위반 등 회사의 귀책이 없는 사유로 회원 자격이 정지된 경우 환불이 제한될 수 있습니다.</li>
+      </ul>
+      <div class="callout">
+        <strong>예시</strong>: 4월 1일에 결제 후 4월 11일에 해지하신 경우,
+        이용일 10일(1일∼10일) 제외한 20일치를 일할 계산해 환불해 드립니다.
+      </div>
+    </section>
+
+    <section>
+      <h2><span class="num">7</span>결제 정보 변경</h2>
+      <p>
+        카드 번호 변경, 카드 만료일 갱신 등 결제 정보 변경이 필요하신 경우 고객센터로 문의해 주세요.
+        기존 구독을 해지하지 않고도 결제 카드를 교체하실 수 있습니다.
+      </p>
+    </section>
+
+    <section>
+      <h2><span class="num">8</span>고객센터 문의</h2>
+      <div class="contact-box">
+        <div style="font-size:.9rem;color:#6b7280;margin-bottom:.4rem;">해지·환불·결제 정보 변경 문의</div>
+        <div class="email">
+          <i class="ti ti-mail me-1"></i>taiengcokr@gmail.com
+        </div>
+        <div style="font-size:.85rem;color:#6b7280;margin-top:.5rem;">
+          평일 10:00 – 18:00 · 영업일 기준 1–2일 내 회신
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2><span class="num">9</span>기타 사항</h2>
+      <ul class="plain">
+        <li>본 안내 내용은 서비스 개선 등 필요에 따라 변경될 수 있으며, 변경 시 사전 공지합니다.</li>
+        <li>본 안내에서 명시되지 않은 사항은 회사의 <a href="https://taieng.co.kr" target="_blank" style="color:#0d6efd;">서비스 이용약관</a> 및 관련 법령(전자상거래법·콘텐츠산업진흥법 등)에 따릅니다.</li>
+        <li>결제대행사 문의: KG이니시스 고객센터 1588-4954</li>
+      </ul>
+    </section>
+
+  </div>
+
+  <div class="footer-nav">
+    <a href="/payments/pricing?type=billing"><i class="ti ti-arrow-left me-1"></i>요금제 페이지로</a>
+    <span style="color:#e5e7eb;">|</span>
+    <a href="https://taieng.co.kr" target="_blank"><i class="ti ti-external-link me-1"></i>TAI Safe 홈</a>
+  </div>
+</div>
+
+</body>
+</html>"""
+
+
+@router.get("/billing/terms", response_class=HTMLResponse, include_in_schema=True)
+def payment_billing_terms_page():
+    """구독 이용 안내 페이지 — 이니시스 정기결제 심사용 공개 페이지"""
+    return HTMLResponse(content=_BILLING_TERMS_HTML, status_code=200)

--- a/routers/payment.py
+++ b/routers/payment.py
@@ -1,5 +1,14 @@
 """
-이니시스 INIStdPay 표준결제 라우터 — v3.2.0
+이니시스 INIStdPay 표준결제 라우터 — v3.3.0
+
+v3.3.0 (2026-04-23)
+  [FEAT] /payments/pricing 에 단건/정기 토글 추가 (?type=billing)
+         - 기본은 단건결제 (기존과 동일)
+         - ?type=billing 또는 상단 탭 선택 시 /inicis/billing/prepare 호출
+         - 정기결제 UI 안내 문구, /월 단위 표시, 버튼 라벨 분기
+         - 이니시스 form 파라미터 분기:
+           단건: gopaymethod=Card,    acceptmethod=CARDONLY:CARDPOINT:centerCd(Y)
+           정기: gopaymethod=(빈값),  acceptmethod=centerCd(Y):BILLAUTH(Card)
 
 v3.2.0 (2026-04-12)
   [FEAT] VBANK(가상계좌) 결제 지원 — 연결 서비스 전용
@@ -232,6 +241,10 @@ _PRICING_HTML = """<!doctype html>
     * { font-family: 'Noto Sans KR', sans-serif; } body { background: #f8fafc; }
     .hero { background: linear-gradient(135deg,#1a1f36 0%,#0d6efd 60%,#0a58ca 100%); color:#fff; padding:3.5rem 0 3rem; text-align:center; }
     .hero h1 { font-size:2.2rem; font-weight:800; margin-bottom:.5rem; }
+    .type-toggle { display:inline-flex; background:#fff; border-radius:999px; padding:.3rem; box-shadow:0 4px 20px rgba(0,0,0,.08); margin-top:1rem; }
+    .type-toggle button { border:none; background:transparent; padding:.55rem 1.4rem; border-radius:999px; font-size:.92rem; font-weight:700; color:#64748b; cursor:pointer; transition:.2s; }
+    .type-toggle button.active { background:linear-gradient(90deg,#0d6efd,#6610f2); color:#fff; box-shadow:0 4px 14px rgba(13,110,253,.35); }
+    .type-toggle .save-badge { display:inline-block; margin-left:.35rem; padding:.08em .5em; font-size:.68rem; background:#fbbf24; color:#78350f; border-radius:.4em; vertical-align:middle; }
     .plan-card { border-radius:1.25rem; border:2px solid #dee2e6; background:#fff; box-shadow:0 6px 30px rgba(0,0,0,.07); transition:transform .18s,border-color .18s; cursor:pointer; overflow:hidden; }
     .plan-card:hover { transform:translateY(-4px); border-color:#0d6efd; }
     .plan-card.selected { border-color:#0d6efd; box-shadow:0 0 0 3px rgba(13,110,253,.18); }
@@ -240,6 +253,8 @@ _PRICING_HTML = """<!doctype html>
     .plan-name { font-size:1.4rem; font-weight:800; }
     .plan-badge { font-size:.72rem; padding:.25em .65em; border-radius:.5em; background:rgba(255,255,255,.25); color:#fff; vertical-align:middle; margin-left:.4rem; }
     .plan-price { font-size:2.2rem; font-weight:800; margin:.75rem 0 .25rem; }
+    .plan-price .unit { font-size:.9rem; font-weight:500; color:#9ca3af; margin-left:.25rem; }
+    .plan-card.premium .plan-price .unit { color:rgba(255,255,255,.7); }
     .plan-desc { font-size:.88rem; color:#6c757d; margin-top:.25rem; }
     .plan-features { padding:1.25rem 1.5rem 1.5rem; }
     .plan-features li { font-size:.88rem; padding:.3rem 0; border-bottom:1px solid #f5f5f5; display:flex; align-items:center; gap:.5rem; }
@@ -248,15 +263,29 @@ _PRICING_HTML = """<!doctype html>
     .btn-pay:disabled { opacity:.55; cursor:not-allowed; }
     .select-indicator { width:22px; height:22px; border-radius:50%; border:2px solid #dee2e6; flex-shrink:0; display:flex; align-items:center; justify-content:center; }
     .plan-card.selected .select-indicator { background:#0d6efd; border-color:#0d6efd; color:#fff; }
+    .billing-notice { background:#eff6ff; border:1px solid #bfdbfe; color:#1e40af; border-radius:.75rem; padding:.75rem 1rem; font-size:.85rem; display:none; align-items:flex-start; gap:.5rem; }
+    .billing-notice.show { display:flex; }
   </style>
 </head>
 <body>
 <div class="hero"><div class="container">
   <div class="badge bg-white bg-opacity-25 text-white mb-3" style="font-size:.85rem;padding:.45em 1em;"><i class="ti ti-shield-check me-1"></i>TAI Safe 요금제</div>
   <h1>안전관리를 더 스마트하게</h1>
-  <p>산업안전보건법 의무를 자동으로 파악하고, 일정·업무를 분배하세요.</p>
+  <p class="mb-0">산업안전보건법 의무를 자동으로 파악하고, 일정·업무를 분배하세요.</p>
+  <div class="type-toggle" role="tablist" aria-label="결제 유형">
+    <button type="button" id="tab-single" class="active" onclick="selectType('single')"><i class="ti ti-coin me-1"></i>단건결제</button>
+    <button type="button" id="tab-billing" onclick="selectType('billing')"><i class="ti ti-repeat me-1"></i>정기결제<span class="save-badge">매월 자동</span></button>
+  </div>
 </div></div>
 <div class="container py-5" style="max-width:900px">
+  <div id="billingNotice" class="billing-notice mb-4">
+    <i class="ti ti-info-circle" style="font-size:1.1rem;flex-shrink:0;margin-top:.1rem;"></i>
+    <div>
+      <strong>매월 자동 결제</strong>로 진행됩니다. 첫 결제는 즉시 이루어지며, 이후 매월 같은 날짜에 자동 청구됩니다.
+      등록한 카드는 안전하게 이니시스에 저장되고, 언제든 구독을 해지할 수 있습니다.
+    </div>
+  </div>
+
   <div class="row g-4 mb-4">
     <div class="col-md-6">
       <div class="plan-card selected" id="card-basic" onclick="selectPlan('basic')">
@@ -265,7 +294,7 @@ _PRICING_HTML = """<!doctype html>
             <div><div class="plan-name">베이직</div><div class="plan-desc">소규모 사업장에 최적</div></div>
             <div class="select-indicator" id="ind-basic"><i class="ti tabler-check" style="font-size:.85rem;"></i></div>
           </div>
-          <div class="plan-price" id="price-basic">&#8361;79,000</div>
+          <div class="plan-price"><span id="price-basic">&#8361;79,000</span><span class="unit" id="unit-basic"></span></div>
         </div>
         <div class="plan-features"><ul class="list-unstyled mb-0">
           <li><i class="ti ti-check"></i>법령 의무 자동 분석</li>
@@ -283,7 +312,7 @@ _PRICING_HTML = """<!doctype html>
             <div><div class="plan-name">프리미엄<span class="plan-badge">추천</span></div><div class="plan-desc" style="color:rgba(255,255,255,.75)">중·대규모 현장 최적</div></div>
             <div class="select-indicator" id="ind-premium" style="border-color:rgba(255,255,255,.5)"></div>
           </div>
-          <div class="plan-price" id="price-premium">&#8361;149,000</div>
+          <div class="plan-price"><span id="price-premium">&#8361;149,000</span><span class="unit" id="unit-premium"></span></div>
         </div>
         <div class="plan-features"><ul class="list-unstyled mb-0">
           <li><i class="ti ti-check" style="color:#6610f2"></i>베이직 모든 기능 포함</li>
@@ -298,19 +327,20 @@ _PRICING_HTML = """<!doctype html>
   </div>
   <div class="card border-0 shadow-sm rounded-3 p-4">
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
-      <div><div class="fw-bold mb-1" id="summaryText">베이직</div><div class="text-body-secondary small">부가세 포함 · 월 단위 결제</div></div>
+      <div><div class="fw-bold mb-1" id="summaryText">베이직</div><div class="text-body-secondary small" id="summarySub">부가세 포함 · 이번 한 번만 결제</div></div>
       <div class="text-end"><div class="fw-bold fs-4" id="summaryPrice">&#8361;79,000</div></div>
     </div>
     <hr class="my-3" />
     <button class="btn-pay" id="btnPay" onclick="startPayment()">
       <span class="spinner-border spinner-border-sm d-none me-1" id="paySpinner"></span>
-      <i class="ti ti-credit-card me-1" id="payIcon"></i>지금 결제하기
+      <i class="ti ti-credit-card me-1" id="payIcon"></i><span id="payLabel">지금 결제하기</span>
     </button>
     <div class="text-center mt-2"><small class="text-body-secondary"><i class="ti ti-lock me-1"></i>이니시스 안전결제 · SSL 암호화</small></div>
   </div>
 </div>
 <form id="inicisForm" method="POST" accept-charset="euc-kr" style="display:none">
-  <input type="hidden" name="version" value="1.0" /><input type="hidden" name="gopaymethod" value="Card" />
+  <input type="hidden" name="version" value="1.0" />
+  <input type="hidden" name="gopaymethod" id="f_gopaymethod" value="Card" />
   <input type="hidden" name="mid" id="f_mid" /><input type="hidden" name="oid" id="f_oid" />
   <input type="hidden" name="price" id="f_price" /><input type="hidden" name="timestamp" id="f_timestamp" />
   <input type="hidden" name="use_chkfake" value="Y" /><input type="hidden" name="signature" id="f_signature" />
@@ -319,17 +349,177 @@ _PRICING_HTML = """<!doctype html>
   <input type="hidden" name="buyertel" id="f_buyertel" /><input type="hidden" name="buyeremail" id="f_buyeremail" />
   <input type="hidden" name="returnUrl" id="f_returnUrl" /><input type="hidden" name="closeUrl" id="f_closeUrl" />
   <input type="hidden" name="currency" value="WON" /><input type="hidden" name="langtype" value="KO" />
-  <input type="hidden" name="acceptmethod" value="CARDONLY:CARDPOINT:centerCd(Y)" />
+  <input type="hidden" name="acceptmethod" id="f_acceptmethod" value="CARDONLY:CARDPOINT:centerCd(Y)" />
 </form>
 <script src="https://stdpay.inicis.com/stdjs/INIStdPay.js" charset="utf-8"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 'use strict';
-var API='https://api.taieng.co.kr',BASE={basic:79000,premium:149000},PNAME={basic:'TAI Safe 베이직',premium:'TAI Safe 프리미엄'},_plan='basic';
-function selectPlan(p){_plan=p;['basic','premium'].forEach(function(x){document.getElementById('card-'+x).classList.toggle('selected',x===p);var ind=document.getElementById('ind-'+x);if(x===p){ind.innerHTML='<i class="ti tabler-check" style="font-size:.85rem;"></i>';ind.style.background='#0d6efd';ind.style.borderColor='#0d6efd';ind.style.color='#fff';}else{ind.innerHTML='';ind.style.background='';ind.style.borderColor=x==='premium'?'rgba(255,255,255,.5)':'';ind.style.color='';}});updatePrices();}
-function updatePrices(){document.getElementById('price-basic').innerHTML='&#8361;'+BASE.basic.toLocaleString();document.getElementById('price-premium').innerHTML='&#8361;'+BASE.premium.toLocaleString();document.getElementById('summaryText').textContent=_plan==='basic'?'베이직':'프리미엄';document.getElementById('summaryPrice').innerHTML='&#8361;'+BASE[_plan].toLocaleString();}
-function startPayment(){var token=localStorage.getItem('access_token')||'',userId=localStorage.getItem('user_id')||'';if(!token||!userId){alert('로그인 후 결제해주세요.');return;}var btn=document.getElementById('btnPay'),sp=document.getElementById('paySpinner'),icon=document.getElementById('payIcon');if(btn.disabled)return;btn.disabled=true;sp.classList.remove('d-none');icon.classList.add('d-none');var total=BASE[_plan],goodname=PNAME[_plan],companyId=localStorage.getItem('company_id')||'',RETURN_URL=API+'/payments/inicis/return',CLOSE_URL=API+'/payments/result?resultCode=CLOSE';var payload=JSON.stringify({user_id:userId,product_type:'SAAS_FACILITY',company_id:companyId||undefined,amount:total,goodname:goodname,buyername:'고객',buyertel:'00000000000',plan_code:_plan.toUpperCase(),period_months:1,payment_type:'CARD',return_url:RETURN_URL,close_url:CLOSE_URL});var xhr=new XMLHttpRequest();xhr.open('POST',API+'/payments/inicis/prepare',true);xhr.setRequestHeader('Content-Type','application/json');if(token)xhr.setRequestHeader('Authorization','Bearer '+token);xhr.onload=function(){try{var d=JSON.parse(xhr.responseText);if(xhr.status<200||xhr.status>=300)throw new Error(d.detail||d.message||'결제 준비 실패');var p=d.data||d;document.getElementById('f_mid').value=p.mid||'';document.getElementById('f_oid').value=p.oid||'';document.getElementById('f_price').value=p.price||String(total);document.getElementById('f_timestamp').value=p.timestamp||'';document.getElementById('f_signature').value=p.signature||'';document.getElementById('f_verification').value=p.verification||'';document.getElementById('f_mKey').value=p.mKey||'';document.getElementById('f_goodname').value=p.goodname||goodname;document.getElementById('f_buyername').value='고객';document.getElementById('f_buyertel').value='00000000000';document.getElementById('f_buyeremail').value='';document.getElementById('f_returnUrl').value=RETURN_URL;document.getElementById('f_closeUrl').value=CLOSE_URL;INIStdPay.pay('inicisForm');}catch(e){alert('오류: '+e.message);}finally{btn.disabled=false;sp.classList.add('d-none');icon.classList.remove('d-none');}};xhr.onerror=function(){alert('네트워크 오류. 다시 시도해 주세요.');btn.disabled=false;sp.classList.add('d-none');icon.classList.remove('d-none');};xhr.send(payload);}
-updatePrices();(function(){var p=new URLSearchParams(location.search).get('plan');if(p==='premium')selectPlan('premium');})();
+var API='https://api.taieng.co.kr',
+    BASE={basic:79000,premium:149000},
+    PNAME={basic:'TAI Safe 베이직',premium:'TAI Safe 프리미엄'},
+    _plan='basic',
+    _type='single';   // 'single' | 'billing'
+
+function selectType(t){
+  if(t!=='single' && t!=='billing') return;
+  _type=t;
+  document.getElementById('tab-single').classList.toggle('active', t==='single');
+  document.getElementById('tab-billing').classList.toggle('active', t==='billing');
+  document.getElementById('billingNotice').classList.toggle('show', t==='billing');
+
+  // 하단 요약 문구
+  document.getElementById('summarySub').textContent =
+    t==='billing' ? '부가세 포함 · 매월 자동결제 (언제든 해지 가능)'
+                  : '부가세 포함 · 이번 한 번만 결제';
+  // 카드 단위 표시 (정기결제일 때만 "/월")
+  var u = t==='billing' ? ' /월' : '';
+  document.getElementById('unit-basic').textContent   = u;
+  document.getElementById('unit-premium').textContent = u;
+
+  // 버튼 라벨
+  document.getElementById('payLabel').textContent =
+    t==='billing' ? '매월 정기결제 시작하기' : '지금 결제하기';
+}
+
+function selectPlan(p){
+  _plan=p;
+  ['basic','premium'].forEach(function(x){
+    document.getElementById('card-'+x).classList.toggle('selected',x===p);
+    var ind=document.getElementById('ind-'+x);
+    if(x===p){
+      ind.innerHTML='<i class="ti tabler-check" style="font-size:.85rem;"></i>';
+      ind.style.background='#0d6efd'; ind.style.borderColor='#0d6efd'; ind.style.color='#fff';
+    }else{
+      ind.innerHTML=''; ind.style.background='';
+      ind.style.borderColor=x==='premium'?'rgba(255,255,255,.5)':''; ind.style.color='';
+    }
+  });
+  updatePrices();
+}
+
+function updatePrices(){
+  document.getElementById('price-basic').innerHTML   = '&#8361;'+BASE.basic.toLocaleString();
+  document.getElementById('price-premium').innerHTML = '&#8361;'+BASE.premium.toLocaleString();
+  document.getElementById('summaryText').textContent = _plan==='basic'?'베이직':'프리미엄';
+  document.getElementById('summaryPrice').innerHTML  = '&#8361;'+BASE[_plan].toLocaleString();
+}
+
+function startPayment(){
+  var token=localStorage.getItem('access_token')||'';
+  var userId=localStorage.getItem('user_id')||'';
+  if(!token||!userId){ alert('로그인 후 결제해주세요.'); return; }
+
+  var btn=document.getElementById('btnPay');
+  var sp=document.getElementById('paySpinner');
+  var icon=document.getElementById('payIcon');
+  if(btn.disabled) return;
+  btn.disabled=true; sp.classList.remove('d-none'); icon.classList.add('d-none');
+
+  var total=BASE[_plan];
+  var goodname=PNAME[_plan];
+  var companyId=localStorage.getItem('company_id')||'';
+  var isBilling=(_type==='billing');
+
+  // 분기 1: 엔드포인트
+  var endpoint = isBilling
+      ? (API+'/payments/inicis/billing/prepare')
+      : (API+'/payments/inicis/prepare');
+
+  // 분기 2: returnUrl (콜백 경로가 다름)
+  var RETURN_URL = isBilling
+      ? (API+'/payments/inicis/billing/return')
+      : (API+'/payments/inicis/return');
+  var CLOSE_URL = API+'/payments/result?resultCode=CLOSE';
+
+  // 분기 3: 요청 body 구조
+  var payload;
+  if(isBilling){
+    payload = JSON.stringify({
+      user_id:      userId,
+      product_type: 'SAAS_FACILITY',
+      plan_code:    _plan.toUpperCase(),
+      plan_name:    goodname,
+      amount:       total,
+      company_id:   companyId || undefined,
+      buyername:    '고객',
+      buyertel:     '00000000000',
+      return_url:   RETURN_URL,
+      close_url:    CLOSE_URL
+    });
+  } else {
+    payload = JSON.stringify({
+      user_id:       userId,
+      product_type: 'SAAS_FACILITY',
+      company_id:    companyId || undefined,
+      amount:        total,
+      goodname:      goodname,
+      buyername:     '고객',
+      buyertel:      '00000000000',
+      plan_code:     _plan.toUpperCase(),
+      period_months: 1,
+      payment_type:  'CARD',
+      return_url:    RETURN_URL,
+      close_url:     CLOSE_URL
+    });
+  }
+
+  var xhr=new XMLHttpRequest();
+  xhr.open('POST', endpoint, true);
+  xhr.setRequestHeader('Content-Type','application/json');
+  if(token) xhr.setRequestHeader('Authorization','Bearer '+token);
+
+  xhr.onload=function(){
+    try{
+      var d=JSON.parse(xhr.responseText);
+      if(xhr.status<200||xhr.status>=300){
+        throw new Error(d.detail||d.message||'결제 준비 실패');
+      }
+      var p=d.data||d;
+
+      // 이니시스 form 공통 필드
+      document.getElementById('f_mid').value          = p.mid||'';
+      document.getElementById('f_oid').value          = p.oid||'';
+      document.getElementById('f_price').value        = p.price||String(total);
+      document.getElementById('f_timestamp').value    = p.timestamp||'';
+      document.getElementById('f_signature').value    = p.signature||'';
+      document.getElementById('f_verification').value = p.verification||'';
+      document.getElementById('f_mKey').value         = p.mKey||'';
+      document.getElementById('f_goodname').value     = p.goodname||goodname;
+      document.getElementById('f_buyername').value    = '고객';
+      document.getElementById('f_buyertel').value     = '00000000000';
+      document.getElementById('f_buyeremail').value   = '';
+      document.getElementById('f_returnUrl').value    = p.returnUrl || RETURN_URL;
+      document.getElementById('f_closeUrl').value     = p.closeUrl  || CLOSE_URL;
+
+      // 정기결제: gopaymethod=""(빈값) + acceptmethod="centerCd(Y):BILLAUTH(Card)"
+      // 단건  : gopaymethod="Card"   + acceptmethod="CARDONLY:CARDPOINT:centerCd(Y)"
+      document.getElementById('f_gopaymethod').value  = (p.gopaymethod!==undefined ? p.gopaymethod : 'Card');
+      document.getElementById('f_acceptmethod').value = (p.acceptmethod || 'CARDONLY:CARDPOINT:centerCd(Y)');
+
+      INIStdPay.pay('inicisForm');
+    } catch(e){
+      alert('오류: '+e.message);
+    } finally {
+      btn.disabled=false; sp.classList.add('d-none'); icon.classList.remove('d-none');
+    }
+  };
+  xhr.onerror=function(){
+    alert('네트워크 오류. 다시 시도해 주세요.');
+    btn.disabled=false; sp.classList.add('d-none'); icon.classList.remove('d-none');
+  };
+  xhr.send(payload);
+}
+
+// 초기화: URL 쿼리스트링 해석
+updatePrices();
+(function(){
+  var qs = new URLSearchParams(location.search);
+  var t  = qs.get('type');
+  if(t==='billing') selectType('billing');
+  var p = qs.get('plan');
+  if(p==='premium') selectPlan('premium');
+})();
 </script>
 </body></html>"""
 
@@ -882,8 +1072,8 @@ def vbank_prepare(body: VbankPrepareBody):
             "buyertel":      body.buyertel  or "00000000000",
             "buyeremail":    body.buyeremail or "",
             "timestamp":     timestamp,
-            "signature":     signature,
             "verification":  verification,
+            "signature":     signature,
             "use_chkfake":   "Y",
             "returnUrl":     DEFAULT_RETURN_URL,
             "closeUrl":      DEFAULT_CLOSE_URL,

--- a/routers/payment_billing.py
+++ b/routers/payment_billing.py
@@ -1,0 +1,823 @@
+"""
+이니시스 빌링(정기결제) 라우터 — v1.0.0 (2026-04-23)
+
+payments.py(단건결제)와는 별도 파일로 분리. 동일한 prefix="/payments"를
+사용하므로 FastAPI에서 include_router 하면 하나의 태그로 합쳐진다.
+
+이니시스 매뉴얼 기준 구현:
+  - 빌링키 발급(STEP3)      : SHA256 + SignKey   (단건결제와 동일)
+  - 빌링승인(Billing API)   : SHA512 + INIAPIKey (단건과 다름!)
+  - timestamp 포맷          : STEP3는 밀리초, 빌링승인은 YYYYMMDDhhmmss
+
+4 엔드포인트:
+  POST /payments/inicis/billing/prepare    — 빌링키 발급 준비
+  POST /payments/inicis/billing/return     — 이니시스 콜백 (내부 첫 결제 포함)
+  POST /payments/inicis/billing/charge     — 수동/cron 정기 청구
+  POST /payments/subscriptions/{id}/cancel — 구독 해지
+
+관련 DB:
+  subscriptions  : 구독 상태 관리 (PENDING → ACTIVE → CANCELLED/PAUSED/FAILED)
+  billing_keys   : 이니시스 빌링키 저장 (ACTIVE / REVOKED)
+  payments       : 회차별 결제 기록 (subscription_id, charge_cycle로 FK)
+
+관련 환경변수 (Railway):
+  INICIS_BILLING_MID          — 정기결제용 상점 ID
+  INICIS_BILLING_SIGN_KEY     — STEP3(SHA256)용
+  INICIS_BILLING_INIAPI_KEY   — Billing API(SHA512)용
+  INICIS_CLIENT_IP            — 이니시스 API 호출 시 clientIp 파라미터
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import urllib.parse
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+import requests as _requests
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, field_validator
+
+from db.supabase_client import get_supabase
+
+# payment.py에 정의된 공통 유틸/상수 재사용
+from routers.payment import (
+    DEFAULT_CLOSE_URL,
+    FRONT_RETURN_URL,
+    SAAS_PRODUCT_TYPES,
+    _sha256,
+    _ts_ms,
+    _now_iso,
+    _calc_expired_at,
+    _call_pay_auth,
+)
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/payments", tags=["결제"])
+
+
+# ── 환경변수 로더 ──────────────────────────────────────────────────────
+INICIS_BILLING_API_URL     = "https://iniapi.inicis.com/api/v1/billing"
+DEFAULT_BILLING_RETURN_URL = "https://api.taieng.co.kr/payments/inicis/billing/return"
+
+
+def _require_env(name: str) -> str:
+    """
+    정기결제 관련 환경변수는 폴백 없이 엄격하게 요구.
+    미설정 시 503 — 운영자가 Railway에 이니시스 정기결제 키를 등록해야 함을
+    명확하게 드러내기 위함(잘못된 단건 MID 폴백으로 인한 혼란 방지).
+    """
+    v = (os.getenv(name) or "").strip()
+    if not v:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"정기결제 환경변수 미설정: {name}. "
+                f"이니시스 정기결제 심사 완료 후 Railway에 등록 필요."
+            ),
+        )
+    return v
+
+
+def _load_billing_mid() -> str:
+    """정기결제용 MID — 단건 MID로 폴백하지 않음."""
+    return _require_env("INICIS_BILLING_MID")
+
+
+def _load_billing_sign_key() -> str:
+    """빌링키 발급(STEP3)용 SignKey — SHA256 대상."""
+    return _require_env("INICIS_BILLING_SIGN_KEY")
+
+
+def _load_billing_iniapi_key() -> str:
+    """빌링승인용 INIAPIKey — SHA512 대상."""
+    return _require_env("INICIS_BILLING_INIAPI_KEY")
+
+
+def _load_client_ip() -> str:
+    """가맹점 서버 IP — 이니시스 방화벽 등록된 고정IP."""
+    return _require_env("INICIS_CLIENT_IP")
+
+
+
+
+# ── 유틸 ──────────────────────────────────────────────────────────────
+
+def _sha512(data: str) -> str:
+    return hashlib.sha512(data.encode("utf-8")).hexdigest()
+
+
+def _make_billing_oid() -> str:
+    """빌링키 발급 주문번호 — TAI-BIL-YYYYMMDDhhmmss-xxxxxx"""
+    return f"TAI-BIL-{datetime.now():%Y%m%d%H%M%S}-{uuid4().hex[:6].upper()}"
+
+
+def _make_charge_moid(subscription_id: str, cycle: int) -> str:
+    """정기청구 주문번호 — TAI-SUB-<sub_id 첫8자>-<cycle>"""
+    sid = (subscription_id or "").replace("-", "")[:8].upper()
+    return f"TAI-SUB-{sid}-{int(cycle)}"
+
+
+def _ts_yyyymmddhhmmss() -> str:
+    """빌링승인 API용 timestamp — YYYYMMDDhhmmss (STEP3의 밀리초와 다름)"""
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def _call_billing_charge_api(
+    *,
+    mid: str,
+    iniapi_key: str,
+    client_ip: str,
+    moid: str,
+    bill_key: str,
+    price: int,
+    goodname: str,
+    buyer_name: str,
+    buyer_email: str,
+    buyer_tel: str,
+    merchant_url: str = "https://taieng.co.kr",
+) -> Dict[str, Any]:
+    """
+    이니시스 빌링승인 API 호출 (SHA512 + INIAPIKey).
+    이니시스 매뉴얼 §빌링결제>빌링승인 기준.
+
+    hashData = SHA512(INIAPIKey + type + paymethod + timestamp
+                      + clientIp + mid + moid + price + billKey)
+    반환: 이니시스 JSON (resultCode / resultMsg / tid / payAuthCode 등)
+    """
+    timestamp = _ts_yyyymmddhhmmss()
+    paymethod = "Card"
+    req_type  = "Billing"
+    price_str = str(int(price))
+
+    hash_src  = (
+        iniapi_key + req_type + paymethod + timestamp
+        + client_ip + mid + moid + price_str + bill_key
+    )
+    hash_data = _sha512(hash_src)
+
+    form: Dict[str, str] = {
+        "type":              req_type,
+        "paymethod":         paymethod,
+        "timestamp":         timestamp,
+        "clientIp":          client_ip,
+        "mid":               mid,
+        "url":               merchant_url,
+        "moid":              moid,
+        "goodName":          goodname[:80],
+        "buyerName":         (buyer_name or "고객")[:80],
+        "buyerEmail":        (buyer_email or "")[:60],
+        "buyerTel":          (buyer_tel or "")[:40],
+        "price":             price_str,
+        "billKey":           bill_key,
+        "authentification":  "00",
+        "hashData":          hash_data,
+    }
+
+    log.info(f"[BILLING CHARGE] moid={moid} mid={mid} price={price_str}")
+    try:
+        resp = _requests.post(
+            INICIS_BILLING_API_URL,
+            data=form,
+            timeout=30,
+            headers={"Content-Type": "application/x-www-form-urlencoded;charset=utf-8"},
+        )
+    except Exception as e:
+        log.error(f"[BILLING CHARGE] 네트워크 오류: {e}")
+        raise HTTPException(status_code=502, detail=f"이니시스 빌링 API 호출 실패: {e}")
+
+    try:
+        result = resp.json()
+    except Exception:
+        log.error(f"[BILLING CHARGE] 응답 파싱 실패 status={resp.status_code} body={resp.text[:500]}")
+        raise HTTPException(status_code=502, detail="이니시스 빌링승인 응답 파싱 실패")
+
+    log.info(
+        f"[BILLING CHARGE] resultCode={result.get('resultCode')} "
+        f"resultMsg={result.get('resultMsg')}"
+    )
+    return result
+
+
+# ── Pydantic 모델 ──────────────────────────────────────────────────────
+
+class BillingPrepareBody(BaseModel):
+    """빌링키 발급 준비 Body"""
+    user_id:      str
+    product_type: str
+    plan_code:    str
+    plan_name:    str
+    amount:       int
+    company_id:   Optional[str] = None
+    buyername:    Optional[str] = "고객"
+    buyertel:     Optional[str] = "00000000000"
+    buyeremail:   Optional[str] = None
+    return_url:   Optional[str] = None
+    close_url:    Optional[str] = None
+
+    @field_validator("user_id")
+    @classmethod
+    def user_id_required(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("user_id는 필수값입니다. 로그인 후 결제해주세요.")
+        return v.strip()
+
+    @field_validator("product_type")
+    @classmethod
+    def must_be_saas(cls, v: str) -> str:
+        if v not in SAAS_PRODUCT_TYPES:
+            raise ValueError(f"정기결제는 SaaS 상품에만 가능합니다: {SAAS_PRODUCT_TYPES}")
+        return v
+
+
+class BillingChargeBody(BaseModel):
+    """수동/cron 청구 Body"""
+    subscription_id: str
+    charge_cycle:    Optional[int] = None
+
+    @field_validator("subscription_id")
+    @classmethod
+    def sub_id_required(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("subscription_id는 필수값입니다.")
+        return v.strip()
+
+
+class SubscriptionCancelBody(BaseModel):
+    """구독 해지 Body"""
+    reason:       Optional[str] = "사용자 요청"
+    cancelled_by: Optional[str] = None
+
+
+# ── 내부 함수 ─────────────────────────────────────────────────────────
+
+def _charge_subscription_once(
+    supabase,
+    *,
+    subscription: Dict[str, Any],
+    billing_key_row: Dict[str, Any],
+    charge_cycle: int,
+    is_recurring: bool,
+    buyer_name: str = "고객",
+    buyer_email: str = "",
+    buyer_tel: str = "",
+) -> Dict[str, Any]:
+    """
+    한 주기 청구 실행. payments INSERT → 이니시스 호출 → 결과 반영.
+    반환: {"success": bool, "payment_id": str, "result": dict}
+    """
+    now             = _now_iso()
+    subscription_id = subscription["id"]
+    user_id         = subscription["user_id"]
+    company_id      = subscription.get("company_id")
+    product_type    = subscription["product_type"]
+    plan_code       = subscription.get("plan_code")
+    plan_name       = subscription.get("plan_name", "TAI Safe")
+    amount          = int(subscription["amount"])
+    supply          = int(subscription["supply_amount"])
+    vat             = int(subscription["vat_amount"])
+    bill_key        = billing_key_row["bill_key"]
+    billing_key_id  = billing_key_row["id"]
+    mid             = billing_key_row.get("mid") or _load_billing_mid()
+
+    moid = _make_charge_moid(subscription_id, charge_cycle)
+
+    # 0) 환경변수 선로드 — 미설정 시 503. payments INSERT 전에 체크해서
+    #    쓰레기 PENDING 레코드가 생기지 않도록 한다.
+    iniapi_key = _load_billing_iniapi_key()
+    client_ip  = _load_client_ip()
+
+    # 1) payments PENDING INSERT (UNIQUE 제약으로 중복방지)
+    payment_row: Dict[str, Any] = {
+        "user_id":         user_id,
+        "product_type":    product_type,
+        "payment_method":  "INICIS",
+        "payment_type":    "CARD",
+        "pg_method":       "CardBilling",
+        "supply_amount":   supply,
+        "vat_amount":      vat,
+        "total_amount":    amount,
+        "inicis_order_id": moid,
+        "status_code":     "PENDING",
+        "service_status":  None,
+        "subscription_id": subscription_id,
+        "billing_key_id":  billing_key_id,
+        "charge_cycle":    charge_cycle,
+        "is_recurring":    is_recurring,
+        "plan_code":       plan_code,
+        "period_months":   1,
+        "created_at":      now,
+        "updated_at":      now,
+    }
+    if company_id:
+        payment_row["company_id"] = company_id
+
+    try:
+        ins = supabase.table("payments").insert(payment_row).execute()
+    except Exception as e:
+        # UNIQUE 위반(이미 같은 subscription_id + cycle 존재) 등
+        log.error(f"[BILLING] payments INSERT 실패 sub={subscription_id} cycle={charge_cycle}: {e}")
+        raise HTTPException(status_code=409, detail=f"결제 레코드 생성 실패 (중복 가능): {e}")
+
+    if not ins.data:
+        raise HTTPException(status_code=500, detail="결제 레코드 생성 실패")
+    payment_id = ins.data[0]["id"]
+
+    # 2) 이니시스 빌링승인 호출 (환경변수는 위에서 선로드됨)
+
+    try:
+        result = _call_billing_charge_api(
+            mid=mid,
+            iniapi_key=iniapi_key,
+            client_ip=client_ip,
+            moid=moid,
+            bill_key=bill_key,
+            price=amount,
+            goodname=plan_name,
+            buyer_name=buyer_name,
+            buyer_email=buyer_email,
+            buyer_tel=buyer_tel,
+        )
+    except HTTPException:
+        # _call_billing_charge_api 내부에서 이미 업스트림 처리
+        fail_reason = "이니시스 빌링승인 호출 실패"
+        supabase.table("payments").update({
+            "status_code": "FAILED",
+            "fail_reason": fail_reason,
+            "updated_at":  _now_iso(),
+        }).eq("id", payment_id).execute()
+        _apply_failure_to_subscription(supabase, subscription_id, fail_reason)
+        return {"success": False, "payment_id": payment_id, "result": {"error": fail_reason}}
+    except Exception as e:
+        log.error(f"[BILLING] charge 예외 sub={subscription_id} cycle={charge_cycle}: {e}")
+        fail_reason = f"빌링승인 API 호출 실패: {e}"
+        supabase.table("payments").update({
+            "status_code": "FAILED",
+            "fail_reason": fail_reason[:500],
+            "updated_at":  _now_iso(),
+        }).eq("id", payment_id).execute()
+        _apply_failure_to_subscription(supabase, subscription_id, fail_reason)
+        return {"success": False, "payment_id": payment_id, "result": {"error": str(e)}}
+
+    # 3) 결과 반영
+    is_ok = str(result.get("resultCode", "")) == "00"
+    now2  = _now_iso()
+
+    if is_ok:
+        paid_at    = now2
+        expired_at = _calc_expired_at(paid_at, 1)   # 1개월
+
+        supabase.table("payments").update({
+            "status_code":      "SUCCESS",
+            "service_status":   "ACTIVE",
+            "inicis_tid":       result.get("tid", ""),
+            "inicis_auth_code": result.get("payAuthCode", ""),
+            "inicis_raw":       result,
+            "paid_at":          paid_at,
+            "expired_at":       expired_at,
+            "updated_at":       now2,
+        }).eq("id", payment_id).execute()
+
+        supabase.table("subscriptions").update({
+            "last_billed_at":      paid_at,
+            "next_billing_at":     expired_at,
+            "failure_count":       0,
+            "last_failure_at":     None,
+            "last_failure_reason": None,
+            "updated_at":          now2,
+        }).eq("id", subscription_id).execute()
+
+        return {"success": True, "payment_id": payment_id, "result": result}
+
+    # 실패
+    fail_reason = result.get("resultMsg") or f"resultCode={result.get('resultCode')}"
+    supabase.table("payments").update({
+        "status_code": "FAILED",
+        "fail_reason": fail_reason[:500] if fail_reason else None,
+        "inicis_raw":  result,
+        "updated_at":  now2,
+    }).eq("id", payment_id).execute()
+    _apply_failure_to_subscription(supabase, subscription_id, fail_reason or "청구 실패")
+    return {"success": False, "payment_id": payment_id, "result": result}
+
+
+def _apply_failure_to_subscription(supabase, subscription_id: str, reason: str) -> None:
+    """실패 카운트 증가 + 3회 이상 시 PAUSED."""
+    now = _now_iso()
+    cur = (
+        supabase.table("subscriptions")
+        .select("failure_count, status")
+        .eq("id", subscription_id)
+        .limit(1)
+        .execute()
+    )
+    if not cur.data:
+        return
+    current_count = int(cur.data[0].get("failure_count") or 0)
+    new_count     = current_count + 1
+    upd: Dict[str, Any] = {
+        "failure_count":       new_count,
+        "last_failure_at":     now,
+        "last_failure_reason": (reason or "")[:500] if reason else None,
+        "updated_at":          now,
+    }
+    if new_count >= 3 and cur.data[0].get("status") == "ACTIVE":
+        upd["status"] = "PAUSED"
+        log.warning(f"[BILLING] subscription {subscription_id} PAUSED (failure_count={new_count})")
+    supabase.table("subscriptions").update(upd).eq("id", subscription_id).execute()
+
+
+def _fail_subscription_by_oid(supabase, oid: str, reason: str) -> None:
+    """prepare/return 단계에서 실패한 구독을 FAILED로 마킹."""
+    if not oid:
+        return
+    supabase.table("subscriptions").update({
+        "status":              "FAILED",
+        "last_failure_at":     _now_iso(),
+        "last_failure_reason": (reason or "")[:500],
+        "updated_at":          _now_iso(),
+    }).eq("inicis_order_id", oid).execute()
+
+
+# ── 엔드포인트 ────────────────────────────────────────────────────────
+
+@router.post("/inicis/billing/prepare")
+def billing_prepare(body: BillingPrepareBody):
+    """
+    정기결제 빌링키 발급 준비 (STEP1).
+    subscriptions PENDING 행을 만들고, 클라이언트에 INIStdPay 파라미터를 반환.
+    """
+    supabase  = get_supabase()
+    mid       = _load_billing_mid()
+    sign_key  = _load_billing_sign_key()
+    oid       = _make_billing_oid()
+    timestamp = _ts_ms()
+    price_str = str(body.amount)
+    mKey      = _sha256(sign_key)
+
+    sig_data     = f"oid={oid}&price={price_str}&timestamp={timestamp}"
+    veri_data    = f"oid={oid}&price={price_str}&signKey={sign_key}&timestamp={timestamp}"
+    signature    = _sha256(sig_data)
+    verification = _sha256(veri_data)
+
+    supply_amount = round(body.amount / 1.1)
+    vat_amount    = body.amount - supply_amount
+    now           = _now_iso()
+
+    sub_row: Dict[str, Any] = {
+        "user_id":         body.user_id,
+        "product_type":    body.product_type,
+        "plan_code":       body.plan_code,
+        "plan_name":       body.plan_name,
+        "amount":          body.amount,
+        "supply_amount":   supply_amount,
+        "vat_amount":      vat_amount,
+        "billing_cycle":   "monthly",
+        "status":          "PENDING",
+        "inicis_order_id": oid,
+        "created_at":      now,
+        "updated_at":      now,
+    }
+    if body.company_id:
+        sub_row["company_id"] = body.company_id
+
+    res = supabase.table("subscriptions").insert(sub_row).execute()
+    if not res.data:
+        raise HTTPException(status_code=500, detail="구독 레코드 생성 실패")
+
+    subscription_id = res.data[0]["id"]
+    log.info(f"[BILLING PREPARE] oid={oid} subscription_id={subscription_id} user={body.user_id}")
+
+    return {
+        "status": "success",
+        "data": {
+            "subscription_id": subscription_id,
+            "mid":             mid,
+            "mKey":            mKey,
+            "oid":             oid,
+            "price":           price_str,
+            "goodname":        body.plan_name,
+            "buyername":       body.buyername or "고객",
+            "buyertel":        body.buyertel  or "00000000000",
+            "buyeremail":      body.buyeremail or "",
+            "timestamp":       timestamp,
+            "signature":       signature,
+            "verification":    verification,
+            "use_chkfake":     "Y",
+            "returnUrl":       body.return_url or DEFAULT_BILLING_RETURN_URL,
+            "closeUrl":        body.close_url  or DEFAULT_CLOSE_URL,
+            "charset":         "UTF-8",
+            "gopaymethod":     "",                                # 빌링은 빈값 고정
+            "acceptmethod":    "centerCd(Y):BILLAUTH(Card)",      # 빌링키 발급 옵션
+        },
+    }
+
+
+@router.post("/inicis/billing/return", include_in_schema=True)
+async def billing_return(request: Request):
+    """
+    빌링키 발급 콜백 (STEP2 → STEP3 → BillKey 저장 → 첫 결제).
+    성공 시 /payments/result 로 RedirectResponse.
+    """
+    try:
+        form = await request.form()
+        data: Dict[str, Any] = dict(form)
+    except Exception:
+        try:
+            data = await request.json()
+        except Exception:
+            return RedirectResponse(
+                f"{FRONT_RETURN_URL}?resultCode=FAIL&msg=파싱실패",
+                status_code=302,
+            )
+
+    result_code = data.get("resultCode", "")
+    result_msg  = data.get("resultMsg", "")
+    auth_token  = data.get("authToken", "")
+    auth_url    = data.get("authUrl", "")
+    order_id    = data.get("orderNumber") or data.get("oid", "")
+    log.info(f"[BILLING RETURN] resultCode={result_code} oid={order_id}")
+
+    supabase = get_supabase()
+
+    if result_code and result_code != "0000":
+        _fail_subscription_by_oid(supabase, order_id, result_msg or "인증 실패")
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(result_msg or '인증 실패')}&oid={order_id}",
+            status_code=302,
+        )
+
+    # 구독 조회
+    sub_res = (
+        supabase.table("subscriptions")
+        .select("*")
+        .eq("inicis_order_id", order_id)
+        .limit(1)
+        .execute()
+    )
+    if not sub_res.data:
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg=구독정보없음&oid={order_id}",
+            status_code=302,
+        )
+    subscription    = sub_res.data[0]
+    subscription_id = subscription["id"]
+
+    # 멱등: 이미 처리됨
+    if subscription.get("status") == "ACTIVE":
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=00&oid={order_id}&subscription_id={subscription_id}",
+            status_code=302,
+        )
+
+    if not auth_url:
+        _fail_subscription_by_oid(supabase, order_id, "authUrl 없음")
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg=authUrl없음&oid={order_id}",
+            status_code=302,
+        )
+
+    # STEP3: BillKey 발급 요청 (SHA256 + signKey — 단건결제와 동일 패턴)
+    sign_key = _load_billing_sign_key()
+    try:
+        auth_result = _call_pay_auth(auth_token, auth_url, sign_key)
+    except Exception as e:
+        _fail_subscription_by_oid(supabase, order_id, f"STEP3 호출 실패: {e}")
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg=STEP3오류&oid={order_id}",
+            status_code=302,
+        )
+
+    if str(auth_result.get("resultCode", "")) != "0000":
+        fail = auth_result.get("resultMsg", "빌링키 발급 실패")
+        _fail_subscription_by_oid(supabase, order_id, fail)
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(fail)}&oid={order_id}",
+            status_code=302,
+        )
+
+    # ── BillKey 저장 ───────────────────────────────────────────────
+    bill_key = auth_result.get("CARD_BillKey", "")
+    if not bill_key:
+        _fail_subscription_by_oid(supabase, order_id, "CARD_BillKey 응답 없음")
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg=빌링키없음&oid={order_id}",
+            status_code=302,
+        )
+
+    now              = _now_iso()
+    mid_used         = _load_billing_mid()
+    card_num_masked  = auth_result.get("CARD_Num", "")
+    card_issuer_code = auth_result.get("CARD_Code", "")
+    card_name        = auth_result.get("P_FN_NM") or auth_result.get("CARD_BankCode", "")
+
+    bk_ins = supabase.table("billing_keys").insert({
+        "user_id":          subscription["user_id"],
+        "company_id":       subscription.get("company_id"),
+        "bill_key":         bill_key,
+        "mid":              mid_used,
+        "inicis_tid":       auth_result.get("tid", ""),
+        "card_name":        card_name,
+        "card_num_masked":  card_num_masked,
+        "card_issuer_code": card_issuer_code,
+        "status":           "ACTIVE",
+        "issued_at":        now,
+        "inicis_raw":       auth_result,
+        "created_at":       now,
+        "updated_at":       now,
+    }).execute()
+    if not bk_ins.data:
+        _fail_subscription_by_oid(supabase, order_id, "billing_keys 저장 실패")
+        return RedirectResponse(
+            f"{FRONT_RETURN_URL}?resultCode=FAIL&msg=빌링키저장실패&oid={order_id}",
+            status_code=302,
+        )
+    billing_key_row = bk_ins.data[0]
+    billing_key_id  = billing_key_row["id"]
+
+    # ── subscription ACTIVE 전환 ───────────────────────────────────
+    supabase.table("subscriptions").update({
+        "billing_key_id":  billing_key_id,
+        "status":          "ACTIVE",
+        "started_at":      now,
+        "next_billing_at": _calc_expired_at(now, 1),
+        "updated_at":      now,
+    }).eq("id", subscription_id).execute()
+
+    # 업데이트 반영된 subscription 재조회
+    sub_cur = (
+        supabase.table("subscriptions")
+        .select("*")
+        .eq("id", subscription_id)
+        .limit(1)
+        .execute()
+    )
+    subscription = sub_cur.data[0] if sub_cur.data else subscription
+
+    # ── 첫 결제 (cycle=1, is_recurring=False) ──────────────────────
+    charge_res = _charge_subscription_once(
+        supabase,
+        subscription=subscription,
+        billing_key_row=billing_key_row,
+        charge_cycle=1,
+        is_recurring=False,
+        buyer_name=auth_result.get("buyerName", "고객"),
+        buyer_email=auth_result.get("buyerEmail", ""),
+        buyer_tel=auth_result.get("buyerTel", ""),
+    )
+
+    if charge_res.get("success"):
+        qs = urllib.parse.urlencode({
+            "resultCode":      "00",
+            "oid":             order_id,
+            "goodname":        subscription.get("plan_name", "TAI Safe"),
+            "price":           str(int(subscription["amount"])),
+            "paymethod":       "CardBilling",
+            "applnum":         charge_res["result"].get("payAuthCode", ""),
+            "payment_id":      charge_res["payment_id"],
+            "subscription_id": subscription_id,
+            "expired_at":      subscription.get("next_billing_at") or "",
+        })
+        return RedirectResponse(f"{FRONT_RETURN_URL}?{qs}", status_code=302)
+
+    fail_msg = charge_res.get("result", {}).get("resultMsg", "첫 결제 실패")
+    return RedirectResponse(
+        f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(str(fail_msg))}&oid={order_id}",
+        status_code=302,
+    )
+
+
+@router.post("/inicis/billing/charge")
+def billing_charge(body: BillingChargeBody):
+    """
+    정기청구 수동/cron 실행.
+    charge_cycle 생략 시 기존 payments 건수 + 1로 자동 계산.
+    """
+    supabase = get_supabase()
+
+    sub_res = (
+        supabase.table("subscriptions")
+        .select("*")
+        .eq("id", body.subscription_id)
+        .limit(1)
+        .execute()
+    )
+    if not sub_res.data:
+        raise HTTPException(status_code=404, detail="구독을 찾을 수 없습니다.")
+    subscription = sub_res.data[0]
+
+    if subscription.get("status") != "ACTIVE":
+        raise HTTPException(
+            status_code=409,
+            detail=f"ACTIVE 상태에서만 청구 가능합니다. (현재 status={subscription.get('status')})",
+        )
+
+    billing_key_id = subscription.get("billing_key_id")
+    if not billing_key_id:
+        raise HTTPException(status_code=409, detail="구독에 연결된 빌링키가 없습니다.")
+
+    bk_res = (
+        supabase.table("billing_keys")
+        .select("*")
+        .eq("id", billing_key_id)
+        .limit(1)
+        .execute()
+    )
+    if not bk_res.data:
+        raise HTTPException(status_code=404, detail="빌링키를 찾을 수 없습니다.")
+    billing_key_row = bk_res.data[0]
+    if billing_key_row.get("status") != "ACTIVE":
+        raise HTTPException(
+            status_code=409,
+            detail=f"빌링키가 ACTIVE 상태가 아닙니다. (status={billing_key_row.get('status')})",
+        )
+
+    # charge_cycle 자동 계산
+    cycle = body.charge_cycle
+    if cycle is None:
+        cnt_res = (
+            supabase.table("payments")
+            .select("id", count="exact")
+            .eq("subscription_id", body.subscription_id)
+            .execute()
+        )
+        cycle = (cnt_res.count or 0) + 1
+
+    result = _charge_subscription_once(
+        supabase,
+        subscription=subscription,
+        billing_key_row=billing_key_row,
+        charge_cycle=cycle,
+        is_recurring=True,
+    )
+
+    return {
+        "status":   "success" if result.get("success") else "failed",
+        "data": {
+            "subscription_id": body.subscription_id,
+            "payment_id":      result.get("payment_id"),
+            "charge_cycle":    cycle,
+            "inicis_result":   result.get("result"),
+        },
+    }
+
+
+@router.post("/subscriptions/{subscription_id}/cancel")
+def cancel_subscription(subscription_id: str, body: SubscriptionCancelBody):
+    """
+    구독 해지.
+    - subscriptions.status = CANCELLED
+    - billing_keys.status  = REVOKED (DB 기록)
+    - 이니시스 BillKey 자체 폐기 API는 호출하지 않음 (매뉴얼상 별도 API 없음).
+      다음 주기 청구를 멈추기만 하면 충분. 기존 결제분 환불은 별도 기능.
+    """
+    supabase = get_supabase()
+    now      = _now_iso()
+
+    sub_res = (
+        supabase.table("subscriptions")
+        .select("*")
+        .eq("id", subscription_id)
+        .limit(1)
+        .execute()
+    )
+    if not sub_res.data:
+        raise HTTPException(status_code=404, detail="구독을 찾을 수 없습니다.")
+    subscription = sub_res.data[0]
+
+    if subscription.get("status") == "CANCELLED":
+        raise HTTPException(status_code=409, detail="이미 해지된 구독입니다.")
+
+    supabase.table("subscriptions").update({
+        "status":          "CANCELLED",
+        "cancelled_at":    now,
+        "cancel_reason":   body.reason or "사용자 요청",
+        "next_billing_at": None,
+        "ended_at":        now,
+        "updated_at":      now,
+    }).eq("id", subscription_id).execute()
+
+    billing_key_id = subscription.get("billing_key_id")
+    if billing_key_id:
+        supabase.table("billing_keys").update({
+            "status":        "REVOKED",
+            "revoked_at":    now,
+            "revoke_reason": body.reason or "사용자 요청",
+            "updated_at":    now,
+        }).eq("id", billing_key_id).execute()
+
+    log.info(f"[BILLING CANCEL] subscription_id={subscription_id} reason={body.reason}")
+
+    return {
+        "status":  "success",
+        "message": "구독이 해지되었습니다.",
+        "data": {
+            "subscription_id": subscription_id,
+            "status":          "CANCELLED",
+            "cancelled_at":    now,
+        },
+    }

--- a/supabase/migrations/20260423_billing_phase2_schema_adjust.sql
+++ b/supabase/migrations/20260423_billing_phase2_schema_adjust.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- Billing Phase 2 schema adjustments
+-- Date: 2026-04-23
+-- Related: tai-api #45 (Billing endpoints)
+--
+-- Changes:
+--   1) subscriptions.billing_key_id -> NULLABLE
+--      reason: During PENDING (before BillKey issuance), the key does not
+--              yet exist. We populate billing_key_id only after the
+--              /billing/return callback succeeds.
+--
+--   2) subscriptions.inicis_order_id (new TEXT column)
+--      reason: The callback from INICIS arrives with orderNumber (oid).
+--              We need an indexed column to look up the PENDING subscription
+--              by oid. Same pattern as payments.inicis_order_id.
+--
+--   3) payments(subscription_id, charge_cycle) UNIQUE (partial)
+--      reason: Idempotency guard for recurring charges. Prevents two
+--              charges from being recorded for the same subscription/cycle
+--              when a retry or duplicate cron tick occurs.
+-- ============================================================================
+
+-- 1) Allow NULL for billing_key_id during PENDING state
+ALTER TABLE subscriptions
+    ALTER COLUMN billing_key_id DROP NOT NULL;
+
+COMMENT ON COLUMN subscriptions.billing_key_id IS
+    'FK to billing_keys.id. NULL while subscription is PENDING (before BillKeyAuth). Set after /billing/return succeeds.';
+
+-- 2) Add inicis_order_id for callback lookup
+ALTER TABLE subscriptions
+    ADD COLUMN IF NOT EXISTS inicis_order_id TEXT;
+
+COMMENT ON COLUMN subscriptions.inicis_order_id IS
+    'INICIS oid issued at /billing/prepare (e.g. TAI-BIL-YYYYMMDDhhmmss-xxxxxx). Used to match the /billing/return callback to the PENDING subscription row.';
+
+-- Unique index on non-null inicis_order_id (duplicate prepare guard)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_subscriptions_inicis_order_id
+    ON subscriptions(inicis_order_id)
+    WHERE inicis_order_id IS NOT NULL;
+
+-- 3) Idempotency guard for recurring charges
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payments_subscription_cycle
+    ON payments(subscription_id, charge_cycle)
+    WHERE subscription_id IS NOT NULL;
+
+COMMENT ON INDEX idx_payments_subscription_cycle IS
+    'Prevents duplicate charges for the same subscription/cycle (retry or cron double-tick).';


### PR DESCRIPTION
## 요약

이슈 #45 Phase 2 — 이니시스 CardBilling(정기결제) 4개 엔드포인트 신규 추가.

## 엔드포인트

| Method | URL | 용도 |
|---|---|---|
| POST | `/payments/inicis/billing/prepare`    | 빌링키 발급 준비 (STEP1) |
| POST | `/payments/inicis/billing/return`     | 이니시스 콜백 → STEP3 → BillKey 저장 → 첫 결제 |
| POST | `/payments/inicis/billing/charge`     | 수동/cron 정기 청구 |
| POST | `/payments/subscriptions/{id}/cancel` | 구독 해지 |

## 주요 설계

- **이니시스 공식 매뉴얼 기준** (https://manual.inicis.com/pay/bill.html)
  - 빌링키 발급 (STEP3): `SHA256(authToken + signKey + timestamp)` + SignKey → 단건결제 승인 API와 동일 패턴
  - 빌링승인 API: `SHA512(INIAPIKey + type + paymethod + timestamp + clientIp + mid + moid + price + billKey)` + INIAPIKey → **단건과 완전히 다름**
  - timestamp 포맷: STEP3는 밀리초, 빌링승인은 `YYYYMMDDhhmmss`
  - 엔드포인트 URL: `https://iniapi.inicis.com/api/v1/billing` (운영)
  - BillKey 폐기 API는 매뉴얼에 없음 → 구독 해지 시 DB만 REVOKED로 표시

- **별도 파일 분리** (`routers/payment_billing.py` 신규)
  - `payment.py`(단건결제) 건드리지 않음, 롤백 안전
  - `prefix="/payments"` 공유로 Swagger상 한 섹션으로 통합
  - 공통 헬퍼(`_sha256`, `_ts_ms`, `_now_iso`, `_calc_expired_at`, `_call_pay_auth` 등)는 `payment.py`에서 import해 재사용

- **환경변수 엄격 체크** (`_require_env` → 503)
  - `INICIS_BILLING_MID` / `INICIS_BILLING_SIGN_KEY` / `INICIS_BILLING_INIAPI_KEY` / `INICIS_CLIENT_IP`
  - 미설정 시 단건 MID로 폴백하지 않고 503 반환 — 이니시스 정기결제 키 등록 전 잘못된 단건 MID 사용 방지
  - 환경변수 체크를 `payments` INSERT **전**에 수행해 쓰레기 PENDING 레코드 방지

- **멱등성 / 실패 관리**
  - 콜백이 `subscriptions.inicis_order_id`로 PENDING 구독을 찾음
  - 이미 ACTIVE인 구독의 콜백은 즉시 성공 응답 (중복 호출 안전)
  - `payments(subscription_id, charge_cycle)` UNIQUE partial index로 중복 결제 방지
  - 연속 3회 실패 시 `subscriptions.status = PAUSED`

## 변경 파일

| 파일 | 종류 | 라인 |
|---|---|---|
| `supabase/migrations/20260423_billing_phase2_schema_adjust.sql` | 신규 | 51 |
| `routers/payment_billing.py` | 신규 | 824 |
| `main.py` | 수정 | +3 (import, include_router, 버전주석) |

## 스키마 변경 (마이그레이션)

1. `subscriptions.billing_key_id` → NULLABLE (PENDING 단계에서는 빌링키 없음)
2. `subscriptions.inicis_order_id TEXT` 추가 + partial unique index
3. `payments(subscription_id, charge_cycle)` partial unique index (중복 결제 방지)

## 운영 측 필요 작업

이 PR 머지 **후** 다음을 순차 진행:

1. **Supabase 마이그레이션 실행**  
   `supabase/migrations/20260423_billing_phase2_schema_adjust.sql` 내용을 SQL Editor에서 실행
2. **이니시스 정기결제 심사 완료 대기**  
   KG이니시스 신혜영 매니저로부터 정기결제용 MID/SignKey/INIAPIKey 수령
3. **Railway 환경변수 등록**  
   - `INICIS_BILLING_MID` = 이니시스 발급 정기결제 상점 ID
   - `INICIS_BILLING_SIGN_KEY` = 정기결제 SignKey (빌링키 발급 STEP3용, SHA256)
   - `INICIS_BILLING_INIAPI_KEY` = INIAPIKey (빌링승인 API용, SHA512)
   - `INICIS_CLIENT_IP` = `115.68.227.222` (iwinv 고정IP, 이미 등록된 경우 불필요)
4. **방화벽 확인** — 이니시스 정기결제 영업담당자에게 outbound IP `115.68.227.222`가 화이트리스트에 등록됐는지 확인
5. **Phase 3/4 진행** — `/payments/pricing` UI에 `?type=billing` 토글 추가, `tai-admin/pricing.html` 링크 분기

## 테스트 주의사항

환경변수 미등록 상태로 `/billing/prepare`를 호출하면 **503 에러**가 명시적으로 반환됩니다 (의도된 동작). 이는 Phase 5 E2E 테스트 시 이니시스 키가 아직 없어도 Swagger 스키마 검증은 가능하다는 의미입니다.

## 롤백

이 PR을 revert하고 main.py에서 `payment_billing_router` 등록을 제거하면 기존 단건결제에 영향 없이 롤백됩니다. 마이그레이션은 ADD COLUMN/DROP NOT NULL이라 역마이그레이션 없이도 안전합니다 (기존 데이터가 있으면 `DROP NOT NULL` 되돌리기 어려울 수 있으니 롤백 시 주의).

## Related

- Closes part of #45 (Phase 2)
- 후속 Phase 3-5는 이 PR 머지 후 별도 PR로 진행 예정