### PR TITLE
fix: construction UUID 검증 추가 (500→400)

### DIFF
--- a/routers/construction_sites_router.py
+++ b/routers/construction_sites_router.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -27,6 +28,14 @@ router = APIRouter(tags=["건설안전"])
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_uuid(value: str) -> str:
+    try:
+        uuid.UUID(value)
+        return value
+    except ValueError:
+        raise HTTPException(status_code=400, detail="유효하지 않은 ID 형식입니다.")
 
 
 @router.get("/sites")
@@ -68,6 +77,7 @@ async def create_site(body: SiteCreate):
 
 @router.get("/sites/{site_id}")
 async def get_site(site_id: str):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     res = supabase.table("construction_sites").select("*").eq("id", site_id).eq("is_active", True).limit(1).execute()
     if not res.data:
@@ -77,6 +87,7 @@ async def get_site(site_id: str):
 
 @router.patch("/sites/{site_id}")
 async def update_site(site_id: str, body: SitePatch):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = body.model_dump(exclude_none=True)
@@ -97,6 +108,7 @@ async def update_site(site_id: str, body: SitePatch):
 
 @router.delete("/sites/{site_id}")
 async def delete_site(site_id: str):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     res = supabase.table("construction_sites").update({"is_active": False, "updated_at": _now_iso()}).eq("id", site_id).execute()
     if not res.data:
@@ -106,6 +118,7 @@ async def delete_site(site_id: str):
 
 @router.get("/sites/{site_id}/stats")
 async def get_site_stats(site_id: str):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         site_res = supabase.table("construction_sites").select("*").eq("id", site_id).limit(1).execute()
@@ -125,6 +138,7 @@ async def get_site_stats(site_id: str):
 
 @router.post("/sites/{site_id}/diagnose")
 async def diagnose_site(site_id: str):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         _, factory_id, diag = run_diagnose_site(
@@ -154,6 +168,7 @@ async def diagnose_site(site_id: str):
 
 @router.post("/sites/{site_id}/generate-schedules")
 async def generate_schedules(site_id: str):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         factory_id, sched = run_generate_site_schedules(supabase, site_id, run_generate_schedules)

--- a/routers/construction_workflow_router.py
+++ b/routers/construction_workflow_router.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -42,6 +43,14 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _validate_uuid(value: str) -> str:
+    try:
+        uuid.UUID(value)
+        return value
+    except ValueError:
+        raise HTTPException(status_code=400, detail="유효하지 않은 ID 형식입니다.")
+
+
 def _ptw_number(site_id: str, supabase) -> str:
     year = datetime.now().year
     res = supabase.table("construction_works").select("id", count="exact").eq("site_id", site_id).execute()
@@ -56,6 +65,7 @@ async def list_processes(
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
 ):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = run_list_query(
@@ -73,6 +83,7 @@ async def list_processes(
 
 @router.post("/sites/{site_id}/processes")
 async def create_process(site_id: str, body: ProcessCreate):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = body.model_dump(exclude_none=True)
@@ -133,6 +144,7 @@ async def list_works(
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
 ):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = run_list_query(
@@ -150,6 +162,7 @@ async def list_works(
 
 @router.post("/sites/{site_id}/works")
 async def create_work(site_id: str, body: WorkCreate):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = body.model_dump(exclude_none=True)
@@ -225,6 +238,7 @@ async def list_workers(
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
 ):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = run_list_query(
@@ -248,6 +262,7 @@ async def list_workers(
 
 @router.post("/sites/{site_id}/workers")
 async def create_worker(site_id: str, body: WorkerCreate):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = body.model_dump(exclude_none=True)
@@ -321,6 +336,7 @@ async def list_inspections(
     page: int = Query(1, ge=1),
     size: int = Query(20, ge=1, le=100),
 ):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = run_list_query(
@@ -344,6 +360,7 @@ async def list_inspections(
 
 @router.post("/sites/{site_id}/inspections")
 async def create_inspection(site_id: str, body: InspectionCreate):
+    site_id = _validate_uuid(site_id)
     supabase = get_supabase()
     try:
         data = prepare_inspection_payload(body.model_dump(exclude_none=True), _now_iso)

--- a/tests/test_construction_current.py
+++ b/tests/test_construction_current.py
@@ -1,6 +1,12 @@
 from types import SimpleNamespace
 
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
 from routers import construction
+from routers.construction_sites_router import _validate_uuid, router as construction_sites_router
+from routers.construction_workflow_router import router as construction_workflow_router
 from services import construction_svc
 
 
@@ -130,6 +136,31 @@ def test_auto_diagnose_and_schedule_merges_inspection_and_action(monkeypatch):
     )
     assert called["rule_ids"] == ["I-1", "A-1"]
     assert out["schedules"]["total_rules"] == 2
+
+
+def test_invalid_uuid_returns_400_not_500():
+    """비-UUID site_id → HTTPException(400) (Supabase 500 유발 방지)."""
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_uuid("not-a-uuid")
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "유효하지 않은 ID 형식입니다."
+
+
+def test_invalid_site_id_get_returns_400():
+    app = FastAPI()
+    app.include_router(construction_sites_router, prefix="/construction")
+    client = TestClient(app)
+    r = client.get("/construction/sites/not-a-uuid")
+    assert r.status_code == 400
+    assert r.json().get("detail") == "유효하지 않은 ID 형식입니다."
+
+
+def test_invalid_site_id_workflow_returns_400():
+    app = FastAPI()
+    app.include_router(construction_workflow_router, prefix="/construction")
+    client = TestClient(app)
+    r = client.get("/construction/sites/bad-id/processes")
+    assert r.status_code == 400
 
 
 def test_penalty_like_fail_count_in_inspection_payload():


### PR DESCRIPTION
## 수정 내용
- `routers/construction_sites_router.py`: `_validate_uuid()` 추가, site_id 6개 엔드포인트 적용
- `routers/construction_workflow_router.py`: 동일 검증 추가
- `tests/test_construction_current.py`: 3개 테스트 추가 (9 passed)

## 원인
비-UUID 문자열 → Supabase UUID cast 에러 → 500
수정 후: 400 + "유효하지 않은 ID 형식입니다."

## 검증
- pytest 9 passed (기존 6 + 신규 3)
- 정상 UUID는 기존 동작 유지