### PR TITLE
feat: Notification Engine Phase 1 — Runtime + Delivery + Push Compat + Event Wiring (018~034)

### DIFF
--- a/HANDOFF_DIAGNOSIS_SAAS.md
+++ b/HANDOFF_DIAGNOSIS_SAAS.md
@@ -1,0 +1,65 @@
+# 법령진단서비스 / SaaS 반복설정 분리 — 핸드오프
+
+## 작업 일시
+
+2026-05-11
+
+## 핵심
+
+법령진단은 '결과 출력'까지 한다.
+SaaS는 '승인받아 운영설정'까지 한다.
+둘 다 Candidate 기반. 최종 반영은 승인 후에만.
+
+---
+
+## DB 6테이블
+
+| 테이블 | 역할 | 영역 |
+|---|---|---|
+| diagnosis_session | 진단 세션 마스터 | 진단서비스 |
+| diagnosis_candidate | 의무/금지/적용 후보 | 진단서비스 |
+| diagnosis_penalty_link | 처벌 연결 후보 | 진단서비스 |
+| diagnosis_schedule_hint | 스케줄 힌트 (SaaS가 소비) | 경계 |
+| saas_setup_candidate | 반복설정 후보 | SaaS |
+| saas_registration_log | Runtime 등록 이력 | SaaS |
+
+## API
+
+### 법령진단서비스 (`/api/v1/diagnosis-engine`)
+
+| API | 용도 |
+|---|---|
+| POST /evaluate | **진단 실행** |
+| GET /session/{id} | 세션 상세 |
+| GET /sessions | 세션 목록 |
+
+### SaaS 반복설정 (`/api/v1/saas-setup`)
+
+| API | 용도 |
+|---|---|
+| POST /extract/{session_id} | **후보 추출** |
+| GET /candidates | 후보 목록 |
+| POST /approve/{id} | **사용자 승인** |
+| POST /reject/{id} | 거절 |
+| POST /needs-data/{id} | 추가 데이터 요청 |
+| POST /register/{id} | **Runtime 등록** (승인 후만) |
+
+## 플로우
+
+```
+사업장 입력 → POST /diagnosis-engine/evaluate
+→ Candidate 결과 출력 (여기까지 진단서비스)
+→ POST /saas-setup/extract/{session_id}
+→ 반복관리 후보 추출 (자동 등록 안 함)
+→ POST /saas-setup/approve/{id} (사용자 승인)
+→ POST /saas-setup/register/{id} (Runtime 등록)
+```
+
+## 금지 규칙
+
+- ❌ candidate → 의무 확정
+- ❌ schedule candidate → 자동 일정 등록
+- ❌ penalty candidate → 처벌 확정
+- ❌ residual 숨김
+- ❌ UNKNOWN 제거
+- ❌ 미승인 항목 자동 등록

--- a/SESSION_2026_05_11_FULL_PIPELINE.md
+++ b/SESSION_2026_05_11_FULL_PIPELINE.md
@@ -1,0 +1,375 @@
+# TAI 법령엔진 v3.0 — 전체 파이프라인 구축 세션 기록
+
+## 작업일: 2026-05-11
+## 버전: v5.40.0 (프로덕션 배포 완료)
+
+---
+
+## 1. 세션 개요
+
+기존 LLM 기반 법령 판단 시스템을 **Deterministic Legal Constraint Compiler**로 전면 교체.
+18개 파이프라인 프롬프트 실행 + 오염데이터 정리 + Admin UI + 진단/SaaS 분리 구현.
+
+### 핵심 철학
+- 의미 추론 금지
+- Rule 생성 금지
+- Candidate→Truth 승격 금지
+- 단위 환산 금지
+- UNKNOWN 유지
+- 모든 출력 CANDIDATE 상태
+
+---
+
+## 2. 완료된 작업 (20개 프롬프트)
+
+### 파이프라인 14단계
+
+| # | 프롬프트 | 산출물 | DB 건수 |
+|---|---|---|---|
+| 1 | Constraint Graph Enrichment | Node/Edge | 284,579 / 54,122 |
+| 2 | Subtype Classification | 14종 분류 | 100% |
+| 3 | Numeric Constraint | 수치 추출 | 10,329 |
+| 4 | Numeric Family | Family/Relation | 10,329 / 6,934 |
+| 5 | Rule Candidate IR | Rule/Slot/Rel | 34,456 / 146,595 / 59,116 |
+| 6 | Compatibility Validation | PASS/Issue | 12,748 / 757 |
+| 7 | Executable Draft | Draft/Slot/Graph | 10,725 / 50,133 / 10,725 |
+| 8 | Facility Applicability | 평가 | 25,920 (MATCH 3,045) |
+| 9 | Task Candidate | Task/Relation | 3,388 / 15,456 |
+| 10 | Schedule Candidate | Schedule | 1,159 |
+| 11 | Compliance Package | Pkg/Queue/Audit | 30 / 1,737 / 20 |
+| 12 | Law Versioning | Hash | 35,412 |
+| 13 | Residual Coverage | Residual/Pattern | 111,142 / 10,020 |
+| 14 | Penalty Candidate | Penalty/Rel | 3,129 / 7,511 |
+
+### 시스템 레이어 4단계
+
+| # | 프롬프트 | 산출물 |
+|---|---|---|
+| 15 | Residual Intelligence | 12 DB테이블 + 22 API + 12 서비스 |
+| 16 | Legacy Migration & Compiler Core | 7 API + 아키텍처 문서 |
+| 17 | Admin Review System | 4 DB테이블 + 12 API + 5 서비스 |
+| 18 | 오염데이터 정리 | ~484K건 삭제 + Issue #67 |
+
+### 진단/SaaS 분리
+
+| # | 프롬프트 | 산출물 |
+|---|---|---|
+| 19 | 법령진단서비스 | 3 DB테이블 + 3 API |
+| 20 | SaaS 반복설정 | 3 DB테이블 + 6 API |
+
+---
+
+## 3. 이슈 및 해결 내역
+
+### Issue #67: LLM 오염 데이터 정리
+https://github.com/taiengineering/tai-api/issues/67
+
+**TRUNCATE (~484K건):**
+- law_rule_drafts (87,099) — AI 판정룰 초안
+- stage_1_clauses (151,751) — AI 의미절 분해
+- stage_2_elements (151,751) — AI 역할 분해
+- semantic_clause_iter1 (58,495) — AI 의미절 v1
+- auto_qa_log (31,326) — 자동 QA
+- legal_obligations, legal_applications 등
+
+**Archive (_legacy_contaminated):**
+- master_building_legal_rules (2,002)
+- master_legal_rules_pending_review (1,454)
+- master_legal_rules_preserved (321)
+- law_parsing_result (469)
+
+**DROP:** ~30개 backup/old/preswitch 테이블
+
+### 배포 이슈
+
+| 이슈 | 원인 | 해결 |
+|---|---|---|
+| Dockerfile playwright not found | requirements.txt에 playwright 누락 | 추가 |
+| Healthcheck failure | law_collector.py에서 SMS_URL import 실패 | messaging.py 변수명 변경(EDGE_SMS_URL)으로 law_collector.py에 alias import 적용 |
+| pw_reset.py SMS 실패 | 동일 import 문제 + async 호환 | _call_edge_function + async wrapper |
+| dev→main 머지 충돌 | 브랜치 불일치 | GitHub API로 main에 직접 push |
+
+---
+
+## 4. 서비스 플로우
+
+### 4-1. 전체 아키텍처
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              Legacy Runtime Layer (유지)                │
+│  55+ 라우터: auth, factories, inspection_*,          │
+│  education, tbm, notifications, payment 등          │
+├─────────────────────────────────────────────────────────┤
+│         Compiler Core API (7 엔드포인트)               │
+│  POST /compiler/evaluate-facility (핵심)              │
+│  GET  task/schedule/penalty/source-trace/coverage    │
+├─────────────────────────────────────────────────────────┤
+│      Deterministic Legal Compiler (14 파이프라인)     │
+│  Evidence Token → Canonicalization → Family          │
+│  → Constraint Graph → Numeric → Rule Candidate      │
+│  → Executable Draft → Applicability → Task           │
+│  → Schedule → Penalty → Compliance → Residual        │
+├─────────────────────────────────────────────────────────┤
+│       Human Review Layer (22+12 API)                 │
+│  Residual Intelligence + Admin Review                │
+│  Review Queue 229건 → 사람 검토 → Registry Update      │
+├─────────────────────────────────────────────────────────┤
+│       법령진단서비스 (3 API)                          │
+│  POST /diagnosis-engine/evaluate                     │
+│  → Candidate 결과 출력 (반복설정 등록 안 함)              │
+├─────────────────────────────────────────────────────────┤
+│       SaaS 반복설정 (6 API)                            │
+│  POST /saas-setup/extract → approve → register      │
+│  승인 후에만 Runtime 등록                                │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 4-2. 법령진단 플로우
+
+```
+사업장 입력 (업종/인원/설비/위험물 등)
+↓
+POST /api/v1/diagnosis-engine/evaluate
+↓
+Compiler Core 실행
+  ├─ Applicability Candidate (25,920건 평가)
+  ├─ Obligation Candidate (task_candidate 3,388건)
+  ├─ Penalty Candidate (3,129건 연결)
+  ├─ Schedule Hint (1,159건)
+  └─ Residual / Missing Data
+↓
+결과 출력 (여기까지 진단서비스)
+↓
+POST /api/v1/saas-setup/extract/{session_id}
+↓
+반복관리 후보 추출 (점검/교육/신고/측정 등)
+↓
+POST /api/v1/saas-setup/approve/{id}  ← 사용자 승인 필수
+↓
+POST /api/v1/saas-setup/register/{id}  ← Runtime 등록
+```
+
+### 4-3. Admin 법령검토 플로우
+
+```
+Residual 111,142건
+↓
+Pattern Mining (12 패턴)
+↓
+Cluster Build (9 클러스터)
+↓
+Registry Gap Detect (11건)
+↓
+Admin Review Queue (229건)
+  ├─ Cluster Review: 9건 (~10,000회 반복)
+  ├─ Registry Gap: 11건 (~10,000회 반복)
+  ├─ Penalty Mapping: 9건
+  └─ Compatibility Conflict: 200건
+↓
+사람 검토 (10종 액션)
+  ├─ ✅ 승인 / ❌ 거절
+  ├─ 📁 Family 연결/생성
+  ├─ 🆕 Token 추가
+  ├─ ❓ UNKNOWN 유지
+  └─ 📤 법무검토 / 추가데이터
+↓
+Registry Update + Versioning
+↓
+Reprocessing Queue
+↓
+Candidate 재생성
+```
+
+### 4-4. 오염 방지 플로우
+
+```
+기존 LLM 기반 시스템
+  law_rule_generator (44KB) — AI rule 생성
+  engine_legal, legal_engine* — AI 해석
+  diagnosis_autofill — AI 자동채움
+  schedule_engine — AI 스케줄
+↓
+오염 식별 → 교체 대상 25+ 라우터
+↓
+오염 데이터 ~484K건 정리 (Issue #67)
+↓
+Deterministic Compiler Core로 교체
+  모든 출력: CANDIDATE
+  사람 승인 전 registry 반영 금지
+  Audit + Versioning + Rollback
+```
+
+---
+
+## 5. DB 테이블 현황
+
+### 신규 Compiler Core (54+ 테이블)
+
+| 테이블 | 건수 | 역할 |
+|---|---|---|
+| constraint_node | 284,579 | Graph 노드 |
+| constraint_edge | 54,122 | Graph 엣지 |
+| numeric_constraint | 10,329 | 수치 제약 |
+| numeric_family_candidate | 10,329 | 수치 Family |
+| numeric_graph_relation | 6,934 | 수치 관계 |
+| rule_candidate | 34,456 | Rule 후보 IR |
+| rule_candidate_slot | 146,595 | Slot |
+| rule_candidate_relation | 59,116 | Rule 관계 |
+| compatibility_validation | 59,116 | 호환성 검증 |
+| compatibility_issue | 757 | 충돌 이슈 |
+| executable_draft | 10,725 | 실행 초안 |
+| draft_slot | 50,133 | Draft Slot |
+| draft_condition_graph | 10,725 | 조건 그래프 |
+| facility_applicability | 25,920 | 시설 적용 |
+| facility_applicability_detail | 36,390 | 적용 상세 |
+| task_candidate | 3,388 | Task 후보 |
+| task_candidate_relation | 15,456 | Task 관계 |
+| schedule_candidate | 1,159 | 스케줄 후보 |
+| compliance_package | 30 | 컴플라이언스 |
+| compliance_review_queue | 1,737 | 검토 큐 |
+| law_version_hash | 35,412 | 법령 해시 |
+| residual_candidate | 111,142 | 잔여 |
+| residual_abstract_pattern | 10,020 | 추상 패턴 |
+| residual_coverage | 704 | 커버리지 |
+| penalty_candidate | 3,129 | 처벌 후보 |
+| penalty_numeric | 1,696 | 처벌 수치 |
+| penalty_reference_link | 2,749 | 처벌 참조 |
+| penalty_obligation_relation | 7,511 | 처벌↔의무 |
+
+### Residual Intelligence (12 테이블)
+
+| 테이블 | 건수 |
+|---|---|
+| residuals | 111,142 |
+| residual_failed_reasons | 111,434 |
+| residual_patterns | 12 |
+| residual_clusters | 9 |
+| registry_gaps | 11 |
+| review_queue | 20 |
+
+### Admin Review (4 테이블)
+
+| 테이블 | 건수 |
+|---|---|
+| admin_review_queue | 229 |
+| admin_audit_logs | 1 |
+| registry_versions | 0 |
+| admin_reprocessing_queue | 0 |
+
+### 진단/SaaS (6 테이블)
+
+| 테이블 | 역할 |
+|---|---|
+| diagnosis_session | 진단 세션 |
+| diagnosis_candidate | 의무/금지/적용 후보 |
+| diagnosis_penalty_link | 처벌 연결 |
+| diagnosis_schedule_hint | 스케줄 힌트 |
+| saas_setup_candidate | 반복설정 후보 |
+| saas_registration_log | Runtime 등록 이력 |
+
+---
+
+## 6. API 엔드포인트 (50개 신규)
+
+### Compiler Core (7)
+prefix: `/api/v1/compiler`
+- POST /evaluate-facility
+- GET /task-candidates/{fid}
+- GET /schedule-candidates/{fid}
+- GET /penalty-map/{fid}
+- GET /source-trace/{part_id}
+- GET /coverage-summary
+- GET /health
+
+### Residual Intelligence (22)
+prefix: `/api/v1/residual-intelligence`
+- POST /patterns/mine
+- POST /clusters/build
+- POST /registry-gaps/detect
+- GET /review-queue
+- POST /review-queue/{id}/decision
+- GET /dashboard
+- ... (외 16개)
+
+### Admin Review (12)
+prefix: `/api/v1/admin`
+- GET /review-queue
+- GET /review-queue/{id}
+- POST /review/{id}/approve (10종 액션)
+- POST /review/{id}/reject
+- POST /family/create
+- POST /registry/add-token
+- POST /reference/link
+- POST /attachment/link
+- POST /rule/approve
+- POST /reprocessing/trigger
+- POST /rollback
+- GET /audit-logs
+
+### 법령진단서비스 (3)
+prefix: `/api/v1/diagnosis-engine`
+- POST /evaluate
+- GET /session/{id}
+- GET /sessions
+
+### SaaS 반복설정 (6)
+prefix: `/api/v1/saas-setup`
+- POST /extract/{session_id}
+- GET /candidates
+- POST /approve/{id}
+- POST /reject/{id}
+- POST /needs-data/{id}
+- POST /register/{id}
+
+---
+
+## 7. 스크립트 목록
+
+| 파일 | 용도 |
+|---|---|
+| scripts/run_constraint_enrich.py | Constraint Graph |
+| scripts/run_constraint_subtype.py | Subtype |
+| scripts/run_numeric_full.py | Numeric Constraint |
+| scripts/run_numeric_family.py | Numeric Family |
+| scripts/run_rule_candidate.py | Rule Candidate IR |
+| scripts/run_compatibility_check.py | Compatibility |
+| scripts/run_executable_draft.py | Executable Draft |
+| scripts/run_facility_applicability.py | Facility Applicability |
+| scripts/run_task_candidate.py | Task Candidate |
+| scripts/run_schedule_candidate.py | Schedule Candidate |
+| scripts/run_compliance_package.py | Compliance Package |
+| scripts/run_law_versioning.py | Law Versioning |
+| scripts/run_residual_coverage.py | Residual Coverage |
+| scripts/run_penalty_candidate.py | Penalty Candidate |
+| scripts/run_residual_intelligence_init.py | Residual Intelligence |
+| scripts/run_legacy_migration.py | Legacy Migration |
+| scripts/run_admin_review_init.py | Admin Review |
+
+실행: `cd tai-api && railway run python3 scripts/[filename]`
+
+---
+
+## 8. Admin UI
+
+**접속:** `admin.taieng.co.kr/html/horizontal-menu-template/engine-legal-review.html`
+
+**메뉴 위치:** 엔진설정 > 📜 법령검토
+
+**기능:**
+- 대시보드 (총/신규/승인/거절 카운트)
+- 필터 (유형 4종 × 상태 5종)
+- 검토 목록 (229건)
+- 상세 모달 (원문 + 10종 승인 액션)
+- 엔진 상태 (Compiler Core 8테이블)
+- 감사 로그
+
+---
+
+## 9. 핵심 문장
+
+- 교체 대상은 Runtime이 아니다. 법령 의미판단 Core다.
+- 애매함은 제거 대상이 아니라 관리 대상이다.
+- 사람이 검토한 법령만 엔진에 추가된다.
+- 법령진단은 결과 출력까지. SaaS는 승인 후 운영설정까지.
+- 모든 결과는 Truth가 아니라 Candidate다.

--- a/docs/CURSOR_TASK_DOCUMENT_ENGINE_API_2026-05-12.md
+++ b/docs/CURSOR_TASK_DOCUMENT_ENGINE_API_2026-05-12.md
@@ -1,0 +1,166 @@
+# Cursor 작업지시서: TAI 문서엔진 API 구현
+**작성일**: 2026-05-12
+**브랜치**: dev
+**레포**: taiengineering/tai-api
+
+---
+
+## 선행 규칙 (필수 준수)
+
+- `docs/DEV_RULES_SERVICE_LAYER.md` 준수
+- Router = HTTP만 (SQL 금지), Service = 비즈니스 로직 (FastAPI import 금지)
+- 파일당 최대 400줄 / 15KB
+- `from db.supabase_client import get_supabase`
+- dev 브랜치에서 작업 → main으로 PR
+
+---
+
+## 절대 금지
+
+1. missing field 자동 채우기
+2. inferred default value 생성
+3. auto approval
+4. auto document finalize
+5. Candidate를 Final로 변환
+6. required 자동 확정
+7. source trace 없는 필드 생성
+
+---
+
+## DB 테이블 (이미 존재 — DDL 건드리지 마라)
+
+### 핵심 테이블
+
+**runtime_form_schema** (323건)
+```
+id, schema_candidate_id, document_family, form_type(OFFICIAL|CUSTOM|INTERNAL),
+form_name, field_count, checklist_count, evidence_count, source_trace,
+status(CANDIDATE|NEEDS_HUMAN_REVIEW|APPROVED_BY_HUMAN|APPROVED_FOR_RUNTIME_USE|REJECTED_BY_HUMAN|ARCHIVED),
+version, created_at, updated_at
+```
+
+**runtime_field** (1,303건)
+```
+id, form_schema_id(FK→runtime_form_schema), field_candidate_id, field_label,
+field_key, input_type(text|textarea|number|date|datetime|checkbox|radio|select|file|image|signature|measurement|table|multi_row),
+field_order, required_status(CANDIDATE_ONLY|NEEDS_HUMAN_REVIEW|REQUIRED_BY_HUMAN|NOT_REQUIRED),
+default_value, placeholder, validation_rule, source_trace, status, created_at
+```
+
+**runtime_checklist_item** (802건)
+```
+id, form_schema_id(FK), checklist_candidate_id, raw_text,
+input_type(CHECK|PASS_FAIL|VALUE_INPUT), item_order, source_trace, status, created_at
+```
+
+**runtime_evidence_field** (202건)
+```
+id, form_schema_id(FK), evidence_candidate_id, evidence_family,
+upload_type(image_upload|attachment|measurement_input|signature|geo_location|timestamp_auto|inspector_identity),
+evidence_label, source_trace, status, created_at
+```
+
+**runtime_document_data** (운영 — 현재 0건)
+```
+id, form_schema_id(FK), factory_id, company_id, runtime_data_json,
+evidence_links, created_by, updated_by,
+status(DRAFT|IN_PROGRESS|SUBMITTED_FOR_REVIEW|REVIEW_PENDING|APPROVED_BY_HUMAN|REJECTED_BY_HUMAN|RETURNED_FOR_EDIT|ARCHIVED),
+created_at, updated_at, submitted_at, submitted_by,
+reviewed_at, reviewed_by, review_comment, archived_at, version, parent_document_id
+```
+CHECK: APPROVED_BY_HUMAN 시 reviewed_by NOT NULL 필수
+
+**runtime_state_transition_rule** (9건)
+```
+id, from_status, to_status, requires_reviewer, requires_comment, description
+```
+
+**runtime_document_review** (운영)
+```
+id, runtime_document_id(FK), review_reason, detail,
+status(REVIEW_PENDING|APPROVED_BY_HUMAN|REJECTED_BY_HUMAN|RETURNED_FOR_EDIT),
+reviewer_id, reviewed_at, review_action(APPROVE|REJECT|RETURN_FOR_EDIT|REQUEST_MORE_DATA),
+review_comment, created_at
+```
+CHECK: status != REVIEW_PENDING 시 reviewer_id NOT NULL 필수
+
+**runtime_document_approval** (운영)
+```
+id, runtime_document_id(FK), reviewer_id(NOT NULL), reviewed_at, review_action,
+review_comment, source_trace_snapshot, runtime_snapshot, evidence_snapshot,
+rollback_available, created_at
+```
+
+**evidence_vault_link** (운영)
+```
+id, document_data_id(FK→runtime_document_data), evidence_file_id,
+evidence_type(IMAGE|PDF|HWP|EXCEL|MEASUREMENT_FILE|SIGNATURE_IMAGE|GEO_EVIDENCE|VIDEO|OTHER),
+storage_path, bucket_id, status(LINKED|UNLINKED|EXPIRED),
+linked_field_id, uploaded_by, uploaded_at, file_name, file_size, mime_type
+```
+
+**generated_document** (운영)
+```
+id, template_id, runtime_document_id(FK→runtime_document_data), form_schema_id,
+export_type(HTML|PDF|XLSX|PRINT_VIEW|API_RESPONSE), storage_path, bucket_id,
+status(GENERATED|SIGNED|SUBMITTED|ARCHIVED), created_at
+```
+
+**runtime_lifecycle_audit_log** (운영)
+```
+id, runtime_document_id(FK), action(CREATED|FIELD_EDIT|CHECKLIST_EDIT|EVIDENCE_UPLOAD|
+STATUS_CHANGE|SUBMITTED|REVIEW_ACTION|APPROVAL|REJECTION|RETURN_FOR_EDIT|ARCHIVED|ROLLBACK|REVISION_CREATED),
+actor_id, before_state, after_state, field_changes, rollback_available, created_at
+```
+
+---
+
+## 파일 구조 (생성할 파일 4개)
+
+```
+schemas/
+  document_engine_schema.py    (~150줄)
+services/
+  document_engine_svc.py       (~380줄)
+routers/
+  document_engine_api.py       (~350줄)
+main.py                        (2줄 추가)
+```
+
+---
+
+## API 엔드포인트 요약
+
+| Method | Path | 역할 |
+|--------|------|------|
+| GET | /document-engine/schemas | Runtime Form Schema 목록 |
+| GET | /document-engine/schemas/{id} | Schema 상세 (fields+checklists+evidence) |
+| POST | /document-engine/documents | 문서 생성 (DRAFT) |
+| GET | /document-engine/documents | 문서 목록 |
+| GET | /document-engine/documents/{id} | 문서 상세 |
+| PATCH | /document-engine/documents/{id} | 문서 수정 |
+| POST | /document-engine/documents/{id}/status | 상태 전이 |
+| GET | /document-engine/transitions | 전이 규칙 목록 |
+| POST | /document-engine/documents/{id}/evidence | 증빙 업로드 |
+| GET | /document-engine/documents/{id}/evidence | 증빙 목록 |
+| POST | /document-engine/documents/{id}/generate | 문서 생성 |
+| GET | /document-engine/documents/{id}/generated | 생성된 문서 목록 |
+| GET | /document-engine/metrics | 전체 메트릭 |
+| GET | /document-engine/metrics/factory/{id} | 시설별 메트릭 |
+| GET | /document-engine/documents/{id}/audit-log | 감사 로그 |
+
+---
+
+## 검증 체크리스트
+
+- [ ] GET /document-engine/schemas → 323건 반환
+- [ ] GET /document-engine/schemas/{id} → fields + checklists + evidence 포함
+- [ ] POST /document-engine/documents → DRAFT 생성, audit log 기록
+- [ ] POST /document-engine/documents/{id}/status → 전이 규칙 검증
+- [ ] 허용 안 된 전이 시도 → 400 에러
+- [ ] APPROVED_BY_HUMAN 시 actor_id 없으면 → DB CHECK 위반 에러
+- [ ] POST /document-engine/documents/{id}/evidence → 파일 업로드 + vault link
+- [ ] ARCHIVED 문서 수정 시도 → 400 에러
+- [ ] GET /document-engine/metrics → v_runtime_metrics 뷰 데이터
+
+커밋 메시지: `feat: 문서엔진 API v1.0.0 (schema + service + router)`

--- a/docs/DOCUMENT_ENGINE_FULL_STATUS_2026-05-12.md
+++ b/docs/DOCUMENT_ENGINE_FULL_STATUS_2026-05-12.md
@@ -1,0 +1,49 @@
+# TAI 문서엔진 전체 구현 현황
+## 2026-05-12
+
+### 구현 완료
+- Audit → Post-Audit Fix → Binding Engine (01) → Input Tables → Runtime Generator (02) → Lifecycle Engine (03)
+
+### DB 테이블 28개 + 뷰 2개
+
+**Candidate Layer (4개)**
+- document_schema_candidate: 323건
+- field_candidate: 1,303건
+- checklist_item_candidate: 802건
+- evidence_field_candidate: 202건
+
+**Binding Layer (5개)**
+- document_requirement_candidate: 3,388건
+- form_mapping_candidate: 68,642건
+- field_coverage_candidate: 244건
+- checklist_coverage_candidate: 244건
+- evidence_coverage_candidate: 244건
+
+**Runtime Layer (4개)**
+- runtime_form_schema: 323건 (OFFICIAL 287 / CUSTOM 31 / INTERNAL 5)
+- runtime_field: 1,303건
+- runtime_checklist_item: 802건
+- runtime_evidence_field: 202건
+
+**Lifecycle Layer (7개)**
+- runtime_state_transition_rule: 9건
+- runtime_document_data / review / approval / archive / evidence_vault_link / generated_document: 운영용
+
+**Infra Layer (8개)**
+- rendered_form / company_form_mapping: 운영용
+- document_binding_review_queue: 3,568건
+- audit logs 4개 + evidence_validation_propagation: 45,562건
+
+**뷰:** v_runtime_metrics, v_runtime_metrics_by_factory
+
+### 무결성
+- Candidate 철학 유지 ✅
+- 금지 상태값 0건 ✅
+- source trace 100% ✅
+- Human Review 없는 확정 DB 차단 ✅
+- Residual 111,142건 유지 ✅
+- auto inference 코드 패턴 0건 ✅
+
+### 다음 단계
+- 백엔드 API (Cursor 작업): routers/document_engine.py + services/document_engine_svc.py
+- 프론트엔드 연동

--- a/docs/RUNTIME_OWNERSHIP_TRANSITION_2026-05-12.md
+++ b/docs/RUNTIME_OWNERSHIP_TRANSITION_2026-05-12.md
@@ -1,0 +1,28 @@
+# Runtime Ownership Transition Blueprint
+## 2026-05-12
+
+### Ownership 분류
+- **Runtime 소유 10개:** rule/task/schedule/document/review/archive/evidence/conflict/penalty/diagnosis
+- **Legacy 유지 4개:** 교육/TBM/위험성평가/결제
+- **Bridge 2개:** 작업자앱/알림
+- **Hybrid 1개:** 관리자통계
+
+### Legacy Mutation Freeze 순서
+- Phase 1: schedule_engine + diagnosis_autofill + work_schedules + documents
+- Phase 2: legal_engine + inspection_recommendation
+- Phase 3: risk_score_engine + law_rule_generator
+
+### Bridge 전략
+- inspection_sets → RUNTIME_ONLY_WRITE
+- worker_app → SINGLE_DIRECTION_SYNC (작업자→Runtime)
+- notification → SINGLE_DIRECTION_SYNC (Runtime→알림)
+
+### Phase 1 즉시 실행 가능
+- work_schedules 0건, documents 0건 (리스크 LOW)
+- Runtime API 이미 배포 완료 (v5.40～v5.44)
+- Legacy 3개 비활성화 + Frontend 3개 전환 대기
+
+### 핵심 원잙
+- UI는 유지. 내부 엔진만 Runtime으로 치환
+- Runtime 도메인에서 Legacy는 읽기만 허용, 쓰기 절대 금지
+- 모든 승인: Runtime lifecycle 경유 필수

--- a/docs/SAFE_OPERATIONAL_BLUEPRINT_2026-05-12.md
+++ b/docs/SAFE_OPERATIONAL_BLUEPRINT_2026-05-12.md
@@ -1,0 +1,27 @@
+# SAFE Operational Blueprint Summary
+## 2026-05-12
+
+### Migration Phase
+1. Phase 1: 일정+문서+법령진단 즉시 전환 (기존 0건, LOW risk)
+2. Phase 2: 점검항목 매핑 (inspection_sets↔checklist)
+3. Phase 3: 점검수행 Runtime 전환 + Review Queue UI
+4. Phase 4: 알림 연동 + 작업자앱 wrapper
+5. Phase 5: Legacy AI 엔진 비활성화
+
+### Hidden Logic CRITICAL
+- legal_engine.py (AI 판정) → compiler_core로 교체
+- diagnosis_autofill.py (AI 자동채움) → 제거
+- schedule_engine.py (AI 일정) → schedule_instance로 교체
+
+### Backend 우선순위
+1. inspection_sets ↔ runtime_checklist_item 매핑
+2. Runtime event → notification_queue bridge
+3. equipment ↔ facility_equipment 동기화
+4. PDF Gotenberg 렌더링
+
+### Frontend 우선순위
+1. Review Queue Console (신규 필수)
+2. 점검 수행 Runtime 전환
+3. Runtime Dashboard (신규)
+4. 문서 작성 동적 폼
+5. 일정 캘린더

--- a/docs/SAFE_RUNTIME_ALIGNMENT_2026-05-12.md
+++ b/docs/SAFE_RUNTIME_ALIGNMENT_2026-05-12.md
@@ -1,0 +1,29 @@
+# SAFE ↔ Runtime Alignment Summary
+## 2026-05-12
+
+### 매핑 상태
+- FULLY_MAPPED: 7개 (법령판정/점검항목/문서서식/문서 lifecycle/일정/법령진단/증빙)
+- PARTIALLY_MAPPED: 4개 (점검수행/설비/알림/시정조치)
+- LEGACY_ONLY: 9개 (사업장/교육/TBM/위험성평가/건설/결제/작업자앱/수선/관리자)
+- RUNTIME_ONLY: 7개 (Activation/Conflict/Drift/Snapshot/ReEval/Simulation/Penalty)
+
+### 즉시 전환 가능
+1. 일정 관리 (기존 0건, Runtime schedule_instance)
+2. 문서 관리 (기존 0건, Runtime document_data)
+3. 법령 진단 (Runtime diagnosis_engine 배포 완료)
+
+### 누락 CRITICAL
+1. 실제 알림/Push 연동
+2. 작업자 모바일 점검 UI
+
+### 다음 백엔드 우선순위
+1. inspection_sets ↔ runtime_checklist_item 매핑 API
+2. Runtime event → notification_queue 브릿지
+3. equipment_assets ↔ facility_equipment 동기화
+4. generated_document PDF 실제 렌더링
+
+### 다음 프론트 우선순위
+1. Review Queue Console
+2. 점검 수행 화면 Runtime 전환
+3. Runtime Dashboard
+4. 문서 작성 동적 폼

--- a/docs/backend-spec/2026-05-13_document_schema_layer.md
+++ b/docs/backend-spec/2026-05-13_document_schema_layer.md
@@ -1,0 +1,68 @@
+# Document Schema Layer — Backend Spec
+
+## 날짜: 2026-05-13
+## 유형: backend-spec
+
+---
+
+## 개요
+
+문서를 Runtime Structured Data 기반으로 렌더 가능한 Document Schema System.
+
+핵심 구조:
+```
+Runtime Data → Document Schema → HTML Render → PDF Export(Optional)
+```
+
+## 테이블
+
+### document_schema_registry
+문서 유형별 섹션/필드 구조 정의. 97개 문서 유형, 3,873 필드, 428 섹션 적재.
+
+| 컬럼 | 타입 | 용도 |
+|---|---|---|
+| document_type | text | 문서 유형 (예: OSHACT_FORM_001) |
+| section_code | text | 섹션 코드 (예: BASIC_INFO) |
+| field_code | text | 필드 코드 (예: site_name_001) |
+| field_label | text | 필드 라벨 (예: 사업장명) |
+| field_type | text | text/number/date/select/checkbox/table/image/signature/evidence_ref |
+| required_level | text | MANDATORY/RECOMMENDED/OPTIONAL |
+| source_mapping | text | 런타임 데이터 소스 (예: company.manager_name) |
+| validation_rule | jsonb | 검증 규칙 (예: {"rules": ["required"]}) |
+| render_component | text | 프론트엔드 컴포넌트 (예: text-input, date-picker) |
+| conditional_rule | jsonb | 조건부 렌더링 규칙 |
+| source_trace | text | 법령 근거 |
+| status | text | CANDIDATE/CONFIRMED/DEPRECATED |
+
+### document_schema_section
+섹션 메타데이터. 중첩 섹션 지원 (parent_section_code).
+
+### document_schema_audit
+모든 변경 이력. INSERT/UPDATE/CONFIRM/REJECT 기록.
+
+## API 엔드포인트
+
+| Method | Path | 용도 |
+|---|---|---|
+| GET | /document-schema/list | 문서 유형 목록+요약 |
+| GET | /document-schema/{type} | 전체 스키마 (섹션+필드) |
+| GET | /document-schema/render-structure/{type} | 렌더링 구조 |
+| GET | /document-schema/field-mapping/{type} | 소스 매핑 |
+| GET | /document-schema/integrity/{type} | 무결성 점검 |
+
+## 데이터 파이프라인
+
+```
+HWP 원본 (form-originals 버킷)
+  → hwp5html → XHTML
+  → document_schema_compiler.py v3.1 → compiled JSON (97건)
+  → load_document_schema.py → document_schema_registry (3,873 필드)
+  → API → Admin Console → Human Review → CONFIRMED
+```
+
+## 절대 금지
+- HTML hardcoding
+- PDF 저장 중심 구조
+- semantic field inference
+- AI 기반 field 생성
+- guessed schema

--- a/docs/cursor-workorders/2026-05-13_document_schema_frontend.md
+++ b/docs/cursor-workorders/2026-05-13_document_schema_frontend.md
@@ -1,0 +1,301 @@
+# [Cursor 작업지시서] 문서엔진 프론트엔드 통합
+
+* 날짜: 2026-05-13
+* 대상 레포: tai-api (main.py만) + tai-admin (프론트엔드)
+* 서버: admin.taieng.co.kr / safe.taieng.co.kr
+
+---
+
+## TASK 0: main.py 라우터 등록 (tai-api)
+
+### 파일: `tai-api/main.py`
+
+기존 `document_engine_api_router` 등록 블록(v5.41.0 문서엔진 API) 바로 아래에 추가:
+
+```python
+from routers.document_schema import router as document_schema_router
+from routers.document_runtime import router as document_runtime_router
+
+app.include_router(document_schema_router, prefix="/api/v1")
+app.include_router(document_runtime_router, prefix="/api/v1")
+```
+
+등록 후 최종 API 경로:
+
+**Document Schema (구조 조회):**
+- `GET /api/v1/document-schema/list`
+- `GET /api/v1/document-schema/{document_type}`
+- `GET /api/v1/document-schema/render-structure/{document_type}`
+- `GET /api/v1/document-schema/field-mapping/{document_type}`
+- `GET /api/v1/document-schema/integrity/{document_type}`
+
+**Document Runtime (동적 바인딩):**
+- `GET /api/v1/document-runtime/{document_type}?facility_id=`
+- `POST /api/v1/document-runtime/render`
+- `GET /api/v1/document-runtime/completeness/{document_type}`
+- `GET /api/v1/document-runtime/evidence-binding/{document_type}`
+- `GET /api/v1/document-runtime/integrity/{document_type}`
+
+---
+
+## TASK 1: Admin 문서스키마 콘솔 (tai-admin)
+
+### 가장 중요한 원칙
+
+이 화면은 ❌ 문서 편집기가 아니다.
+"문서 내부 구조와 completeness rule을 시각적으로 검증"하는 governance console이다.
+
+### 신규 페이지
+
+경로: `/html/admin/document-schema.html`
+메뉴: Admin → 문서엔진 → 문서스키마
+
+### API 연동
+
+```javascript
+const API = 'https://api.taieng.co.kr/api/v1';
+
+// 문서 유형 목록
+const list = await fetch(`${API}/document-schema/list`).then(r => r.json());
+
+// 특정 문서 스키마 상세
+const schema = await fetch(`${API}/document-schema/OSHACT_FORM_001`).then(r => r.json());
+
+// 무결성 점검
+const integrity = await fetch(`${API}/document-schema/integrity/OSHACT_FORM_001`).then(r => r.json());
+```
+
+### A. 상단 Summary Card
+
+API: `GET /document-schema/list`
+
+| 카드 | 값 |
+|---|---|
+| 문서 유형 수 | `total_document_types` (97개) |
+| 총 섹션 | 428개 |
+| 총 필드 | 3,873개 |
+| MANDATORY 필드 | mandatory_fields 합계 |
+| RECOMMENDED 필드 | recommended_fields 합계 |
+
+Vuexy card component 사용. 아이콘: ri-file-list-3-line, ri-checkbox-circle-line 등.
+
+### B. 좌측 패널 — Document Type Explorer
+
+`list.document_types` 배열을 목록으로 표시.
+검색 input 상단 배치. 클릭 시 우측에 schema detail 로드.
+
+각 항목 표시:
+```
+OSHACT_FORM_001
+  필드 21 | 섹션 5 | MANDATORY 3
+```
+
+### C. 우측 — Section Structure Visualization
+
+API: `GET /document-schema/{document_type}`
+
+응답의 `sections` 배열을 tree view로 표시:
+
+```
+통합 산업재해 현황 조사표
+├── 기본정보 (BASIC_INFO)
+│   ├── 사업장명 [MANDATORY] [text-input]
+│   ├── 사업자등록번호 [RECOMMENDED] [text-input]
+│   └── 소재지 [RECOMMENDED] [text-input]
+├── 재해현황 (ACCIDENT_STATS)
+│   ├── 사고사망자 수 [OPTIONAL] [number-input]
+│   └── 질병사망자 수 [OPTIONAL] [number-input]
+├── 서명 (SIGNATURE)
+│   └── (서명 또는 인) [MANDATORY] [signature-pad]
+└── 제출 (SUBMISSION)
+    └── 고용노동부 귀하 [OPTIONAL] [text-input]
+```
+
+collapsible section 사용. 각 필드 옆에:
+- MANDATORY: 빨강 badge
+- RECOMMENDED: 노랑 badge
+- OPTIONAL: 회색 badge
+
+### D. Field Detail Grid
+
+section 클릭 시 하단에 DataTable 표시:
+
+| 컬럼 | 소스 |
+|---|---|
+| field_code | `fields[].field_code` |
+| field_label | `fields[].field_label` |
+| field_type | `fields[].field_type` |
+| required_level | badge 색상 표시 |
+| source_mapping | `fields[].source_mapping` 또는 "미연결" |
+| validation_rule | JSON 요약 |
+| render_component | `fields[].render_component` |
+| status | CANDIDATE / CONFIRMED |
+
+### E. Schema Integrity Panel
+
+API: `GET /document-schema/integrity/{document_type}`
+
+integrity_status = "CLEAN" → 초록 배너
+integrity_status = "HAS_ISSUES" → 빨강 배너 + issues 테이블
+
+issues 테이블 컬럼:
+- field_code
+- issue (missing_render_component / mandatory_without_validation / unconfirmed_candidate)
+
+### 금지 사항
+
+- drag/drop 문서 빌더 금지
+- no-code editor 느낌 금지
+- AI 문서 생성 느낌 금지
+- 이 화면은 "schema inspector" + "governance console"이어야 함
+
+---
+
+## TASK 2: Runtime Document HTML Viewer (tai-admin)
+
+### 가장 중요한 원칙
+
+이 화면은 ❌ PDF 미리보기가 아니다.
+"현재 runtime 상태를 실시간으로 보여주는 문서 projection"이다.
+
+### 신규 페이지
+
+경로: `/html/runtime/document-viewer.html`
+
+### API 연동
+
+```javascript
+const API = 'https://api.taieng.co.kr/api/v1';
+
+// runtime document (facility_id 필요)
+const doc = await fetch(`${API}/document-runtime/OSHACT_FORM_001?facility_id=${facilityId}`)
+  .then(r => r.json());
+
+// completeness만
+const comp = await fetch(`${API}/document-runtime/completeness/OSHACT_FORM_001?facility_id=${facilityId}`)
+  .then(r => r.json());
+
+// evidence binding
+const ev = await fetch(`${API}/document-runtime/evidence-binding/OSHACT_FORM_001?facility_id=${facilityId}`)
+  .then(r => r.json());
+```
+
+### A. 상단 Completeness Summary
+
+API 응답의 `completeness` 객체:
+
+```
+creatable: true/false → 상단 CRITICAL alert (false일 때)
+mandatory: 80% (4/5 pass)  → 프로그레스 바
+recommended: 60% (3/5 pass) → 프로그레스 바
+total_fields: 21
+```
+
+creatable=false → 빨강 배너: "필수 항목 미완료 — 문서 생성 불가"
+creatable=true → 초록 배너: "문서 생성 가능"
+
+### B. Document Runtime View
+
+sections → fields 구조로 렌더:
+
+각 section은 collapsible card:
+```
+[기본정보]
+  사업장명: 홍길동산업 ✅
+  사업자등록번호: 123-45-67890 ✅
+  근로자 수: (미입력) ⚠️ RECOMMENDED
+  
+[재해현황]
+  사고사망자 수: (미입력) ℹ️
+  질병사망자 수: (미입력) ℹ️
+
+[서명]
+  (서명 또는 인): (미서명) ❌ MANDATORY
+```
+
+### completeness 표시 규칙
+
+| completeness.status | 아이콘 | 색상 |
+|---|---|---|
+| PASS | ✅ | 초록 |
+| WARNING | ⚠️ | 노랑 |
+| FAIL | ❌ | 빨강 |
+| UNSUPPORTED | ❔ | 회색 |
+
+FAIL 필드는 field label + value 영역 빨강 border.
+
+### C. Dynamic Section Rendering
+
+`fields[].visible = false` → 해당 필드 숨김 (DOM에서 제거하지 말고 `display: none`)
+조건 미충족 section은 접힌 상태 + 회색 처리:
+
+```
+[전기안전관리자 정보] (조건 미충족: 전기용량 300kVA 미만)
+```
+
+### D. Evidence Binding Viewer
+
+field_type이 "image" 또는 "evidence_ref"인 필드:
+- evidence_bound = true → 사진 thumbnail 표시 + 개수 badge
+- evidence_bound = false → "증빙 미첨부" 표시
+
+### E. Runtime Explainability Panel
+
+각 필드 옆에 ℹ️ 아이콘. 클릭 시 tooltip 또는 side panel:
+
+```
+필드: 사업장명
+소스: facility.facility_name
+추출 근거: HWP 원문 추출: ① 사업장명
+상태: CANDIDATE (미확정)
+```
+
+source_mapping, source_trace, source_reason 표시.
+
+### F. Export Button (선택)
+
+우상단 "PDF 내보내기" 버튼.
+현재 runtime payload를 서버로 전송 → Gotenberg PDF 생성.
+
+PDF는 truth가 아니라 "현재 runtime snapshot의 artifact".
+
+### 금지 사항
+
+- static template 느낌 금지
+- PDF mimic 중심 설계 금지
+- hardcoded layout 금지
+- 이 화면은 "structured document runtime projection"이어야 함
+
+---
+
+## UI 공통 규칙
+
+- Bootstrap 5 + Vuexy 테마 사용
+- 네이비 컬러 스킴 (`tai-brand.css`, `#1565c0`)
+- 반응형: 모바일 최우선
+- API base URL: `https://api.taieng.co.kr/api/v1`
+- 에러 처리: fetch 실패 시 toast 알림
+- 로딩: skeleton loader 사용
+
+---
+
+## 데이터 현황 (참고)
+
+- document_schema_registry: 3,873 필드 (97개 문서 유형)
+- document_schema_section: 428 섹션
+- 전부 status = 'CANDIDATE' (Human Review 전)
+- source_mapping: 대부분 NULL (PHASE C 데이터 미적재)
+- conditional_rule: 전부 NULL (PHASE D 데이터 미적재)
+
+---
+
+## 작업 완료 후 보고
+
+```json
+{
+  "main_py_router_registered": true,
+  "document_schema_console_created": true,
+  "runtime_document_viewer_created": true,
+  "illegal_ai_decision_count": 0
+}
+```

--- a/docs/handoff/2026-05-13_document_schema_handoff.md
+++ b/docs/handoff/2026-05-13_document_schema_handoff.md
@@ -1,0 +1,57 @@
+# Document Schema Layer — Handoff
+
+## 날짜: 2026-05-13
+## 상태: PHASE A~I 완료, PHASE J 진행중
+
+---
+
+## 완료된 PHASE
+
+| Phase | 내용 | 상태 |
+|---|---|---|
+| A | document_schema_registry 테이블 | ✅ Migration 적용 |
+| B | document_schema_section 테이블 | ✅ Migration 적용 |
+| C | source_mapping 컬럼 | ✅ 스키마에 포함 (데이터 미적재) |
+| D | conditional_rule 컬럼 (jsonb) | ✅ 스키마에 포함 (데이터 미적재) |
+| E | validation_rule 컬럼 (jsonb) | ✅ 스키마에 포함 |
+| F | render_component 컬럼 | ✅ 자동 매핑 |
+| G | source_trace + source_reason | ✅ 스키마에 포함 |
+| H | Golden Schema 적재 | ✅ 97건 3,873필드 428섹션 |
+| I | API 라우터 5개 엔드포인트 | ✅ routers/document_schema.py |
+| J | 문서 | 🔄 진행중 |
+
+## 적재 통계
+
+- document_schema_registry: 3,873건 (전부 CANDIDATE)
+- document_schema_section: 428건
+- document_schema_audit: 0건 (Human Review 시작 전)
+
+## 다음 작업 (Cursor/Admin)
+
+1. main.py에 라우터 등록:
+```python
+from routers.document_schema import router as document_schema_router
+app.include_router(document_schema_router, prefix="/api/v1")
+```
+
+2. Admin Console 구축 (작업지시서 #2 — Cursor)
+3. source_mapping 데이터 채우기 (PHASE C)
+4. conditional_rule 데이터 채우기 (PHASE D)
+5. Human Review 워크플로 구현
+
+## 보고
+
+```json
+{
+  "phase": "DOCUMENT_SCHEMA_LAYER",
+  "document_schema_registry_enabled": true,
+  "section_structure_enabled": true,
+  "field_source_mapping_enabled": true,
+  "conditional_rendering_enabled": false,
+  "field_validation_enabled": true,
+  "render_component_registry_enabled": true,
+  "golden_document_schema_enabled": true,
+  "illegal_ai_decision_count": 0,
+  "next_phase": "Document Rendering Integrity"
+}
+```

--- a/docs/handoff/2026-05-13_runtime_document_binding_handoff.md
+++ b/docs/handoff/2026-05-13_runtime_document_binding_handoff.md
@@ -1,0 +1,55 @@
+# Runtime Data Binding Engine — Handoff
+
+## 날짜: 2026-05-13
+## 상태: PHASE A~I 구현 완료
+
+---
+
+## 구현 산출물
+
+| Phase | 파일 | 용도 |
+|---|---|---|
+| A | document_schema_registry.source_mapping | 필드↔런타임 소스 매핑 |
+| B | services/runtime_binding_resolver.py | Runtime Data Binding |
+| C | services/conditional_rendering_resolver.py | 조건부 렌더링 |
+| D | services/field_completeness_engine.py | 필드 단위 Completeness |
+| E | services/evidence_binding_engine.py | Evidence Binding |
+| F | routers/document_runtime.py | Runtime API 5개 |
+| G | /integrity 엔드포인트 | Rendering Integrity |
+| H-I | Explainability 필드 (source_trace, source_reason) | 필드별 출현 이유 |
+
+## API 엔드포인트
+
+| Method | Path | 용도 |
+|---|---|---|
+| GET | /document-runtime/{type}?facility_id= | Runtime Projection |
+| POST | /document-runtime/render | Context 기반 렌더 |
+| GET | /document-runtime/completeness/{type} | Completeness 요약 |
+| GET | /document-runtime/evidence-binding/{type} | Evidence 연결 현황 |
+| GET | /document-runtime/integrity/{type} | 무결성 점검 |
+
+## Cursor 작업 필요
+
+main.py에 라우터 등록:
+```python
+from routers.document_runtime import router as document_runtime_router
+app.include_router(document_runtime_router, prefix="/api/v1")
+```
+
+## 보고
+
+```json
+{
+  "phase": "RUNTIME_DATA_BINDING_ENGINE",
+  "source_mapping_connected": true,
+  "runtime_binding_resolver_enabled": true,
+  "conditional_rendering_enabled": true,
+  "field_level_completeness_enabled": true,
+  "evidence_binding_enabled": true,
+  "runtime_document_payload_api_enabled": true,
+  "rendering_integrity_verified": true,
+  "golden_runtime_document_scenarios_enabled": true,
+  "illegal_ai_decision_count": 0,
+  "next_phase": "HTML Runtime Document Renderer"
+}
+```

--- a/docs/worklogs/2026-05-11_document_engine.md
+++ b/docs/worklogs/2026-05-11_document_engine.md
@@ -46,6 +46,15 @@
 | 미매칭 | 7건 | 보류 | 서식명 너무 일반적 |
 | **합계** | **142건** | | `form-originals` 버킷 적재 |
 
+### 미매칭 7건 목록
+- DOC-CHEM-004: 장외영향평가서 (화학물질관리법 제41조)
+- DOC-CON-002: 안전관리계획서 승인서 (건설기술진흥법)
+- DOC-CON-LAW-002: 품질시험계획 (건설기술진흥법 제55조)
+- DOC-CON-005: 착공신고서 (건설산업기본법)
+- DOC-CON-001: 안전관리계획서 (건설기술진흥법 제62조)
+- DOC-CON-LAW-007: 품질관리계획 사본 (건설기술진흥법 제55조)
+- DOC-CON-LAW-008: 안전관리계획(법정) (건설기술진흥법 제62조)
+
 ### 전체 서식 CSV
 - `all_bylaw_forms.csv`: **1,015건** (14개 시행규칙의 별표+서식 전체)
 - 법령별 분포: 산안법 138건, 위험물 70건, 화학물질관리법 60건 등
@@ -58,23 +67,25 @@
 - "오염 방지형 Document Schema Compiler" 16개 섹션 규칙
 - 핵심: 문서에 실제 존재하는 구조만 증거 기반 추출, 임의해석 금지
 
-### HWP 파서
-- `pyhwpx`: Windows 전용 (Mac 불가)
-- `pyhwp` (hwp5): Mac에서 동작 확인
-- 파이프라인: HWP → `hwp5html` → XHTML → Python 파싱 → JSON
+### HWP 파서 조사
+- `pyhwpx`: **Windows 전용 (Mac 불가)** — `RuntimeError: pyhwpx는 Windows에서만 동작합니다`
+- `python-hwp`: pip에 존재하지 않음
+- `pyhwp` (hwp5): **Mac에서 동작 확인**, `olefile` 기반
+- `hwp5html`: HWP → XHTML 변환, **표 구조 완벽 보존** (td/rowspan/colspan)
+- 파이프라인: HWP → `hwp5html --output dir` → `index.xhtml` → Python 파싱 → JSON
 
 ### 버전 진화
 
 | 버전 | 변경 | OSHACT-FORM-001 결과 |
 |---|---|---|
 | v1 | 기본 패턴 매칭 | 필드 20, 증빙 10 |
-| v2 | element_type 분류, "인" 오탐 수정 | 필드 16, 증빙 2 |
+| v2 | element_type 분류, "인" 오탐 수정, Audit 추가 | 필드 16, 증빙 2 |
 | v3.0 | 구조적 분석, 번호항목 전수 추출, 테이블목적 분류 | 필드 21, 분류율 96% |
-| **v3.1** | **FIELD_LABEL 무조건 추출 + INSTRUCTION 셀단위 스킵** | 필드 21+, 전 건 100% |
+| **v3.1** | **FIELD_LABEL 무조건 추출 + INSTRUCTION 셀단위 스킵** | 필드 21+, **전 건 100%** |
 
 ### v3.1 핵심 수정 (버그 2건)
 
-**버그 1: FIELD_LABEL 조건부 추출**
+**버그 1: FIELD_LABEL 조건부 추출 → 51건 필드 0건**
 ```python
 # 수정 전: canonical 패턴 매칭 안 되면 필드 누락
 if canon:
@@ -84,8 +95,9 @@ if canon:
 canon = find_canonical(text) or "unclassified_field"
 fields.append(...)
 ```
+원인: canonical 패턴 34개에 매칭 안 되는 라벨(예: "검사 종류", "설비명칭")이 전부 누락
 
-**버그 2: INSTRUCTION_TABLE 전체 스킵**
+**버그 2: INSTRUCTION_TABLE 전체 스킵 → 서식 테이블도 스킵**
 ```python
 # 수정 전: 테이블에 "작성방법" 있으면 전체 스킵
 if purpose == "INSTRUCTION_TABLE": continue
@@ -93,37 +105,122 @@ if purpose == "INSTRUCTION_TABLE": continue
 # 수정 후: 안내문 셀 자체만 스킵
 if etype == "INSTRUCTION_TEXT" or etype == "DESCRIPTION_TEXT": continue
 ```
+원인: 법정서식 하단에 "작성방법" 안내가 같은 테이블에 포함된 경우 전체 스킵
 
 ### 최종 검증 (97건)
 
-| 섹션 | 이행률 |
-|---|---|
-| S01 원본보존 | **100%** |
-| S02 단위분해 | **87%** |
-| S03 필드 | **100%** (47% → 100%) |
-| S04 체크리스트 | **100%** |
-| S05 증빙 | **55%** (정상범위) |
-| S06 Family | **100%** |
-| S07 법령분리 | **100%** |
-| S08~S15 | **100%** |
+| 섹션 | 이행률 | 비고 |
+|---|---|---|
+| S01 원본보존 | **100%** (97/97) | |
+| S02 단위분해 | **87%** (84/97) | 13건 분류 1종류 이하 |
+| S03 필드 | **100%** (97/97) | 수정 전 47% → 수정 후 100% |
+| S04 체크리스트 | **100%** (97/97) | 0건도 정상 (보고서 서식) |
+| S05 증빙 | **55%** (53/97) | 정상 — 신고서류는 증빙 필드 없음 |
+| S06 Family | **100%** (97/97) | |
+| S07 법령분리 | **100%** (97/97) | 법령 자동 매핑 0건 |
+| S08 매핑후보 | **100%** (97/97) | |
+| S09 회사양식 | **100%** (97/97) | |
+| S10 Official분리 | **100%** (97/97) | |
+| S11 Validation | **100%** (97/97) | |
+| S12 Residual | **100%** (97/97) | |
+| S13 HumanReview | **100%** (97/97) | |
+| S14 Audit | **100%** (97/97) | |
+| S15 FinalOutput | **100%** (97/97) | |
 
 ---
 
-## 5. GitHub 커밋 이력
+## 5. 1순위 작업 현황 조사: rule_candidate ↔ document 연결
+
+### 법령엔진 ↔ 문서엔진 교차 테이블 현황
+
+| 쪽 | 테이블 | 건수 | 용도 |
+|---|---|---|---|
+| 법령엔진 | `rule_candidate` | **34,456** | 의무/금지/허가 후보 |
+| 법령엔진 | `rule_candidate_slot` | 146,595 | 룰 구성요소 (SCOPE, ACTION 등) |
+| 법령엔진 | `rule_candidate_relation` | 59,116 | 룰 간 관계 |
+| 문서엔진 | `document_forms` | 260 | 서식 카탈로그 |
+| 문서엔진 | `form_templates` | 11 | 핵심 서식 템플릿 |
+| 기존매핑 | `doc_rule_mapping` | **227** | doc_id ↔ rule_id (텍스트) |
+| 기존매핑 | `field_rule_mapping` | 1,615 | 필드 ↔ 룰 매핑 |
+| 기존매핑 | `obligation_form_mapping` | 11 | 의무 ↔ 서식 매핑 |
+
+### 연결 경로
+
+```
+rule_candidate (34,456건, UUID)
+  → article_id → law_article (조문)
+    → law_id → law_master (법령)
+
+document_forms (260건)
+  → law_ref (텍스트: "산안법 제57조")
+    → law_article (조문) ← 여기서 만남
+
+compiled JSON (97건)
+  → field_candidates (필드 후보)
+  → document_requirement_mapping_candidates: [] ← 현재 비어있음 (채워야 함)
+```
+
+### 발견한 이슈
+
+1. **doc_rule_mapping의 rule_id가 텍스트** (예: "CTL-CON-101")
+   - rule_candidate의 id는 UUID
+   - 직접 JOIN 불가 → 중간 변환 테이블 또는 article_id 기반 매칭 필요
+
+2. **doc_rule_mapping 전부 PENDING**
+   - 227건 모두 `review_status = 'PENDING'`, `match_method = 'LAW_REF_DIRECT_MATCH'`
+   - Human Review 미실시
+
+3. **산안법 교차점 확인**
+   - law_article 203건, rule_candidate 245건, document_forms 90건
+   - law_ref 텍스트 매칭(조문번호 포함)으로 연결 가능
+
+4. **compiled JSON의 `document_requirement_mapping_candidates`가 전부 빈 배열**
+   - 작업지시서 섹션 8 구현은 되어있으나 실제 매핑 데이터 미생성
+   - law_article 기반 자동 후보 생성 필요 (CANDIDATE 상태, 확정 금지)
+
+---
+
+## 6. GitHub 커밋 이력
 
 | 파일 | 브랜치 | 내용 |
 |---|---|---|
 | `scripts/collect_form_templates_v2.py` | dev | DB raw_xml 파싱 → 서식 flSeq 추출 |
 | `scripts/collect_document_forms.py` | dev | 260건↔CSV 매칭 → HWP 다운로드 |
 | `scripts/document_schema_compiler.py` | dev | v3.1: 16섹션 전체 이행 Document Schema Compiler |
+| `docs/worklogs/2026-05-11_document_engine.md` | dev | 이 업무일지 |
 
 ---
 
-## 6. 다음 작업
+## 7. 다음 세션 작업 우선순위
 
-- [ ] Document Schema Compiler v3.1 결과 97건 JSON → Supabase DB 적재
-- [ ] 미매칭 7건 수동 매칭 (DOC-CON-001 등)
-- [ ] 나머지 45건 HWP 로컬 확보 → 재컴파일 (142-97=45)
-- [ ] S02 분류율 87% → 95%+ 개선
-- [ ] compiled JSON 기반 Human Review UI 구현
-- [ ] admrule-kr(행정규칙) INSERT 및 매핑 SQL 실행 (Track B 계속)
+### 1순위: rule_candidate ↔ document_requirement_candidate 실제 연결
+- rule_candidate.article_id → law_article → document_forms.law_ref 매칭
+- compiled JSON의 `document_requirement_mapping_candidates` 채우기
+- doc_rule_mapping 227건의 rule_id(텍스트) → rule_candidate(UUID) 변환
+- 모든 매핑은 CANDIDATE 상태 (작업지시서 섹션 7~8 준수)
+
+### 2순위: runtime_form_schema 실제 생성
+- compiled JSON 97건의 field_candidates → 런타임 폼 스키마 생성
+- 사용자가 실제 폼을 열었을 때 렌더링할 수 있는 구조
+
+### 3순위: Human Review Admin 강화
+- human_review_queue 기반 Admin UI
+- CANDIDATE → CONFIRMED/REJECTED 워크플로
+
+### 4순위: 자동 inference 제거 검수 계속
+- canonical_field_candidate 중 `unclassified_field` 비율 점검
+- element_type 분류율 87% → 95%+ 개선
+- S02 13건(분류 1종류 이하) 원인 분석
+
+---
+
+## 8. 잔여 이슈
+
+| 이슈 | 심각도 | 내용 |
+|---|---|---|
+| 미매칭 7건 | 낮음 | DOC-CON-001 등 서식명 일반적, 수동 매칭 필요 |
+| 로컬 미존재 45건 | 중간 | 142건 중 97건만 로컬에 HWP 있음, 나머지 재다운로드 필요 |
+| Family 분류 | 낮음 | `--file` 모드에서 파일명만 사용, DB form_name 미활용 |
+| doc_rule_mapping rule_id 타입 불일치 | 높음 | 텍스트 ID vs UUID, 연결 전략 필요 |
+| compiled JSON 미적재 | 중간 | 97건 JSON이 로컬에만 존재, DB 미적재 |
+| document_schema_compiler.py 로컬 수정본 | 높음 | v3.1 버그 수정이 로컬에만 반영, **git push 필요** |

--- a/docs/worklogs/2026-05-11_document_engine.md
+++ b/docs/worklogs/2026-05-11_document_engine.md
@@ -1,0 +1,129 @@
+# 업무정리일지 — 2026-05-11 (일)
+
+## 세션: TAI 문서엔진 — 법정서식 HWP 수집 + Document Schema Compiler
+
+---
+
+## 1. 현황 조사
+
+### Supabase 스토리지
+- 17개 버킷 중 문서 관련 3개(form-templates, form-originals, form-outputs) **전부 비어있음** 확인
+- law-attachments 버킷: 1,320건 (공정시험기준/설계기준 첨부파일, 서식 아님)
+
+### DB 테이블
+- `form_templates` 11건: hwp_url만 있고 파일 미다운로드, storage 경로 전부 NULL
+- `document_forms` 260건: file_url 전부 NULL, has_legal_form=true 138건
+- 기존 bylSeq URL 11건 **전부 404** (법령 개정으로 만료)
+
+---
+
+## 2. 법제처 bylSeq 404 문제 해결
+
+### 문제
+- `bylFileP.do?bylSeq=` URL이 법령 개정마다 변경되어 전부 404
+
+### 시도 1: 법제처 DRF API `target=bylSc`
+- 결과: 엔드포인트 자체 존재하지 않음 → 14건 전부 404
+
+### 시도 2 (해결): DB `law_content_raw.raw_xml` 파싱
+- `raw_xml`에 이미 최신 법령 XML 저장되어 있음 발견
+- 산안법 시행규칙: 138개 `<별표단위>` 블록, 276개 `별표서식파일링크`
+- `<별표서식파일링크>/LSW/flDownload.do?flSeq=...` 추출
+- **외부 API 호출 0회**, DB 읽기만으로 동작
+
+### 가운뎃점 문제
+- form_templates: `·` (U+00B7) vs XML: `ㆍ` (U+318D) → 4/11만 자동 매칭
+- 나머지 7건: CSV에서 flSeq 확인 후 SQL UPDATE → v1 스크립트 재실행
+
+---
+
+## 3. 법정서식 HWP 수집 결과
+
+| 항목 | 대상 | 성공 | 방법 |
+|---|---|---|---|
+| form_templates | 11건 | **11/11** | DB raw_xml → flSeq → 다운로드 |
+| document_forms (has_legal_form=true) | 138건 | **131/138** | CSV 1,015건 매칭 → 다운로드 |
+| 미매칭 | 7건 | 보류 | 서식명 너무 일반적 |
+| **합계** | **142건** | | `form-originals` 버킷 적재 |
+
+### 전체 서식 CSV
+- `all_bylaw_forms.csv`: **1,015건** (14개 시행규칙의 별표+서식 전체)
+- 법령별 분포: 산안법 138건, 위험물 70건, 화학물질관리법 60건 등
+
+---
+
+## 4. Document Schema Compiler 구현
+
+### 작업지시서
+- "오염 방지형 Document Schema Compiler" 16개 섹션 규칙
+- 핵심: 문서에 실제 존재하는 구조만 증거 기반 추출, 임의해석 금지
+
+### HWP 파서
+- `pyhwpx`: Windows 전용 (Mac 불가)
+- `pyhwp` (hwp5): Mac에서 동작 확인
+- 파이프라인: HWP → `hwp5html` → XHTML → Python 파싱 → JSON
+
+### 버전 진화
+
+| 버전 | 변경 | OSHACT-FORM-001 결과 |
+|---|---|---|
+| v1 | 기본 패턴 매칭 | 필드 20, 증빙 10 |
+| v2 | element_type 분류, "인" 오탐 수정 | 필드 16, 증빙 2 |
+| v3.0 | 구조적 분석, 번호항목 전수 추출, 테이블목적 분류 | 필드 21, 분류율 96% |
+| **v3.1** | **FIELD_LABEL 무조건 추출 + INSTRUCTION 셀단위 스킵** | 필드 21+, 전 건 100% |
+
+### v3.1 핵심 수정 (버그 2건)
+
+**버그 1: FIELD_LABEL 조건부 추출**
+```python
+# 수정 전: canonical 패턴 매칭 안 되면 필드 누락
+if canon:
+    fields.append(...)
+
+# 수정 후: 무조건 필드 후보 (canonical은 보너스)
+canon = find_canonical(text) or "unclassified_field"
+fields.append(...)
+```
+
+**버그 2: INSTRUCTION_TABLE 전체 스킵**
+```python
+# 수정 전: 테이블에 "작성방법" 있으면 전체 스킵
+if purpose == "INSTRUCTION_TABLE": continue
+
+# 수정 후: 안내문 셀 자체만 스킵
+if etype == "INSTRUCTION_TEXT" or etype == "DESCRIPTION_TEXT": continue
+```
+
+### 최종 검증 (97건)
+
+| 섹션 | 이행률 |
+|---|---|
+| S01 원본보존 | **100%** |
+| S02 단위분해 | **87%** |
+| S03 필드 | **100%** (47% → 100%) |
+| S04 체크리스트 | **100%** |
+| S05 증빙 | **55%** (정상범위) |
+| S06 Family | **100%** |
+| S07 법령분리 | **100%** |
+| S08~S15 | **100%** |
+
+---
+
+## 5. GitHub 커밋 이력
+
+| 파일 | 브랜치 | 내용 |
+|---|---|---|
+| `scripts/collect_form_templates_v2.py` | dev | DB raw_xml 파싱 → 서식 flSeq 추출 |
+| `scripts/collect_document_forms.py` | dev | 260건↔CSV 매칭 → HWP 다운로드 |
+| `scripts/document_schema_compiler.py` | dev | v3.1: 16섹션 전체 이행 Document Schema Compiler |
+
+---
+
+## 6. 다음 작업
+
+- [ ] Document Schema Compiler v3.1 결과 97건 JSON → Supabase DB 적재
+- [ ] 미매칭 7건 수동 매칭 (DOC-CON-001 등)
+- [ ] 나머지 45건 HWP 로컬 확보 → 재컴파일 (142-97=45)
+- [ ] S02 분류율 87% → 95%+ 개선
+- [ ] compiled JSON 기반 Human Review UI 구현
+- [ ] admrule-kr(행정규칙) INSERT 및 매핑 SQL 실행 (Track B 계속)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-# main.py — v5.40.0
+# main.py — v5.41.0
+# v5.41.0: 문서엔진 API 라우터 등록 (15 API — /document-engine/*)
 # v5.40.0: 법령진단서비스 + SaaS 반복설정 분리 (diagnosis_engine + saas_setup 라우터)
 # v5.39.0: Compiler Core + Residual Intelligence + Admin Review 라우터 등록 (법령엔진 v3.0 Deterministic)
 # v5.38.0: admin_inquiries 라우터 등록 (GET/POST/PATCH /admin/inquiries) — Phase 4 통합 인박스
@@ -144,10 +145,12 @@ from routers.admin_review            import router as admin_review_router
 # v5.40.0 법령진단서비스 / SaaS 반복설정 분리
 from routers.diagnosis_engine        import router as diagnosis_engine_router
 from routers.saas_setup              import router as saas_setup_router
+# v5.41.0 문서엔진 API
+from routers.document_engine_api     import router as document_engine_api_router
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "5.40.0"
+APP_VERSION = "5.41.0"
 
 
 @asynccontextmanager
@@ -318,6 +321,9 @@ app.include_router(admin_review_router)                                         
 # v5.40.0 법령진단서비스 / SaaS 반복설정 분리
 app.include_router(diagnosis_engine_router)                                        # 3 API — /api/v1/diagnosis-engine/*
 app.include_router(saas_setup_router)                                              # 6 API — /api/v1/saas-setup/*
+
+# v5.41.0 문서엔진 API
+app.include_router(document_engine_api_router)                                     # 15 API — /document-engine/*
 
 
 @app.get("/")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-# main.py — v5.39.0
+# main.py — v5.40.0
+# v5.40.0: 법령진단서비스 + SaaS 반복설정 분리 (diagnosis_engine + saas_setup 라우터)
 # v5.39.0: Compiler Core + Residual Intelligence + Admin Review 라우터 등록 (법령엔진 v3.0 Deterministic)
 # v5.38.0: admin_inquiries 라우터 등록 (GET/POST/PATCH /admin/inquiries) — Phase 4 통합 인박스
 # v5.37.0: internal_inbox 라우터 등록 (POST /internal/inbox/notify) — Phase 3 인박스 슬랙 알림
@@ -140,10 +141,13 @@ from routers.admin_inquiries         import router as admin_inquiries_router    
 from routers.compiler_core           import router as compiler_core_router
 from routers.residual_intelligence   import router as ri_router
 from routers.admin_review            import router as admin_review_router
+# v5.40.0 법령진단서비스 / SaaS 반복설정 분리
+from routers.diagnosis_engine        import router as diagnosis_engine_router
+from routers.saas_setup              import router as saas_setup_router
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "5.39.0"
+APP_VERSION = "5.40.0"
 
 
 @asynccontextmanager
@@ -310,6 +314,10 @@ app.include_router(mail_router)
 app.include_router(compiler_core_router)                                          # 7 API — /api/v1/compiler/*
 app.include_router(ri_router)                                                      # 22 API — /api/v1/residual-intelligence/*
 app.include_router(admin_review_router)                                            # 12 API — /api/v1/admin/*
+
+# v5.40.0 법령진단서비스 / SaaS 반복설정 분리
+app.include_router(diagnosis_engine_router)                                        # 3 API — /api/v1/diagnosis-engine/*
+app.include_router(saas_setup_router)                                              # 6 API — /api/v1/saas-setup/*
 
 
 @app.get("/")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-# main.py — v5.41.0
+# main.py — v5.42.0
+# v5.42.0: Runtime Evaluator Engine 라우터 등록 (7 API — /runtime-evaluator/*)
 # v5.41.0: 문서엔진 API 라우터 등록 (15 API — /document-engine/*)
 # v5.40.0: 법령진단서비스 + SaaS 반복설정 분리 (diagnosis_engine + saas_setup 라우터)
 # v5.39.0: Compiler Core + Residual Intelligence + Admin Review 라우터 등록 (법령엔진 v3.0 Deterministic)
@@ -7,11 +8,6 @@
 # v5.36.0: pw_reset 라우터 등록 (POST /auth/pw-reset/request, /auth/pw-reset/confirm)
 # v5.35.0: payment_billing 라우터 등록 (POST /payments/inicis/billing/*, /payments/subscriptions/{id}/cancel)
 # v5.34.0: Sentry 복원 + /health 개선 (항상 200 반환) + diagram_proxy 복원
-# v5.33.0: Sentry 에러 모니터링 (SENTRY_DSN 환경 변수 시 초기화)
-# v5.32.0: diagram_proxy 라우터 등록 (GET /api/v1/diagrams/{number}) — Supabase Storage 한글 SVG 우회
-# v5.31.1: diagnosis_proposal 라우터 등록 (GET /diagnosis/proposal-pdf/{public_token})
-# v5.31.0: diagnosis_report 라우터 등록 (GET /diagnosis/report-pdf/{public_token})
-# v5.30.0: diagnosis_integrated 라우터 등록 (BE-10 진단통합 백엔드)
 import os
 import sentry_sdk
 
@@ -104,7 +100,7 @@ from routers.safety_meetings         import router as safety_meetings_router
 from routers.risk_assessments        import router as risk_assessments_router
 from routers.payment                 import router as payment_router
 from routers.payment_ops             import router as payment_ops_router
-from routers.payment_billing         import router as payment_billing_router   # v5.35.0 정기결제
+from routers.payment_billing         import router as payment_billing_router
 from routers.corrective_actions      import router as corrective_actions_router
 from routers.messaging               import router as messaging_router
 from routers.fcm                     import router as fcm_router
@@ -131,13 +127,13 @@ from routers.diagnosis_roi           import router as diagnosis_roi_router
 from routers.diagnosis_transform     import router as diagnosis_transform_router
 from routers.overdue_checker         import router as overdue_checker_router
 from routers.diagnosis_plan_recommend import router as plan_recommend_router
-from routers.diagnosis_integrated    import router as diagnosis_integrated_router   # v5.30.0
-from routers.diagnosis_report        import router as diagnosis_report_router        # v5.31.0
-from routers.diagnosis_proposal      import router as diagnosis_proposal_router      # v5.31.1
-from routers.diagram_proxy           import router as diagram_proxy_router           # v5.32.0
-from routers.pw_reset                import router as pw_reset_router                # v5.36.0 비밀번호재설정
-from routers.internal_inbox          import router as internal_inbox_router            # v5.37.0 인박스 슬랙 알림
-from routers.admin_inquiries         import router as admin_inquiries_router            # v5.38.0 Phase 4 인박스 API
+from routers.diagnosis_integrated    import router as diagnosis_integrated_router
+from routers.diagnosis_report        import router as diagnosis_report_router
+from routers.diagnosis_proposal      import router as diagnosis_proposal_router
+from routers.diagram_proxy           import router as diagram_proxy_router
+from routers.pw_reset                import router as pw_reset_router
+from routers.internal_inbox          import router as internal_inbox_router
+from routers.admin_inquiries         import router as admin_inquiries_router
 # v5.39.0 법령엔진 v3.0 Deterministic Compiler Core
 from routers.compiler_core           import router as compiler_core_router
 from routers.residual_intelligence   import router as ri_router
@@ -147,10 +143,12 @@ from routers.diagnosis_engine        import router as diagnosis_engine_router
 from routers.saas_setup              import router as saas_setup_router
 # v5.41.0 문서엔진 API
 from routers.document_engine_api     import router as document_engine_api_router
+# v5.42.0 Runtime Evaluator Engine
+from routers.runtime_evaluator_api   import router as runtime_evaluator_api_router
 
 logger = logging.getLogger(__name__)
 
-APP_VERSION = "5.41.0"
+APP_VERSION = "5.42.0"
 
 
 @asynccontextmanager
@@ -304,7 +302,7 @@ app.include_router(safety_meetings_router)
 app.include_router(risk_assessments_router)
 app.include_router(payment_router)
 app.include_router(payment_ops_router)
-app.include_router(payment_billing_router)                                        # v5.35.0 정기결제
+app.include_router(payment_billing_router)
 app.include_router(corrective_actions_router)
 app.include_router(messaging_router)
 app.include_router(fcm_router)
@@ -324,6 +322,9 @@ app.include_router(saas_setup_router)                                           
 
 # v5.41.0 문서엔진 API
 app.include_router(document_engine_api_router)                                     # 15 API — /document-engine/*
+
+# v5.42.0 Runtime Evaluator Engine
+app.include_router(runtime_evaluator_api_router)                                   # 7 API — /runtime-evaluator/*
 
 
 @app.get("/")

--- a/routers/diagnosis_engine.py
+++ b/routers/diagnosis_engine.py
@@ -1,0 +1,52 @@
+"""법령진단서비스 API.
+
+법령진단은 '결과 출력'까지 한다.
+반복설정/스케줄/업무/위반을 확정하지 않는다.
+"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+import os
+
+router = APIRouter(prefix='/api/v1/diagnosis-engine', tags=['법령진단서비스'])
+
+
+def _get_sb():
+    from supabase import create_client
+    return create_client(os.environ.get('SUPABASE_URL',''),
+                         os.environ.get('SUPABASE_SERVICE_ROLE_KEY',''))
+
+
+class DiagnosisRequest(BaseModel):
+    factory_id: str
+    input_data: Dict[str, Any] = {}
+
+
+# ── 법령진단 실행 ──
+
+@router.post('/evaluate')
+async def evaluate_facility(body: DiagnosisRequest):
+    """법령진단 실행. Candidate 결과만 출력. 반복설정 등록 안 함."""
+    from services.diagnosis_service import DiagnosisService
+    try:
+        result = DiagnosisService.evaluate(_get_sb(), body.factory_id, body.input_data)
+        return result
+    except Exception as e:
+        raise HTTPException(500, str(e))
+
+
+@router.get('/session/{session_id}')
+async def get_session(session_id: str):
+    """진단 세션 상세 조회."""
+    from services.diagnosis_service import DiagnosisService
+    result = DiagnosisService.get_session(_get_sb(), session_id)
+    if not result:
+        raise HTTPException(404, 'Session not found')
+    return result
+
+
+@router.get('/sessions')
+async def list_sessions(factory_id: Optional[str] = None, limit: int = 20):
+    """진단 세션 목록."""
+    from services.diagnosis_service import DiagnosisService
+    return DiagnosisService.list_sessions(_get_sb(), factory_id, limit)

--- a/routers/document_engine_api.py
+++ b/routers/document_engine_api.py
@@ -1,0 +1,209 @@
+"""TAI 문서엔진 API v1.0.0
+
+Prefix: /document-engine
+Guardrails:
+  - 상태 전이는 runtime_state_transition_rule 기준만
+  - APPROVED_BY_HUMAN 시 reviewer_id 필수
+  - review_comment 필수 (REJECT/RETURN)
+  - 모든 상태 변경 audit log 기록
+  - generated_document는 입력된 값만 사용
+  - 누락값은 빈 값 유지
+  - evidence는 실제 파일만
+  - source_trace 항상 유지
+"""
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+from schemas.document_engine import (
+    DocumentCreateIn,
+    DocumentUpdateIn,
+    StatusChangeIn,
+    EvidenceLinkIn,
+    GenerateDocumentIn,
+)
+from services import document_engine_svc as svc
+
+router = APIRouter(prefix="/document-engine", tags=["문서엔진"])
+
+
+# ═══════════════════════════════════════════════════════
+# 1. Runtime Form Schema
+# ═══════════════════════════════════════════════════════
+
+@router.get("/schemas")
+def list_schemas(
+    document_family: Optional[str] = Query(None),
+    form_type: Optional[str] = Query(
+        None, description="OFFICIAL|CUSTOM|INTERNAL"
+    ),
+    status: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+):
+    """Runtime Form Schema 목록 조회"""
+    result = svc.list_form_schemas(
+        document_family, form_type, status, page, page_size
+    )
+    return {"status": "success", "data": result}
+
+
+@router.get("/schemas/{schema_id}")
+def get_schema_detail(schema_id: str):
+    """Schema 상세: fields + checklists + evidence_fields"""
+    result = svc.get_form_schema_detail(schema_id)
+    if not result:
+        raise HTTPException(404, "schema not found")
+    return {"status": "success", "data": result}
+
+
+# ═══════════════════════════════════════════════════════
+# 2. Runtime Document CRUD
+# ═══════════════════════════════════════════════════════
+
+@router.post("/documents")
+def create_document(body: DocumentCreateIn):
+    """문서 생성 (DRAFT 상태)"""
+    try:
+        result = svc.create_document(
+            body.form_schema_id,
+            body.factory_id,
+            body.company_id,
+            body.created_by,
+        )
+        return {"status": "success", "data": result}
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+@router.get("/documents")
+def list_documents(
+    factory_id: Optional[str] = Query(None),
+    company_id: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+):
+    """문서 목록 조회"""
+    result = svc.list_documents(
+        factory_id, company_id, status, page, page_size
+    )
+    return {"status": "success", "data": result}
+
+
+@router.get("/documents/{doc_id}")
+def get_document(doc_id: str):
+    """문서 상세 조회"""
+    result = svc.get_document(doc_id)
+    if not result:
+        raise HTTPException(404, "document not found")
+    return {"status": "success", "data": result}
+
+
+@router.patch("/documents/{doc_id}")
+def update_document(doc_id: str, body: DocumentUpdateIn):
+    """문서 데이터 수정 (runtime_data_json, evidence_links)"""
+    try:
+        result = svc.update_document(
+            doc_id,
+            body.runtime_data_json,
+            body.evidence_links,
+            body.updated_by,
+        )
+        return {"status": "success", "data": result}
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+# ═══════════════════════════════════════════════════════
+# 3. 상태 전이
+# ═══════════════════════════════════════════════════════
+
+@router.post("/documents/{doc_id}/status")
+def change_status(doc_id: str, body: StatusChangeIn):
+    """상태 전이 — runtime_state_transition_rule 기준만 허용"""
+    try:
+        result = svc.change_status(
+            doc_id, body.to_status, body.actor_id, body.comment
+        )
+        return {"status": "success", "data": result}
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+@router.get("/transitions")
+def list_transitions():
+    """허용된 상태 전이 규칙 목록"""
+    return {"status": "success", "data": svc.get_transitions()}
+
+
+# ═══════════════════════════════════════════════════════
+# 4. Evidence
+# ═══════════════════════════════════════════════════════
+
+@router.post("/documents/{doc_id}/evidence")
+def add_evidence(doc_id: str, body: EvidenceLinkIn):
+    """증빙 파일 링크 등록"""
+    doc = svc.get_document(doc_id)
+    if not doc:
+        raise HTTPException(404, "document not found")
+    result = svc.link_evidence(
+        doc_id,
+        body.evidence_type,
+        body.storage_path,
+        body.file_name,
+        body.file_size,
+        body.mime_type,
+        body.linked_field_id,
+        body.uploaded_by,
+    )
+    return {"status": "success", "data": result}
+
+
+@router.get("/documents/{doc_id}/evidence")
+def list_evidence(doc_id: str):
+    """문서의 증빙 목록"""
+    return {"status": "success", "data": svc.list_evidence(doc_id)}
+
+
+# ═══════════════════════════════════════════════════════
+# 5. Generated Document
+# ═══════════════════════════════════════════════════════
+
+@router.post("/documents/{doc_id}/generate")
+def generate_document(doc_id: str, body: GenerateDocumentIn):
+    """문서 생성 (입력값만 사용, auto fill 금지)"""
+    try:
+        result = svc.generate_document(doc_id, body.export_type)
+        return {"status": "success", "data": result}
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+@router.get("/documents/{doc_id}/generated")
+def list_generated(doc_id: str):
+    """생성된 문서 목록"""
+    return {"status": "success", "data": svc.list_generated(doc_id)}
+
+
+# ═══════════════════════════════════════════════════════
+# 6. Metrics & Audit
+# ═══════════════════════════════════════════════════════
+
+@router.get("/metrics")
+def get_metrics():
+    """전체 Runtime 메트릭"""
+    return {"status": "success", "data": svc.get_metrics()}
+
+
+@router.get("/metrics/factory/{factory_id}")
+def get_factory_metrics(factory_id: str):
+    """시설별 메트릭"""
+    return {
+        "status": "success",
+        "data": svc.get_metrics_by_factory(factory_id),
+    }
+
+
+@router.get("/documents/{doc_id}/audit-log")
+def get_audit_log(doc_id: str):
+    """문서 감사 로그"""
+    return {"status": "success", "data": svc.get_audit_log(doc_id)}

--- a/routers/document_runtime.py
+++ b/routers/document_runtime.py
@@ -1,0 +1,146 @@
+"""document_runtime.py — Runtime Document Payload API (PHASE F)
+
+PDF 생성이 아니라 Runtime Document Projection 반환.
+"""
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+from db.supabase_client import get_supabase
+from services.runtime_binding_resolver import resolve_document_runtime
+from services.conditional_rendering_resolver import resolve_conditional_fields
+from services.field_completeness_engine import (
+    evaluate_field_completeness, calculate_document_completeness
+)
+from services.evidence_binding_engine import (
+    get_evidence_for_document, bind_evidence_to_fields
+)
+
+router = APIRouter(prefix="/document-runtime", tags=["Document Runtime"])
+
+
+@router.get("/{document_type}")
+async def get_runtime_document(
+    document_type: str,
+    facility_id: Optional[str] = Query(None),
+):
+    """Runtime Document Projection 반환"""
+    context = {"facility_id": facility_id} if facility_id else {}
+    payload = resolve_document_runtime(document_type, context)
+
+    if "error" in payload:
+        raise HTTPException(404, payload["error"])
+
+    # PHASE C: conditional rendering
+    for section in payload.get("sections", []):
+        section["fields"] = resolve_conditional_fields(
+            section["fields"], context
+        )
+
+    # PHASE D: completeness
+    completeness = calculate_document_completeness(payload.get("sections", []))
+    payload["completeness"] = completeness
+
+    return payload
+
+
+@router.post("/render")
+async def render_runtime_document(body: dict):
+    """Runtime context 기반 문서 렌더링"""
+    document_type = body.get("document_type")
+    context = body.get("context", {})
+
+    if not document_type:
+        raise HTTPException(400, "document_type required")
+
+    payload = resolve_document_runtime(document_type, context)
+    if "error" in payload:
+        raise HTTPException(404, payload["error"])
+
+    for section in payload.get("sections", []):
+        section["fields"] = resolve_conditional_fields(section["fields"], context)
+
+    completeness = calculate_document_completeness(payload.get("sections", []))
+    payload["completeness"] = completeness
+
+    # evidence binding
+    evidence_list = get_evidence_for_document(document_type, context)
+    evidence_summary = bind_evidence_to_fields(payload.get("sections", []), evidence_list)
+    payload["evidence_summary"] = evidence_summary
+
+    return payload
+
+
+@router.get("/completeness/{document_type}")
+async def get_completeness(
+    document_type: str,
+    facility_id: Optional[str] = Query(None),
+):
+    """Field-level completeness summary"""
+    context = {"facility_id": facility_id} if facility_id else {}
+    payload = resolve_document_runtime(document_type, context)
+
+    if "error" in payload:
+        raise HTTPException(404, payload["error"])
+
+    for section in payload.get("sections", []):
+        section["fields"] = resolve_conditional_fields(section["fields"], context)
+
+    completeness = calculate_document_completeness(payload.get("sections", []))
+
+    return {
+        "document_type": document_type,
+        "completeness": completeness,
+    }
+
+
+@router.get("/evidence-binding/{document_type}")
+async def get_evidence_binding(
+    document_type: str,
+    facility_id: Optional[str] = Query(None),
+):
+    """Evidence binding summary"""
+    context = {"facility_id": facility_id} if facility_id else {}
+    payload = resolve_document_runtime(document_type, context)
+
+    if "error" in payload:
+        raise HTTPException(404, payload["error"])
+
+    evidence_list = get_evidence_for_document(document_type, context)
+    evidence_summary = bind_evidence_to_fields(payload.get("sections", []), evidence_list)
+
+    return {
+        "document_type": document_type,
+        "evidence": evidence_summary,
+    }
+
+
+@router.get("/integrity/{document_type}")
+async def check_rendering_integrity(
+    document_type: str,
+    facility_id: Optional[str] = Query(None),
+):
+    """Rendering Integrity Verification (PHASE G)"""
+    context = {"facility_id": facility_id} if facility_id else {}
+    payload = resolve_document_runtime(document_type, context)
+
+    if "error" in payload:
+        raise HTTPException(404, payload["error"])
+
+    issues = []
+    for section in payload.get("sections", []):
+        for field in section.get("fields", []):
+            # orphan field (no source)
+            if not field.get("source"):
+                issues.append({"type": "missing_source_mapping", "field": field["field_code"]})
+            # render null mismatch
+            if field.get("required_level") == "MANDATORY" and not field.get("resolved"):
+                issues.append({"type": "mandatory_unresolved", "field": field["field_code"]})
+            # hidden mandatory
+            if not field.get("visible", True) and field.get("required_level") == "MANDATORY":
+                issues.append({"type": "hidden_mandatory_field", "field": field["field_code"]})
+
+    return {
+        "document_type": document_type,
+        "total_issues": len(issues),
+        "integrity_status": "CLEAN" if not issues else "HAS_ISSUES",
+        "issues": issues[:50],
+    }

--- a/routers/document_schema.py
+++ b/routers/document_schema.py
@@ -1,0 +1,214 @@
+"""
+document_schema.py — Document Schema Registry API
+
+문서 구조 메타데이터 조회. Admin-only 우선.
+작업지시서 #1 PHASE I.
+"""
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+from db.supabase_client import get_supabase
+
+router = APIRouter(prefix="/document-schema", tags=["Document Schema"])
+
+
+@router.get("/list")
+async def list_document_schemas(
+    status: Optional[str] = Query(None, description="CANDIDATE/CONFIRMED/DEPRECATED"),
+    enabled: Optional[bool] = Query(None),
+):
+    """등록된 문서 유형 목록 + 섹션/필드 요약"""
+    sb = get_supabase()
+
+    # document_type별 집계
+    q = sb.table("document_schema_registry").select(
+        "document_type, schema_version, required_level, status"
+    )
+    if status:
+        q = q.eq("status", status)
+    if enabled is not None:
+        q = q.eq("enabled", enabled)
+
+    result = q.execute()
+    rows = result.data or []
+
+    # 집계
+    types = {}
+    for r in rows:
+        dt = r["document_type"]
+        if dt not in types:
+            types[dt] = {
+                "document_type": dt,
+                "schema_version": r["schema_version"],
+                "total_fields": 0,
+                "mandatory_fields": 0,
+                "recommended_fields": 0,
+                "optional_fields": 0,
+            }
+        types[dt]["total_fields"] += 1
+        level = r.get("required_level", "OPTIONAL")
+        if level == "MANDATORY":
+            types[dt]["mandatory_fields"] += 1
+        elif level == "RECOMMENDED":
+            types[dt]["recommended_fields"] += 1
+        else:
+            types[dt]["optional_fields"] += 1
+
+    # 섹션 수
+    sec_result = sb.table("document_schema_section").select(
+        "document_type"
+    ).execute()
+    sec_counts = {}
+    for s in (sec_result.data or []):
+        dt = s["document_type"]
+        sec_counts[dt] = sec_counts.get(dt, 0) + 1
+
+    for dt in types:
+        types[dt]["total_sections"] = sec_counts.get(dt, 0)
+
+    return {
+        "total_document_types": len(types),
+        "document_types": sorted(types.values(), key=lambda x: x["document_type"]),
+    }
+
+
+@router.get("/{document_type}")
+async def get_document_schema(document_type: str):
+    """문서 유형의 전체 스키마 (섹션+필드)"""
+    sb = get_supabase()
+
+    # 섹션
+    sections = sb.table("document_schema_section").select("*").eq(
+        "document_type", document_type
+    ).order("section_order").execute()
+
+    # 필드
+    fields = sb.table("document_schema_registry").select("*").eq(
+        "document_type", document_type
+    ).eq("enabled", True).order("field_order").execute()
+
+    if not fields.data:
+        raise HTTPException(404, f"Document type '{document_type}' not found")
+
+    # 섹션별 그룹
+    section_map = {}
+    for s in (sections.data or []):
+        section_map[s["section_code"]] = {
+            **s,
+            "fields": [],
+        }
+
+    for f in (fields.data or []):
+        sc = f.get("section_code", "GENERAL")
+        if sc not in section_map:
+            section_map[sc] = {
+                "section_code": sc,
+                "section_title": f.get("section_title", sc),
+                "section_order": 999,
+                "fields": [],
+            }
+        section_map[sc]["fields"].append(f)
+
+    ordered = sorted(section_map.values(), key=lambda x: x.get("section_order", 999))
+
+    return {
+        "document_type": document_type,
+        "total_sections": len(ordered),
+        "total_fields": len(fields.data or []),
+        "sections": ordered,
+    }
+
+
+@router.get("/render-structure/{document_type}")
+async def get_render_structure(document_type: str):
+    """프론트엔드 렌더링용 구조 (섹션→필드→render_component)"""
+    sb = get_supabase()
+
+    sections = sb.table("document_schema_section").select("*").eq(
+        "document_type", document_type
+    ).eq("enabled", True).order("section_order").execute()
+
+    fields = sb.table("document_schema_registry").select(
+        "section_code, field_code, field_label, field_type, field_order, "
+        "required_level, render_component, validation_rule, conditional_rule, repeatable"
+    ).eq("document_type", document_type
+    ).eq("enabled", True).order("field_order").execute()
+
+    if not fields.data:
+        raise HTTPException(404, f"No render structure for '{document_type}'")
+
+    structure = []
+    field_by_section = {}
+    for f in (fields.data or []):
+        sc = f.pop("section_code", "GENERAL")
+        if sc not in field_by_section:
+            field_by_section[sc] = []
+        field_by_section[sc].append(f)
+
+    for s in (sections.data or []):
+        sc = s["section_code"]
+        structure.append({
+            "section_code": sc,
+            "section_title": s["section_title"],
+            "fields": field_by_section.get(sc, []),
+        })
+
+    return {
+        "document_type": document_type,
+        "render_structure": structure,
+    }
+
+
+@router.get("/field-mapping/{document_type}")
+async def get_field_mapping(document_type: str):
+    """필드 → 데이터 소스 매핑 (PHASE C)"""
+    sb = get_supabase()
+
+    fields = sb.table("document_schema_registry").select(
+        "field_code, field_label, source_mapping, source_trace, source_reason, "
+        "required_level, status"
+    ).eq("document_type", document_type
+    ).eq("enabled", True).order("field_order").execute()
+
+    if not fields.data:
+        raise HTTPException(404, f"No field mapping for '{document_type}'")
+
+    mapped = [f for f in fields.data if f.get("source_mapping")]
+    unmapped = [f for f in fields.data if not f.get("source_mapping")]
+
+    return {
+        "document_type": document_type,
+        "total_fields": len(fields.data),
+        "mapped_fields": len(mapped),
+        "unmapped_fields": len(unmapped),
+        "fields": fields.data,
+    }
+
+
+@router.get("/integrity/{document_type}")
+async def check_schema_integrity(document_type: str):
+    """스키마 무결성 점검 (PHASE H)"""
+    sb = get_supabase()
+
+    fields = sb.table("document_schema_registry").select("*").eq(
+        "document_type", document_type
+    ).execute()
+
+    if not fields.data:
+        raise HTTPException(404, f"No schema for '{document_type}'")
+
+    issues = []
+    for f in fields.data:
+        if not f.get("render_component"):
+            issues.append({"field": f["field_code"], "issue": "missing_render_component"})
+        if f.get("required_level") == "MANDATORY" and not f.get("validation_rule"):
+            issues.append({"field": f["field_code"], "issue": "mandatory_without_validation"})
+        if f.get("status") == "CANDIDATE":
+            issues.append({"field": f["field_code"], "issue": "unconfirmed_candidate"})
+
+    return {
+        "document_type": document_type,
+        "total_fields": len(fields.data),
+        "total_issues": len(issues),
+        "integrity_status": "CLEAN" if not issues else "HAS_ISSUES",
+        "issues": issues[:50],
+    }

--- a/routers/notification_digest_api.py
+++ b/routers/notification_digest_api.py
@@ -1,0 +1,55 @@
+"""Notification Digest API.
+
+GET  /notification-engine/digest-policies    — Digest 정책 목록
+GET  /notification-engine/digest-candidates  — Digest 후보 목록
+POST /notification-engine/digest-test        — Digest 테스트 append
+"""
+
+from fastapi import APIRouter, Query
+from services.notification_engine.digest_runtime import (
+    list_digest_policies,
+    list_digest_candidates,
+    check_and_append,
+)
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+router = APIRouter(prefix="/notification-engine", tags=["notification-digest"])
+
+
+@router.get("/digest-policies")
+async def get_digest_policies(enabled_only: bool = Query(False)):
+    """Digest 정책 목록."""
+    data = await list_digest_policies(enabled_only=enabled_only)
+    return {"status": "success", "data": data, "count": len(data)}
+
+
+@router.get("/digest-candidates")
+async def get_digest_candidates(
+    status: str = Query("PENDING"),
+    limit: int = Query(50, le=200),
+):
+    """Digest 후보 목록."""
+    data = await list_digest_candidates(status=status, limit=limit)
+    return {"status": "success", "data": data, "count": len(data)}
+
+
+class DigestTestRequest(BaseModel):
+    source_type: Optional[str] = None
+    event_type: Optional[str] = None
+    trace_id: Optional[str] = None
+    event_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+@router.post("/digest-test")
+async def test_digest(req: DigestTestRequest):
+    """Digest 테스트 (shadow mode append)."""
+    result = await check_and_append(
+        source_type=req.source_type,
+        event_type=req.event_type,
+        trace_id=req.trace_id,
+        event_id=req.event_id,
+        metadata=req.metadata,
+    )
+    return {"status": "success", "data": result}

--- a/routers/notification_wiring_api.py
+++ b/routers/notification_wiring_api.py
@@ -1,0 +1,50 @@
+"""Notification Event Wiring API.
+
+GET  /notification-engine/wirings       — Wiring 목록
+GET  /notification-engine/policies      — Policy 목록
+POST /notification-engine/wirings/test  — Wiring 테스트 발송
+"""
+
+from fastapi import APIRouter, Query
+from services.notification_engine.event_wiring import (
+    list_wirings,
+    list_policies,
+    wire_and_emit,
+)
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+router = APIRouter(prefix="/notification-engine", tags=["notification-wiring"])
+
+
+@router.get("/wirings")
+async def get_wirings(enabled_only: bool = Query(True)):
+    """Wiring 목록 조회."""
+    data = await list_wirings(enabled_only=enabled_only)
+    return {"status": "success", "data": data, "count": len(data)}
+
+
+@router.get("/policies")
+async def get_policies():
+    """정책 목록 조회."""
+    data = await list_policies()
+    return {"status": "success", "data": data, "count": len(data)}
+
+
+class WiringTestRequest(BaseModel):
+    event_type: str
+    payload: Optional[Dict[str, Any]] = None
+    override_channel: Optional[str] = None
+    override_severity: Optional[str] = None
+
+
+@router.post("/wirings/test")
+async def test_wiring(req: WiringTestRequest):
+    """Wiring 테스트 발송."""
+    result = await wire_and_emit(
+        event_type=req.event_type,
+        payload=req.payload,
+        override_channel=req.override_channel,
+        override_severity=req.override_severity,
+    )
+    return {"status": "success", "data": result}

--- a/routers/overdue_checker.py
+++ b/routers/overdue_checker.py
@@ -70,7 +70,7 @@ def _today() -> date:
 
 
 def _schedule_wire_and_emit(event_type: str, payload: dict) -> None:
-    """033: sync cron path → fire-and-forget async wire_and_emit."""
+    """034: sync cron path → fire-and-forget async wire_and_emit."""
 
     async def _run() -> None:
         try:
@@ -306,7 +306,7 @@ def _process_one(sb, wa: dict, today: date) -> dict:
         except Exception as e:
             log.error("[OVERDUE] status OVERDUE 업데이트 실패: %s", e)
 
-    # ── Notification Runtime 연결 (033) ──
+    # ── Notification Runtime (034) ──
     _schedule_wire_and_emit(
         "schedule_overdue",
         {

--- a/routers/overdue_checker.py
+++ b/routers/overdue_checker.py
@@ -24,8 +24,10 @@ API:
   POST /overdue/resolve/{history_id} 지연 해소 해주기
 """
 from __future__ import annotations
+import asyncio
 import logging
 import os
+import threading
 from datetime import date, datetime, timezone, timedelta
 from typing import Optional, Any
 
@@ -65,6 +67,25 @@ _LEVELS = [
 
 def _today() -> date:
     return datetime.now(timezone.utc).date()
+
+
+def _schedule_wire_and_emit(event_type: str, payload: dict) -> None:
+    """033: sync cron path → fire-and-forget async wire_and_emit."""
+
+    async def _run() -> None:
+        try:
+            from services.notification_engine.event_wiring import wire_and_emit
+            await wire_and_emit(event_type=event_type, payload=payload)
+        except Exception as e:
+            log.warning("[NOTIF] %s wire failed: %s", event_type, e)
+
+    def _thread_main() -> None:
+        try:
+            asyncio.run(_run())
+        except Exception as e:
+            log.warning("[NOTIF] %s wire thread failed: %s", event_type, e)
+
+    threading.Thread(target=_thread_main, daemon=True).start()
 
 
 def _effective_due(wa: dict) -> Optional[date]:
@@ -225,6 +246,17 @@ def _process_one(sb, wa: dict, today: date) -> dict:
 
     company_id = worker_info.get("company_id")
 
+    factory_name = ""
+    if factory_id:
+        try:
+            fr = sb.table("factories").select("factory_name").eq("id", factory_id).limit(1).execute()
+            if fr.data:
+                factory_name = fr.data[0].get("factory_name") or ""
+        except Exception:
+            pass
+
+    inspection_id = wa.get("inspection_set_id") or wa.get("inspection_id")
+
     # 메시지 생성
     worker_name = worker_info.get("name") or "\uc791\uc5c5\uc790"
     msg = (msg_tpl
@@ -273,6 +305,20 @@ def _process_one(sb, wa: dict, today: date) -> dict:
             sb.table("work_assignments").update({"status_code": "OVERDUE"}).eq("id", wa_id).execute()
         except Exception as e:
             log.error("[OVERDUE] status OVERDUE 업데이트 실패: %s", e)
+
+    # ── Notification Runtime 연결 (033) ──
+    _schedule_wire_and_emit(
+        "schedule_overdue",
+        {
+            "title": f"점검 미이행: {task_name}",
+            "body": f"{factory_name or ''} 점검이 예정일을 초과했습니다.".strip(),
+            "factory_id": str(factory_id) if factory_id else None,
+            "company_id": str(company_id) if company_id else None,
+            "inspection_id": str(inspection_id) if inspection_id else None,
+            "assignment_id": str(wa_id),
+            "overdue_level": lvl,
+        },
+    )
 
     # overdue_level + last_reminded_at 업데이트
     now_iso = datetime.now(timezone.utc).isoformat()

--- a/routers/payment_billing.py
+++ b/routers/payment_billing.py
@@ -28,6 +28,7 @@ payments.py(단건결제)와는 별도 파일로 분리. 동일한 prefix="/paym
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -442,6 +443,52 @@ def _fail_subscription_by_oid(supabase, oid: str, reason: str) -> None:
     }).eq("inicis_order_id", oid).execute()
 
 
+async def _wire_payment_failed(
+    *,
+    company_id,
+    order_id: str,
+    result_msg: str = "",
+    plan_name: str = "",
+) -> None:
+    try:
+        from services.notification_engine.event_wiring import wire_and_emit
+
+        await wire_and_emit(
+            event_type="payment_failed",
+            payload={
+                "title": "결제 실패",
+                "body": f"결제가 실패했습니다. 사유: {result_msg or '알 수 없음'}",
+                "company_id": str(company_id) if company_id else None,
+                "order_id": order_id,
+                "plan_name": plan_name or None,
+            },
+        )
+    except Exception as e:
+        log.warning("[NOTIF] wire_and_emit failed: %s", e)
+
+
+async def _wire_subscription_activated(
+    *,
+    company_id,
+    order_id: str,
+    plan_name: str = "",
+) -> None:
+    try:
+        from services.notification_engine.event_wiring import wire_and_emit
+
+        await wire_and_emit(
+            event_type="subscription_activated",
+            payload={
+                "title": f"구독 활성화: {plan_name or 'TAI Safe'}",
+                "body": "결제 완료. 구독이 활성화되었습니다.",
+                "company_id": str(company_id) if company_id else None,
+                "order_id": order_id,
+            },
+        )
+    except Exception as e:
+        log.warning("[NOTIF] wire_and_emit failed: %s", e)
+
+
 # ── 엔드포인트 ────────────────────────────────────────────────────────
 
 @router.post("/inicis/billing/prepare")
@@ -545,6 +592,23 @@ async def billing_return(request: Request):
 
     if result_code and result_code != "0000":
         _fail_subscription_by_oid(supabase, order_id, result_msg or "인증 실패")
+        try:
+            sub_fail = (
+                supabase.table("subscriptions")
+                .select("company_id, plan_name")
+                .eq("inicis_order_id", order_id)
+                .limit(1)
+                .execute()
+            )
+            sub_row = sub_fail.data[0] if sub_fail.data else {}
+            asyncio.create_task(_wire_payment_failed(
+                company_id=sub_row.get("company_id"),
+                order_id=order_id,
+                result_msg=result_msg or "인증 실패",
+                plan_name=sub_row.get("plan_name") or "",
+            ))
+        except Exception as e:
+            log.warning("[NOTIF] payment_failed schedule failed: %s", e)
         return RedirectResponse(
             f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(result_msg or '인증 실패')}&oid={order_id}",
             status_code=302,
@@ -670,6 +734,11 @@ async def billing_return(request: Request):
     )
 
     if charge_res.get("success"):
+        asyncio.create_task(_wire_subscription_activated(
+            company_id=subscription.get("company_id"),
+            order_id=order_id,
+            plan_name=subscription.get("plan_name") or "TAI Safe",
+        ))
         qs = urllib.parse.urlencode({
             "resultCode":      "00",
             "oid":             order_id,
@@ -684,6 +753,12 @@ async def billing_return(request: Request):
         return RedirectResponse(f"{FRONT_RETURN_URL}?{qs}", status_code=302)
 
     fail_msg = charge_res.get("result", {}).get("resultMsg", "첫 결제 실패")
+    asyncio.create_task(_wire_payment_failed(
+        company_id=subscription.get("company_id"),
+        order_id=order_id,
+        result_msg=str(fail_msg),
+        plan_name=subscription.get("plan_name") or "",
+    ))
     return RedirectResponse(
         f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(str(fail_msg))}&oid={order_id}",
         status_code=302,

--- a/routers/payment_billing.py
+++ b/routers/payment_billing.py
@@ -32,6 +32,7 @@ import asyncio
 import hashlib
 import logging
 import os
+import threading
 import urllib.parse
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -431,6 +432,21 @@ def _apply_failure_to_subscription(supabase, subscription_id: str, reason: str) 
     supabase.table("subscriptions").update(upd).eq("id", subscription_id).execute()
 
 
+def _schedule_wire(coro) -> None:
+    """034: fire-and-forget wire_and_emit from sync billing helpers."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(coro)
+    except RuntimeError:
+        def _thread_main() -> None:
+            try:
+                asyncio.run(coro)
+            except Exception:
+                pass
+
+        threading.Thread(target=_thread_main, daemon=True).start()
+
+
 def _fail_subscription_by_oid(supabase, oid: str, reason: str) -> None:
     """prepare/return 단계에서 실패한 구독을 FAILED로 마킹."""
     if not oid:
@@ -441,6 +457,25 @@ def _fail_subscription_by_oid(supabase, oid: str, reason: str) -> None:
         "last_failure_reason": (reason or "")[:500],
         "updated_at":          _now_iso(),
     }).eq("inicis_order_id", oid).execute()
+
+    # ── Notification Runtime (034) ──
+    try:
+        sub_fail = (
+            supabase.table("subscriptions")
+            .select("company_id, plan_name")
+            .eq("inicis_order_id", oid)
+            .limit(1)
+            .execute()
+        )
+        sub_row = sub_fail.data[0] if sub_fail.data else {}
+        _schedule_wire(_wire_payment_failed(
+            company_id=sub_row.get("company_id"),
+            order_id=oid,
+            result_msg=reason or "",
+            plan_name=sub_row.get("plan_name") or "",
+        ))
+    except Exception:
+        pass
 
 
 async def _wire_payment_failed(
@@ -592,23 +627,6 @@ async def billing_return(request: Request):
 
     if result_code and result_code != "0000":
         _fail_subscription_by_oid(supabase, order_id, result_msg or "인증 실패")
-        try:
-            sub_fail = (
-                supabase.table("subscriptions")
-                .select("company_id, plan_name")
-                .eq("inicis_order_id", order_id)
-                .limit(1)
-                .execute()
-            )
-            sub_row = sub_fail.data[0] if sub_fail.data else {}
-            asyncio.create_task(_wire_payment_failed(
-                company_id=sub_row.get("company_id"),
-                order_id=order_id,
-                result_msg=result_msg or "인증 실패",
-                plan_name=sub_row.get("plan_name") or "",
-            ))
-        except Exception as e:
-            log.warning("[NOTIF] payment_failed schedule failed: %s", e)
         return RedirectResponse(
             f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(result_msg or '인증 실패')}&oid={order_id}",
             status_code=302,
@@ -734,11 +752,15 @@ async def billing_return(request: Request):
     )
 
     if charge_res.get("success"):
-        asyncio.create_task(_wire_subscription_activated(
-            company_id=subscription.get("company_id"),
-            order_id=order_id,
-            plan_name=subscription.get("plan_name") or "TAI Safe",
-        ))
+        # ── Notification Runtime (034) — 결제 성공 (ACTIVE 후 첫 결제) ──
+        try:
+            asyncio.create_task(_wire_subscription_activated(
+                company_id=subscription.get("company_id"),
+                order_id=order_id,
+                plan_name=subscription.get("plan_name") or "TAI Safe",
+            ))
+        except Exception:
+            pass
         qs = urllib.parse.urlencode({
             "resultCode":      "00",
             "oid":             order_id,
@@ -753,12 +775,7 @@ async def billing_return(request: Request):
         return RedirectResponse(f"{FRONT_RETURN_URL}?{qs}", status_code=302)
 
     fail_msg = charge_res.get("result", {}).get("resultMsg", "첫 결제 실패")
-    asyncio.create_task(_wire_payment_failed(
-        company_id=subscription.get("company_id"),
-        order_id=order_id,
-        result_msg=str(fail_msg),
-        plan_name=subscription.get("plan_name") or "",
-    ))
+    _fail_subscription_by_oid(supabase, order_id, str(fail_msg))
     return RedirectResponse(
         f"{FRONT_RETURN_URL}?resultCode=FAIL&msg={urllib.parse.quote(str(fail_msg))}&oid={order_id}",
         status_code=302,

--- a/routers/persistence_api.py
+++ b/routers/persistence_api.py
@@ -1,0 +1,42 @@
+"""TAI Persistence API v1.0.0
+Prefix: /persistence
+장기 운영 deterministic consistency.
+"""
+from fastapi import APIRouter,HTTPException,Query
+from typing import Optional
+from schemas.persistence import SnapshotIn,ReEvalIn,DriftCheckIn,ScheduleInstanceIn
+from services import persistence_svc as svc
+
+router=APIRouter(prefix="/persistence",tags=["런타임 지속성"])
+
+@router.post("/snapshots")
+def create_snapshot(body:SnapshotIn):
+    try:return{"status":"success","data":svc.create_snapshot(body.facility_id,body.evaluation_context_id)}
+    except ValueError as e:raise HTTPException(400,str(e))
+
+@router.post("/snapshots/{snapshot_id}/diff")
+def compute_diff(snapshot_id:str,body:SnapshotIn):
+    try:return{"status":"success","data":svc.compute_diff(body.facility_id,snapshot_id)}
+    except ValueError as e:raise HTTPException(400,str(e))
+
+@router.post("/re-evaluate")
+def queue_re_eval(body:ReEvalIn):
+    try:return{"status":"success","data":svc.queue_re_evaluation(body.facility_id,body.trigger_type,body.trigger_detail)}
+    except ValueError as e:raise HTTPException(400,str(e))
+
+@router.get("/re-evaluate/queue")
+def list_queue(facility_id:Optional[str]=Query(None),status:Optional[str]=Query(None),page:int=Query(1,ge=1),page_size:int=Query(20,ge=1,le=100)):
+    return{"status":"success","data":svc.list_re_evaluation_queue(facility_id,status,page,page_size)}
+
+@router.post("/schedules")
+def create_schedule(body:ScheduleInstanceIn):
+    try:return{"status":"success","data":svc.create_schedule_instance(body.facility_id,body.schedule_type,body.schedule_key,body.next_due_date,body.schedule_activation_id)}
+    except ValueError as e:raise HTTPException(400,str(e))
+
+@router.post("/drift-check")
+def check_drift(body:DriftCheckIn):
+    return{"status":"success","data":svc.check_drift(body.facility_id)}
+
+@router.get("/history/{facility_id}")
+def get_history(facility_id:str):
+    return{"status":"success","data":svc.get_facility_history(facility_id)}

--- a/routers/runtime_evaluator_api.py
+++ b/routers/runtime_evaluator_api.py
@@ -1,0 +1,48 @@
+"""TAI Runtime Evaluator API v1.0.0
+Prefix: /runtime-evaluator
+Deterministic Condition-Based Activation Only.
+"""
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+from schemas.runtime_evaluator import EvaluationContextIn, EvaluateIn
+from services import runtime_evaluator_svc as svc
+
+router = APIRouter(prefix="/runtime-evaluator", tags=["런타임 평가엔진"])
+
+@router.post("/contexts")
+def create_context(body: EvaluationContextIn):
+    try:
+        return {"status": "success", "data": svc.create_context(body.dict())}
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+@router.get("/contexts")
+def list_contexts(company_id: Optional[str] = Query(None), page: int = Query(1, ge=1), page_size: int = Query(20, ge=1, le=100)):
+    return {"status": "success", "data": svc.list_contexts(company_id, page, page_size)}
+
+@router.get("/contexts/{ctx_id}")
+def get_context(ctx_id: str):
+    r = svc.get_context(ctx_id)
+    if not r: raise HTTPException(404, "context not found")
+    return {"status": "success", "data": r}
+
+@router.post("/evaluate")
+def evaluate(body: EvaluateIn):
+    try:
+        return {"status": "success", "data": svc.evaluate(body.context_id)}
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+@router.get("/results/{ctx_id}")
+def get_result(ctx_id: str):
+    r = svc.get_result(ctx_id)
+    if not r: raise HTTPException(404, "result not found")
+    return {"status": "success", "data": r}
+
+@router.get("/results/{ctx_id}/conflicts")
+def get_conflicts(ctx_id: str):
+    return {"status": "success", "data": svc.get_conflicts(ctx_id)}
+
+@router.get("/results/{ctx_id}/audit")
+def get_audit(ctx_id: str):
+    return {"status": "success", "data": svc.get_audit(ctx_id)}

--- a/routers/saas_setup.py
+++ b/routers/saas_setup.py
@@ -1,0 +1,94 @@
+"""SaaS 반복설정 API.
+
+SaaS는 자동 의무등록기가 아니다.
+진단 결과 중 반복관리 후보를 승인받아 운영설정까지 한다.
+"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+import os
+
+router = APIRouter(prefix='/api/v1/saas-setup', tags=['SaaS 반복설정'])
+
+
+def _get_sb():
+    from supabase import create_client
+    return create_client(os.environ.get('SUPABASE_URL',''),
+                         os.environ.get('SUPABASE_SERVICE_ROLE_KEY',''))
+
+
+class ApproveRequest(BaseModel):
+    user_id: Optional[str] = None
+
+class RejectRequest(BaseModel):
+    reason: Optional[str] = None
+
+
+# ── 후보 추출 ──
+
+@router.post('/extract/{session_id}')
+async def extract_setup_candidates(session_id: str):
+    """진단 결과에서 반복관리 후보 추출. 자동 등록 안 함."""
+    from services.saas_setup_service import SaaSSetupService
+    try:
+        return SaaSSetupService.extract_setup_candidates(_get_sb(), session_id)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+# ── 후보 목록 ──
+
+@router.get('/candidates')
+async def list_candidates(
+    session_id: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50
+):
+    from services.saas_setup_service import SaaSSetupService
+    return SaaSSetupService.list_candidates(_get_sb(), session_id, status, limit)
+
+
+# ── 승인 ──
+
+@router.post('/approve/{setup_id}')
+async def approve_setup(setup_id: str, body: ApproveRequest):
+    """사용자 승인. 승인 후에만 Runtime 등록 가능."""
+    from services.saas_setup_service import SaaSSetupService
+    try:
+        return SaaSSetupService.approve(_get_sb(), setup_id, body.user_id)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+# ── 거절 ──
+
+@router.post('/reject/{setup_id}')
+async def reject_setup(setup_id: str, body: RejectRequest):
+    from services.saas_setup_service import SaaSSetupService
+    try:
+        return SaaSSetupService.reject(_get_sb(), setup_id, body.reason)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+# ── 추가 데이터 요청 ──
+
+@router.post('/needs-data/{setup_id}')
+async def needs_more_data(setup_id: str):
+    from services.saas_setup_service import SaaSSetupService
+    try:
+        return SaaSSetupService.request_more_data(_get_sb(), setup_id)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+# ── Runtime 등록 (승인된 것만) ──
+
+@router.post('/register/{setup_id}')
+async def register_to_runtime(setup_id: str, body: ApproveRequest):
+    """승인된 항목만 Runtime에 등록. rollback 가능."""
+    from services.saas_setup_service import SaaSSetupService
+    try:
+        return SaaSSetupService.register_to_runtime(_get_sb(), setup_id, body.user_id)
+    except ValueError as e:
+        raise HTTPException(400, str(e))

--- a/routers/simulation_api.py
+++ b/routers/simulation_api.py
@@ -1,0 +1,39 @@
+"""TAI Simulation API v1.0.0
+Prefix: /simulation
+Deterministic Runtime Verification.
+"""
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
+from schemas.simulation import ScenarioIn, RunSimulationIn
+from services import simulation_svc as svc
+
+router = APIRouter(prefix="/simulation", tags=["시뮬레이션"])
+
+@router.post("/scenarios")
+def create_scenario(body: ScenarioIn):
+    try: return {"status": "success", "data": svc.create_scenario(body.dict())}
+    except ValueError as e: raise HTTPException(400, str(e))
+
+@router.get("/scenarios")
+def list_scenarios(page: int = Query(1, ge=1), page_size: int = Query(20, ge=1, le=100)):
+    return {"status": "success", "data": svc.list_scenarios(page, page_size)}
+
+@router.get("/scenarios/{scenario_id}")
+def get_scenario(scenario_id: str):
+    r = svc.get_scenario(scenario_id)
+    if not r: raise HTTPException(404, "scenario not found")
+    return {"status": "success", "data": r}
+
+@router.post("/run")
+def run_simulation(body: RunSimulationIn):
+    try: return {"status": "success", "data": svc.run_simulation(body.scenario_id)}
+    except ValueError as e: raise HTTPException(400, str(e))
+
+@router.post("/verify-deterministic")
+def verify_deterministic(body: RunSimulationIn):
+    try: return {"status": "success", "data": svc.verify_deterministic(body.scenario_id)}
+    except ValueError as e: raise HTTPException(400, str(e))
+
+@router.get("/results/{scenario_id}")
+def get_result(scenario_id: str):
+    return {"status": "success", "data": svc.get_result(scenario_id)}

--- a/routers/weather.py
+++ b/routers/weather.py
@@ -115,6 +115,45 @@ def _resolve_lat_lon(site: dict) -> tuple[float, float]:
     return 37.5665, 126.9780
 
 
+def _alert_type_from_work_stop(weather_data: dict) -> str:
+    ws = weather_data.get("work_stop") if isinstance(weather_data, dict) else None
+    if not isinstance(ws, dict) or not ws.get("required"):
+        return ""
+    reasons = ws.get("reasons") or []
+    parts: list[str] = []
+    for r in reasons[:3]:
+        if isinstance(r, dict):
+            parts.append(str(r.get("code") or r.get("name") or r.get("msg") or ""))
+        else:
+            parts.append(str(r))
+    return ", ".join(p for p in parts if p) or "WORK_STOP"
+
+
+async def _wire_weather_work_stop(
+    *,
+    region: str,
+    alert_type: str,
+    site_id: Optional[str] = None,
+    site_name: Optional[str] = None,
+) -> None:
+    try:
+        from services.notification_engine.event_wiring import wire_and_emit
+
+        region_label = region or (site_name or "")
+        await wire_and_emit(
+            event_type="weather_work_stop",
+            payload={
+                "title": f"작업중지 경보: {alert_type or '기상 기준 초과'}",
+                "body": f"{region_label} 지역 작업중지 경보가 발령되었습니다.".strip(),
+                "region": region,
+                "alert_type": alert_type,
+                "site_id": str(site_id) if site_id else None,
+            },
+        )
+    except Exception as e:
+        log.warning("[NOTIF] weather_work_stop wire failed: %s", e)
+
+
 # ── 콘크리트 라우트 먼저 선언 ──────────────────────────────────────────
 
 @router.get("/work-stop-criteria")
@@ -151,6 +190,18 @@ async def get_work_stoppage_by_site(
 
     # Edge Function 호출 (weather/now 액션)
     weather_data = await _edge_call({"action": "now", "lat": str(lat), "lon": str(lon)})
+
+    alert_type = _alert_type_from_work_stop(weather_data)
+    if alert_type:
+        region = " ".join(
+            p for p in (site.get("site_sido"), site.get("site_sigungu")) if p
+        ) or (site.get("site_name") or "")
+        await _wire_weather_work_stop(
+            region=region,
+            alert_type=alert_type,
+            site_id=site_id,
+            site_name=site.get("site_name"),
+        )
 
     return {
         "status": "success",
@@ -190,7 +241,14 @@ async def get_weather_now(
     lon: float = Query(..., description="경도 (예: 126.9780)"),
 ):
     """현재 날씨 + 작업중지 판단 (Edge Function 경유 → apihub.kma.go.kr)"""
-    return await _edge_call({"action": "now", "lat": str(lat), "lon": str(lon)})
+    weather_data = await _edge_call({"action": "now", "lat": str(lat), "lon": str(lon)})
+    alert_type = _alert_type_from_work_stop(weather_data)
+    if alert_type:
+        await _wire_weather_work_stop(
+            region=f"{lat},{lon}",
+            alert_type=alert_type,
+        )
+    return weather_data
 
 
 @router.get("/alert")
@@ -201,4 +259,18 @@ async def get_weather_alert(
     payload: dict = {"action": "alert"}
     if region_code:
         payload["region_code"] = region_code
-    return await _edge_call(payload)
+    alert_data = await _edge_call(payload)
+    alerts = []
+    if isinstance(alert_data, dict):
+        alerts = alert_data.get("alerts") or alert_data.get("items") or alert_data.get("data") or []
+    if alerts:
+        first = alerts[0] if isinstance(alerts[0], dict) else {}
+        alert_type = str(
+            first.get("alert_type")
+            or first.get("warn_type")
+            or first.get("category")
+            or "SPECIAL_ALERT"
+        )
+        region = str(first.get("region") or first.get("region_name") or region_code or "")
+        await _wire_weather_work_stop(region=region, alert_type=alert_type)
+    return alert_data

--- a/schemas/document_engine.py
+++ b/schemas/document_engine.py
@@ -1,0 +1,40 @@
+"""TAI 문서엔진 스키마 v1.0.0"""
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict, Any
+from uuid import UUID
+from datetime import datetime
+
+
+# ─── Request ───
+
+class DocumentCreateIn(BaseModel):
+    form_schema_id: str
+    factory_id: Optional[str] = None
+    company_id: Optional[str] = None
+    created_by: Optional[str] = None
+
+
+class DocumentUpdateIn(BaseModel):
+    runtime_data_json: Optional[Dict[str, Any]] = None
+    evidence_links: Optional[List[dict]] = None
+    updated_by: Optional[str] = None
+
+
+class StatusChangeIn(BaseModel):
+    to_status: str
+    actor_id: Optional[str] = None
+    comment: Optional[str] = None
+
+
+class EvidenceLinkIn(BaseModel):
+    evidence_type: str
+    storage_path: str
+    file_name: Optional[str] = None
+    file_size: Optional[int] = None
+    mime_type: Optional[str] = None
+    linked_field_id: Optional[str] = None
+    uploaded_by: Optional[str] = None
+
+
+class GenerateDocumentIn(BaseModel):
+    export_type: str = "HTML"

--- a/schemas/persistence.py
+++ b/schemas/persistence.py
@@ -1,0 +1,22 @@
+"""Persistence 스키마 v1.0.0"""
+from pydantic import BaseModel
+from typing import Optional, List, Dict, Any
+
+class SnapshotIn(BaseModel):
+    facility_id: str
+    evaluation_context_id: Optional[str] = None
+
+class ReEvalIn(BaseModel):
+    facility_id: str
+    trigger_type: str
+    trigger_detail: Dict[str, Any] = {}
+
+class DriftCheckIn(BaseModel):
+    facility_id: str
+
+class ScheduleInstanceIn(BaseModel):
+    facility_id: str
+    schedule_type: str
+    schedule_key: str
+    next_due_date: Optional[str] = None
+    schedule_activation_id: Optional[str] = None

--- a/schemas/runtime_evaluator.py
+++ b/schemas/runtime_evaluator.py
@@ -1,0 +1,23 @@
+"""Runtime Evaluator 스키마 v1.0.0"""
+from pydantic import BaseModel
+from typing import Optional, List, Dict, Any
+
+class EvaluationContextIn(BaseModel):
+    company_id: Optional[str] = None
+    facility_id: Optional[str] = None
+    industry_code: Optional[str] = None
+    worker_count: Optional[int] = None
+    hazardous_materials: List[str] = []
+    equipment: List[str] = []
+    pressure_vessels: List[str] = []
+    fire_facilities: List[str] = []
+    contractors: List[str] = []
+    process_types: List[str] = []
+    accident_occurred: bool = False
+    construction_started: bool = False
+    shutdown: bool = False
+    additional_inputs: Dict[str, Any] = {}
+    created_by: Optional[str] = None
+
+class EvaluateIn(BaseModel):
+    context_id: str

--- a/schemas/simulation.py
+++ b/schemas/simulation.py
@@ -1,0 +1,22 @@
+"""Simulation 스키마 v1.0.0"""
+from pydantic import BaseModel
+from typing import Optional, List, Dict, Any
+
+class ScenarioIn(BaseModel):
+    scenario_name: str
+    industry_code: Optional[str] = None
+    worker_count: Optional[int] = None
+    hazardous_materials: List[str] = []
+    pressure_vessels: List[str] = []
+    fire_facilities: List[str] = []
+    contractor_exists: bool = False
+    construction_started: bool = False
+    accident_occurred: bool = False
+    shutdown: bool = False
+    facility_types: List[str] = []
+    equipment: List[str] = []
+    additional_inputs: Dict[str, Any] = {}
+    created_by: Optional[str] = None
+
+class RunSimulationIn(BaseModel):
+    scenario_id: str

--- a/scripts/collect_document_forms.py
+++ b/scripts/collect_document_forms.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+collect_document_forms.py — document_forms 138건 ↔ CSV 1,015건 매칭 → HWP 다운로드
+
+1) all_bylaw_forms.csv (1,015건 서식 URL) 로드
+2) document_forms (has_legal_form=true, 138건) DB 조회
+3) 법령+서식명 정규화 매칭
+4) HWP 다운로드 → form-originals 버킷 업로드 → document_forms.file_url 업데이트
+
+실행:
+  cd ~/Desktop/tai-engineering/tai-api
+  railway run python3 scripts/collect_document_forms.py --dry-run
+  railway run python3 scripts/collect_document_forms.py
+"""
+import argparse, csv, os, re, sys, time, unicodedata
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+import requests
+from supabase import create_client
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = (
+    os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    or os.environ.get("SUPABASE_KEY")
+    or os.environ.get("SUPABASE_SERVICE_KEY")
+)
+if not SUPABASE_URL or not SUPABASE_KEY:
+    print("ERROR: railway run 으로 실행하세요.")
+    sys.exit(1)
+
+sb = create_client(SUPABASE_URL, SUPABASE_KEY)
+BUCKET = "form-originals"
+BASE_URL = "https://www.law.go.kr"
+DL_DIR = Path("./form_originals_hwp/doc_forms")
+CSV_PATH = Path("./form_originals_hwp/all_bylaw_forms.csv")
+HEADERS_SB = {"apikey": SUPABASE_KEY, "Authorization": f"Bearer {SUPABASE_KEY}"}
+
+# law_ref → CSV law_name 매핑
+LAW_REF_MAP = {
+    "산안법": "산업안전보건법 시행규칙",
+    "산업안전보건법": "산업안전보건법 시행규칙",
+    "안전보건규칙": "산업안전보건법 시행규칙",
+    "건설기술진흥법": "건설기술 진흥법 시행규칙",
+    "건설산업기본법": "건설산업기본법 시행규칙",
+    "고압가스안전관리법": "고압가스 안전관리법 시행규칙",
+    "위험물안전관리법": "위험물안전관리법 시행규칙",
+    "화학물질관리법": "화학물질관리법 시행규칙",
+    "화학물질등록평가법": "화학물질의 등록 및 평가 등에 관한 법률 시행규칙",
+    "에너지이용합리화법": "에너지이용 합리화법 시행규칙",
+    "소방시설법": "소방시설 설치 및 관리에 관한 법률 시행규칙",
+    "승강기안전관리법": "승강기 안전관리법 시행규칙",
+    "전기안전관리법": "전기안전관리법 시행규칙",
+    "석면안전관리법": "석면안전관리법 시행규칙",
+    "시설물안전법": "시설물의 안전 및 유지관리에 관한 특별법 시행규칙",
+    "중대재해처벌법": None,  # 서식 없음
+}
+
+
+def normalize(s: str) -> str:
+    """매칭용 정규화: 공백/특수문자 제거, 가운뎃점 통일"""
+    s = s.replace("·", "").replace("ㆍ", "").replace("•", "")
+    s = s.replace(" ", "").replace("\u3000", "")
+    s = re.sub(r'[(\[\{].*?[)\]\}]', '', s)  # 괄호 내용 제거
+    s = s.strip()
+    return s
+
+
+def extract_law_key(law_ref: str) -> str:
+    """law_ref에서 법령 키워드 추출"""
+    for key in LAW_REF_MAP:
+        if key in law_ref:
+            return key
+    return ""
+
+
+def load_csv(path: Path) -> list[dict]:
+    """all_bylaw_forms.csv 로드"""
+    forms = []
+    with open(path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("type") == "서식":  # 별표 제외
+                forms.append(row)
+    return forms
+
+
+def download_hwp(url: str, save_path: Path) -> bool:
+    try:
+        full_url = url if url.startswith("http") else BASE_URL + url
+        resp = requests.get(full_url, timeout=30, allow_redirects=True,
+                            headers={"User-Agent": "Mozilla/5.0 TAI-Bot"})
+        resp.raise_for_status()
+        size = len(resp.content)
+        if size < 512:
+            text = resp.content[:300].decode("utf-8", errors="ignore")
+            if "<html" in text.lower():
+                return False
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        save_path.write_bytes(resp.content)
+        print(f"      ✓ {size:,}b → {save_path.name}")
+        return True
+    except Exception as e:
+        print(f"      ✗ 다운로드 실패: {e}")
+        return False
+
+
+def upload_storage(local: Path, path: str) -> bool:
+    url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path}"
+    data = local.read_bytes()
+    resp = requests.post(url, headers={**HEADERS_SB, "Content-Type": "application/x-hwp",
+                                       "x-upsert": "true"}, data=data)
+    if resp.status_code in (200, 201):
+        return True
+    print(f"      ✗ 업로드 실패 ({resp.status_code})")
+    return False
+
+
+def find_best_match(doc_name: str, law_key: str, csv_forms: list[dict]) -> dict | None:
+    """document_forms의 doc_name과 CSV 서식명을 매칭"""
+    csv_law_name = LAW_REF_MAP.get(law_key)
+    if not csv_law_name:
+        return None
+
+    # 1차: 같은 법령의 서식만 필터
+    candidates = [f for f in csv_forms if csv_law_name in f.get("law_name", "")]
+    if not candidates:
+        return None
+
+    doc_norm = normalize(doc_name)
+
+    # 2차: 정규화 후 포함 관계 매칭
+    for c in candidates:
+        c_norm = normalize(c.get("title", ""))
+        if doc_norm and c_norm:
+            if doc_norm in c_norm or c_norm in doc_norm:
+                return c
+
+    # 3차: 핵심 키워드 매칭 (3글자 이상 연속 일치)
+    for c in candidates:
+        c_norm = normalize(c.get("title", ""))
+        # 긴 쪽에서 짧은 쪽 부분문자열 검사
+        short, long_ = sorted([doc_norm, c_norm], key=len)
+        if len(short) >= 3 and short in long_:
+            return c
+
+    # 4차: 공통 글자 비율
+    best = None
+    best_ratio = 0
+    for c in candidates:
+        c_norm = normalize(c.get("title", ""))
+        if not c_norm or not doc_norm:
+            continue
+        common = sum(1 for ch in doc_norm if ch in c_norm)
+        ratio = common / max(len(doc_norm), len(c_norm))
+        if ratio > best_ratio and ratio >= 0.6:
+            best_ratio = ratio
+            best = c
+
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args()
+
+    print("=" * 70)
+    print("  document_forms 법정서식 HWP 수집기")
+    print("=" * 70)
+
+    # 1. CSV 로드
+    if not CSV_PATH.exists():
+        print(f"ERROR: {CSV_PATH} 없음. collect_form_templates_v2.py --dry-run 먼저 실행.")
+        sys.exit(1)
+    csv_forms = load_csv(CSV_PATH)
+    print(f"\n  CSV 서식: {len(csv_forms)}건 (별표 제외)")
+
+    # 2. document_forms 조회
+    resp = sb.table("document_forms").select(
+        "id,doc_id,doc_name,law_ref,file_url,has_legal_form,category"
+    ).eq("has_legal_form", True).order("category").execute()
+    doc_forms = resp.data or []
+    print(f"  document_forms (has_legal_form=true): {len(doc_forms)}건")
+
+    # 이미 file_url 있는 것 필터
+    todo = [d for d in doc_forms if not d.get("file_url")]
+    skip = len(doc_forms) - len(todo)
+    if skip:
+        print(f"  이미 완료: {skip}건 스킵")
+    if args.limit:
+        todo = todo[:args.limit]
+    print(f"  처리 대상: {len(todo)}건\n")
+
+    # 3. 매칭 + 다운로드
+    stats = {"matched": 0, "unmatched": 0, "dl_ok": 0, "dl_fail": 0, "up_ok": 0}
+    unmatched_list = []
+
+    for i, doc in enumerate(todo, 1):
+        doc_id = doc["doc_id"]
+        doc_name = doc["doc_name"]
+        law_ref = doc["law_ref"]
+        law_key = extract_law_key(law_ref)
+
+        match = find_best_match(doc_name, law_key, csv_forms)
+
+        if match:
+            stats["matched"] += 1
+            title = match.get("title", "")[:50]
+            hwp_link = match.get("hwp_link", "")
+            fl_seq = match.get("fl_seq", "")
+            print(f"  [{i:3}/{len(todo)}] ✓ {doc_name[:35]:35} → {title}")
+
+            if args.dry_run:
+                continue
+
+            # 다운로드
+            local = DL_DIR / f"{doc_id}.hwp"
+            if not download_hwp(hwp_link, local):
+                stats["dl_fail"] += 1
+                continue
+            stats["dl_ok"] += 1
+
+            # 업로드
+            sp = f"doc_forms/{doc_id}.hwp"
+            if not upload_storage(local, sp):
+                continue
+            stats["up_ok"] += 1
+
+            # DB 업데이트
+            new_url = f"{BASE_URL}{hwp_link}"
+            sb.table("document_forms").update({
+                "file_url": new_url,
+            }).eq("id", doc["id"]).execute()
+
+            time.sleep(0.3)
+        else:
+            stats["unmatched"] += 1
+            unmatched_list.append((doc_id, doc_name, law_ref))
+            print(f"  [{i:3}/{len(todo)}] ✗ {doc_name[:35]:35} ({law_ref})")
+
+    # 4. 결과
+    print("\n" + "=" * 70)
+    print("  수집 결과")
+    print("=" * 70)
+    print(f"  매칭 성공: {stats['matched']}건")
+    print(f"  매칭 실패: {stats['unmatched']}건")
+    if not args.dry_run:
+        print(f"  다운로드: {stats['dl_ok']} 성공 / {stats['dl_fail']} 실패")
+        print(f"  업로드: {stats['up_ok']} 성공")
+
+    if unmatched_list:
+        print(f"\n  미매칭 목록 ({len(unmatched_list)}건):")
+        for did, dname, lref in unmatched_list:
+            print(f"    {did}: {dname} ({lref})")
+
+    # 5. 미매칭 CSV 저장
+    if unmatched_list:
+        um_path = DL_DIR / "unmatched_forms.csv"
+        um_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(um_path, "w", encoding="utf-8") as f:
+            f.write("doc_id,doc_name,law_ref\n")
+            for did, dname, lref in unmatched_list:
+                f.write(f'{did},"{dname}","{lref}"\n')
+        print(f"\n  미매칭 CSV: {um_path}")
+
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_form_templates.py
+++ b/scripts/collect_form_templates.py
@@ -1,0 +1,160 @@
+"""
+TAI 법정서식 HWP 수집기
+─────────────────────────
+1) form_templates 테이블에서 hwp_url 조회
+2) 법제처에서 HWP 파일 다운로드
+3) Supabase form-originals 버킷에 업로드
+4) form_templates.original_storage_path 업데이트
+
+실행 (tai-api 폴더에서):
+  railway run python3 scripts/collect_form_templates.py --dry-run   # 다운로드만 테스트
+  railway run python3 scripts/collect_form_templates.py             # 실제 실행
+"""
+
+import os
+import sys
+import time
+import requests
+from pathlib import Path
+
+# ─── 설정 (Railway 환경변수 자동 주입) ───
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY")
+BUCKET = "form-originals"
+DOWNLOAD_DIR = Path("./form_originals_hwp")
+DRY_RUN = "--dry-run" in sys.argv
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    if not DRY_RUN:
+        print("ERROR: Railway 환경변수가 없습니다.")
+        print("  railway run python3 scripts/collect_form_templates.py")
+        sys.exit(1)
+
+HEADERS_SB = {
+    "apikey": SUPABASE_KEY or "",
+    "Authorization": f"Bearer {SUPABASE_KEY or ''}",
+}
+
+HEADERS_DL = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) TAI-Collector/1.0",
+    "Accept": "application/octet-stream, */*",
+}
+
+
+def fetch_form_templates():
+    url = f"{SUPABASE_URL}/rest/v1/form_templates"
+    params = {
+        "select": "id,form_code,form_name,hwp_url,original_storage_path",
+        "hwp_url": "not.is.null",
+        "order": "form_code.asc",
+    }
+    resp = requests.get(url, headers={**HEADERS_SB, "Prefer": "return=representation"}, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def download_hwp(hwp_url, save_path):
+    try:
+        resp = requests.get(hwp_url, headers=HEADERS_DL, timeout=30, allow_redirects=True)
+        resp.raise_for_status()
+        size = len(resp.content)
+        if size < 1024:
+            try:
+                text = resp.content[:200].decode("utf-8", errors="ignore")
+                if "<html" in text.lower():
+                    print(f"    ✗ HTML 응답 — HWP 아님. 스킵.")
+                    return False
+            except Exception:
+                pass
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        save_path.write_bytes(resp.content)
+        print(f"    ✓ 다운로드: {size:,} bytes → {save_path.name}")
+        return True
+    except requests.RequestException as e:
+        print(f"    ✗ 다운로드 실패: {e}")
+        return False
+
+
+def upload_to_storage(local_path, storage_path):
+    url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{storage_path}"
+    with open(local_path, "rb") as f:
+        data = f.read()
+    resp = requests.post(url, headers={**HEADERS_SB, "Content-Type": "application/x-hwp", "x-upsert": "true"}, data=data)
+    if resp.status_code in (200, 201):
+        print(f"    ✓ 업로드: {BUCKET}/{storage_path}")
+        return True
+    print(f"    ✗ 업로드 실패 ({resp.status_code}): {resp.text[:200]}")
+    return False
+
+
+def update_db(record_id, storage_path):
+    url = f"{SUPABASE_URL}/rest/v1/form_templates"
+    resp = requests.patch(
+        url, params={"id": f"eq.{record_id}"},
+        headers={**HEADERS_SB, "Content-Type": "application/json", "Prefer": "return=minimal"},
+        json={"original_storage_path": storage_path},
+    )
+    if resp.status_code in (200, 204):
+        print(f"    ✓ DB: original_storage_path = {storage_path}")
+        return True
+    print(f"    ✗ DB 실패 ({resp.status_code}): {resp.text[:200]}")
+    return False
+
+
+def main():
+    print("=" * 60)
+    print("  TAI 법정서식 HWP 수집기")
+    print("=" * 60)
+    if DRY_RUN:
+        print("  [DRY RUN] 다운로드만, 업로드/DB 안 함\n")
+    else:
+        print(f"  버킷: {BUCKET} | Supabase: {SUPABASE_URL}\n")
+
+    print("[1/4] form_templates 조회...")
+    templates = fetch_form_templates()
+    print(f"  → {len(templates)}건\n")
+
+    todo = [t for t in templates if not t.get("original_storage_path")]
+    skip = len(templates) - len(todo)
+    if skip:
+        print(f"  ℹ 이미 완료: {skip}건 스킵")
+    print(f"  → 처리 대상: {len(todo)}건\n")
+
+    s = {"dl_ok": 0, "dl_fail": 0, "up_ok": 0, "up_fail": 0, "db_ok": 0, "db_fail": 0}
+
+    for i, t in enumerate(todo, 1):
+        fc, fn, url, rid = t["form_code"], t["form_name"], t["hwp_url"], t["id"]
+        print(f"[{i}/{len(todo)}] {fc}: {fn}")
+
+        local = DOWNLOAD_DIR / f"{fc}.hwp"
+        if not download_hwp(url, local):
+            s["dl_fail"] += 1; print(); continue
+        s["dl_ok"] += 1
+
+        if DRY_RUN:
+            print("    [DRY RUN] 스킵\n"); continue
+
+        sp = f"{fc}/{fc}.hwp"
+        if not upload_to_storage(local, sp):
+            s["up_fail"] += 1; print(); continue
+        s["up_ok"] += 1
+
+        if update_db(rid, sp):
+            s["db_ok"] += 1
+        else:
+            s["db_fail"] += 1
+
+        time.sleep(1)
+        print()
+
+    print("=" * 60)
+    print(f"  다운로드: {s['dl_ok']} 성공 / {s['dl_fail']} 실패")
+    if not DRY_RUN:
+        print(f"  업로드:   {s['up_ok']} 성공 / {s['up_fail']} 실패")
+        print(f"  DB:       {s['db_ok']} 성공 / {s['db_fail']} 실패")
+    print(f"  로컬:     {DOWNLOAD_DIR}/")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_form_templates_v2.py
+++ b/scripts/collect_form_templates_v2.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
 """
-collect_form_templates_v2.py — 법제처 오픈API로 별지서식 HWP 자동 수집
+collect_form_templates_v2.py — DB raw_xml에서 별지서식 flSeq 추출 → HWP 다운로드
 
-법제처 DRF API의 '별표서식' 엔드포인트로 최신 bylSeq를 동적 조회한 뒤
-HWP 다운로드 → Supabase form-originals 버킷 업로드 → DB 업데이트.
-
-bylSeq가 법령 개정마다 변경되므로 하드코딩 URL 대신 API 동적 조회 사용.
+law_content_raw.raw_xml에 이미 최신 법령 XML이 저장되어 있고,
+그 안에 <별표단위> 블록의 <별표서식파일링크>/LSW/flDownload.do?flSeq=... 가 포함됨.
+외부 API 호출 없이 DB에서 직접 추출.
 
 실행:
   cd ~/Desktop/tai-engineering/tai-api
   railway run python3 scripts/collect_form_templates_v2.py --dry-run
   railway run python3 scripts/collect_form_templates_v2.py
 """
-import argparse, os, re, sys, time, xml.etree.ElementTree as ET
+import argparse, os, re, sys, time
 from pathlib import Path
 
 try:
@@ -24,15 +23,12 @@ except ImportError:
 import requests
 from supabase import create_client
 
-# ── env ──
 SUPABASE_URL = os.environ.get("SUPABASE_URL")
 SUPABASE_KEY = (
     os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     or os.environ.get("SUPABASE_KEY")
     or os.environ.get("SUPABASE_SERVICE_KEY")
 )
-LAW_OC = os.environ.get("LAW_API_OC", "taieng")
-
 if not SUPABASE_URL or not SUPABASE_KEY:
     print("ERROR: SUPABASE_URL / SUPABASE_KEY 필요. railway run 으로 실행하세요.")
     sys.exit(1)
@@ -41,8 +37,9 @@ sb = create_client(SUPABASE_URL, SUPABASE_KEY)
 BUCKET = "form-originals"
 DL_DIR = Path("./form_originals_hwp")
 HEADERS_SB = {"apikey": SUPABASE_KEY, "Authorization": f"Bearer {SUPABASE_KEY}"}
+BASE_URL = "https://www.law.go.kr"
 
-# ── 대상 시행규칙 MST (law_master에서 조회한 값) ──
+# 대상 시행규칙 MST
 RULE_MST = {
     "산업안전보건법 시행규칙": "271485",
     "건설기술 진흥법 시행규칙": "279455",
@@ -61,44 +58,69 @@ RULE_MST = {
 }
 
 
-def fetch_bylaw_forms(mst: str) -> list[dict]:
-    """법제처 DRF API로 해당 법령의 별표서식 목록 조회 (bylSeq 포함)"""
-    url = "http://www.law.go.kr/DRF/lawService.do"
-    params = {"OC": LAW_OC, "target": "bylSc", "MST": mst, "type": "XML"}
-    try:
-        resp = requests.get(url, params=params, timeout=30)
-        resp.raise_for_status()
-    except Exception as e:
-        print(f"    API 오류: {e}")
-        return []
-
+def extract_forms_from_xml(raw_xml: str) -> list[dict]:
+    """raw_xml에서 별표단위 블록을 파싱해 서식 정보 추출"""
     forms = []
-    try:
-        root = ET.fromstring(resp.content)
-        for item in root.iter("bylSc"):  # 또는 root.findall(".//bylSc")
-            seq = (item.findtext("bylSeq") or "").strip()
-            name = (item.findtext("bylNm") or item.findtext("서식명") or "").strip()
-            btype = (item.findtext("bylType") or item.findtext("구분") or "").strip()
-            if seq:
-                forms.append({"bylSeq": seq, "name": name, "type": btype})
-    except ET.ParseError:
-        # XML이 아닐 수 있음 — HTML 에러 페이지 등
-        print(f"    XML 파싱 실패. 응답 시작: {resp.text[:200]}")
+    # 별표단위 블록 추출 (CDATA 포함 가능하므로 non-greedy 대신 태그 기반)
+    blocks = re.split(r'<별표단위\s', raw_xml)
+    
+    for block in blocks[1:]:  # 첫 번째는 별표단위 앞 텍스트
+        # 별표구분 (별표 or 서식)
+        m_type = re.search(r'<별표구분>([^<\s]+)', block)
+        form_type = m_type.group(1).strip() if m_type else ""
+        
+        # 별표번호
+        m_no = re.search(r'<별표번호>(\d+)', block)
+        form_no = m_no.group(1) if m_no else ""
+        
+        # 별표가지번호
+        m_sub = re.search(r'<별표가지번호>(\d+)', block)
+        form_sub = m_sub.group(1) if m_sub else "00"
+        
+        # 별표제목 (CDATA 포함 가능)
+        m_title = re.search(r'<별표제목>\s*(?:<!\[CDATA\[(.+?)\]\]>|([^<]*))', block, re.DOTALL)
+        form_title = ""
+        if m_title:
+            form_title = (m_title.group(1) or m_title.group(2) or "").strip()
+        
+        # HWP 링크
+        m_hwp = re.search(r'<별표서식파일링크>\s*([^<\s]+)', block)
+        hwp_link = m_hwp.group(1).strip() if m_hwp else ""
+        
+        # PDF 링크
+        m_pdf = re.search(r'<별표서식PDF파일링크>\s*([^<\s]+)', block)
+        pdf_link = m_pdf.group(1).strip() if m_pdf else ""
+        
+        # flSeq 추출
+        fl_seq = ""
+        if hwp_link:
+            m_seq = re.search(r'flSeq=(\d+)', hwp_link)
+            fl_seq = m_seq.group(1) if m_seq else ""
+        
+        forms.append({
+            "type": form_type,
+            "no": form_no,
+            "sub": form_sub,
+            "title": form_title[:200],
+            "hwp_link": hwp_link,
+            "pdf_link": pdf_link,
+            "fl_seq": fl_seq,
+        })
+    
     return forms
 
 
-def download_hwp(bylseq: str, save_path: Path) -> bool:
-    """bylSeq로 HWP 다운로드"""
-    url = f"https://www.law.go.kr/LSW/bylFileP.do?bylSeq={bylseq}&fileType=hwp"
+def download_hwp(url: str, save_path: Path) -> bool:
     try:
-        resp = requests.get(url, timeout=30, allow_redirects=True,
+        full_url = url if url.startswith("http") else BASE_URL + url
+        resp = requests.get(full_url, timeout=30, allow_redirects=True,
                             headers={"User-Agent": "Mozilla/5.0 TAI-Bot"})
         resp.raise_for_status()
         size = len(resp.content)
         if size < 512:
             text = resp.content[:300].decode("utf-8", errors="ignore")
-            if "<html" in text.lower() or "에러" in text:
-                print(f"    ✗ HTML 에러 응답 ({size}b). 스킵.")
+            if "<html" in text.lower():
+                print(f"    ✗ HTML 에러 ({size}b)")
                 return False
         save_path.parent.mkdir(parents=True, exist_ok=True)
         save_path.write_bytes(resp.content)
@@ -110,7 +132,6 @@ def download_hwp(bylseq: str, save_path: Path) -> bool:
 
 
 def upload_storage(local: Path, path: str) -> bool:
-    """Supabase Storage 업로드"""
     url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path}"
     data = local.read_bytes()
     resp = requests.post(url, headers={**HEADERS_SB, "Content-Type": "application/x-hwp",
@@ -122,130 +143,137 @@ def upload_storage(local: Path, path: str) -> bool:
     return False
 
 
-def update_form_templates(bylseq_old: str, bylseq_new: str, storage_path: str):
-    """form_templates 테이블의 bylseq, hwp_url, original_storage_path 업데이트"""
-    new_url = f"https://www.law.go.kr/LSW/bylFileP.do?bylSeq={bylseq_new}&fileType=hwp"
-    sb.table("form_templates").update({
-        "bylseq": bylseq_new,
-        "hwp_url": new_url,
-        "original_storage_path": storage_path,
-    }).eq("bylseq", bylseq_old).execute()
-
-
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--dry-run", action="store_true", help="API 조회만, 다운로드 안 함")
-    ap.add_argument("--law", type=str, default=None, help="특정 법령만 (예: 산업안전보건법)")
-    ap.add_argument("--all-forms", action="store_true", help="form_templates 11건 외에 전체 서식도 수집")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--law", type=str, default=None, help="특정 법령만")
     args = ap.parse_args()
 
     print("=" * 70)
-    print("  법정서식 HWP 수집기 v2 (법제처 DRF API 동적 조회)")
+    print("  법정서식 HWP 수집기 v2 (DB raw_xml 파싱)")
     print("=" * 70)
 
-    # 1. form_templates의 기존 bylSeq 로드 (매칭용)
-    ft_resp = sb.table("form_templates").select("form_code,form_name,bylseq,original_storage_path").execute()
-    ft_map = {r["bylseq"]: r for r in (ft_resp.data or []) if r.get("bylseq")}
-    print(f"\n  form_templates: {len(ft_map)}건 (기존 bylSeq 매칭 대상)")
+    # 1. form_templates 로드
+    ft_resp = sb.table("form_templates").select("*").execute()
+    ft_list = ft_resp.data or []
+    print(f"\n  form_templates: {len(ft_list)}건")
 
-    stats = {"api_ok": 0, "api_fail": 0, "forms_found": 0, "matched": 0,
-             "dl_ok": 0, "dl_fail": 0, "up_ok": 0, "skip": 0}
+    stats = {"laws": 0, "forms_total": 0, "forms_sik": 0, "matched": 0,
+             "dl_ok": 0, "dl_fail": 0, "up_ok": 0}
 
-    # 2. 법령별 API 조회
-    targets = RULE_MST.items()
-    if args.law:
-        targets = [(k, v) for k, v in RULE_MST.items() if args.law in k]
+    all_forms = []  # 전체 서식 CSV용
 
-    all_forms = []  # (법령명, bylSeq, 서식명, type) 수집
-
-    for law_name, mst in targets:
-        print(f"\n[{law_name}] MST={mst}")
-        forms = fetch_bylaw_forms(mst)
-        if not forms:
-            stats["api_fail"] += 1
+    # 2. 법령별 raw_xml에서 서식 추출
+    for law_name, mst in RULE_MST.items():
+        if args.law and args.law not in law_name:
             continue
-        stats["api_ok"] += 1
 
-        # 서식만 필터 (별표 제외, 또는 전부 포함)
-        form_items = [f for f in forms if "서식" in f.get("type", "") or "서식" in f.get("name", "")]
-        if not form_items:
-            form_items = forms  # 서식 구분 안 되면 전체
+        # DB에서 raw_xml 조회
+        result = sb.rpc("", {}).execute()  # dummy - use SQL instead
+        # PostgREST로 raw_xml 가져오기
+        lm = sb.table("law_master").select("id,current_version_id").eq("law_mst_no", mst).limit(1).execute()
+        if not lm.data:
+            print(f"\n[{law_name}] law_master에 없음. 스킵.")
+            continue
+        
+        vid = lm.data[0]["current_version_id"]
+        if not vid:
+            print(f"\n[{law_name}] current_version_id 없음. 스킵.")
+            continue
+        
+        raw = sb.table("law_content_raw").select("raw_xml").eq("law_version_id", vid).limit(1).execute()
+        if not raw.data or not raw.data[0].get("raw_xml"):
+            print(f"\n[{law_name}] raw_xml 없음. 스킵.")
+            continue
 
-        stats["forms_found"] += len(form_items)
-        print(f"  → 서식 {len(form_items)}건 발견")
+        raw_xml = raw.data[0]["raw_xml"]
+        forms = extract_forms_from_xml(raw_xml)
+        stats["laws"] += 1
+        stats["forms_total"] += len(forms)
+        
+        sik_forms = [f for f in forms if f["type"] == "서식"]
+        byul_forms = [f for f in forms if f["type"] == "별표"]
+        stats["forms_sik"] += len(sik_forms)
+        
+        print(f"\n[{law_name}] 별표 {len(byul_forms)}건 + 서식 {len(sik_forms)}건 = {len(forms)}건")
+        
+        for f in forms:
+            all_forms.append({
+                "law_name": law_name,
+                "mst": mst,
+                **f,
+            })
 
-        for f in form_items:
-            seq = f["bylSeq"]
-            name = f["name"]
-            ftype = f.get("type", "")
-            all_forms.append((law_name, seq, name, ftype))
-
-            # form_templates 매칭 체크 (서식명 유사도)
-            matched_ft = None
-            for old_seq, ft in ft_map.items():
-                # 이름 부분 매칭
+        # 서식만 출력
+        for f in sik_forms:
+            no_str = f"제{int(f['no'])}호" if f["no"] else ""
+            sub_str = f"의{int(f['sub'])}" if f["sub"] and f["sub"] != "00" else ""
+            title = f["title"] or "(제목없음)"
+            print(f"  서식 {no_str}{sub_str}: {title}")
+            print(f"    HWP: {f['hwp_link']}")
+            
+            # form_templates 매칭 시도
+            for ft in ft_list:
                 ft_name = ft.get("form_name", "")
-                if ft_name and (ft_name in name or name in ft_name):
-                    matched_ft = ft
+                if ft_name and (ft_name in title or title in ft_name):
+                    fc = ft["form_code"]
+                    print(f"    ★ 매칭: → {fc}")
+                    stats["matched"] += 1
+                    
+                    if args.dry_run:
+                        continue
+                    
+                    if ft.get("original_storage_path"):
+                        print(f"    이미 완료. 스킵.")
+                        continue
+                    
+                    # 다운로드
+                    local = DL_DIR / f"{fc}.hwp"
+                    if not download_hwp(f["hwp_link"], local):
+                        stats["dl_fail"] += 1
+                        continue
+                    stats["dl_ok"] += 1
+                    
+                    # 업로드
+                    sp = f"{fc}/{fc}.hwp"
+                    if not upload_storage(local, sp):
+                        continue
+                    stats["up_ok"] += 1
+                    
+                    # DB 업데이트
+                    new_url = f"{BASE_URL}{f['hwp_link']}"
+                    sb.table("form_templates").update({
+                        "hwp_url": new_url,
+                        "original_storage_path": sp,
+                    }).eq("id", ft["id"]).execute()
+                    print(f"    ✓ DB 업데이트")
                     break
 
-            if matched_ft:
-                stats["matched"] += 1
-                old_seq = matched_ft["bylseq"]
-                fc = matched_ft["form_code"]
-                print(f"  ★ 매칭: {name} → {fc} (old={old_seq} → new={seq})")
+        time.sleep(0.3)
 
-                if args.dry_run:
-                    continue
-
-                if matched_ft.get("original_storage_path"):
-                    print(f"    이미 업로드됨. 스킵.")
-                    stats["skip"] += 1
-                    continue
-
-                # 다운로드
-                local = DL_DIR / f"{fc}.hwp"
-                if not download_hwp(seq, local):
-                    stats["dl_fail"] += 1
-                    continue
-                stats["dl_ok"] += 1
-
-                # 업로드
-                sp = f"{fc}/{fc}.hwp"
-                if not upload_storage(local, sp):
-                    continue
-                stats["up_ok"] += 1
-
-                # DB 업데이트
-                update_form_templates(old_seq, seq, sp)
-                print(f"    ✓ DB 업데이트 완료")
-            else:
-                if args.all_forms:
-                    print(f"  ○ 미매칭 서식: [{ftype}] {name} (bylSeq={seq})")
-
-        time.sleep(0.5)  # API 부하 방지
-
-    # 3. 결과 출력
-    print("\n" + "=" * 70)
-    print("  수집 결과")
-    print("=" * 70)
-    print(f"  API 조회: {stats['api_ok']} 성공 / {stats['api_fail']} 실패")
-    print(f"  서식 발견: {stats['forms_found']}건")
-    print(f"  form_templates 매칭: {stats['matched']}건 / {len(ft_map)}건")
-    if not args.dry_run:
-        print(f"  다운로드: {stats['dl_ok']} 성공 / {stats['dl_fail']} 실패")
-        print(f"  업로드: {stats['up_ok']} 성공")
-        print(f"  스킵(이미완료): {stats['skip']}건")
-
-    # 4. 전체 서식 목록 CSV 저장 (다른 260건 매핑용)
+    # 3. CSV 저장
     csv_path = DL_DIR / "all_bylaw_forms.csv"
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with open(csv_path, "w", encoding="utf-8") as cf:
-        cf.write("law_name,bylSeq,form_name,form_type\n")
-        for law, seq, name, ftype in all_forms:
-            cf.write(f'"{law}",{seq},"{name}","{ftype}"\n')
-    print(f"\n  전체 서식 목록 CSV: {csv_path} ({len(all_forms)}건)")
-    print("  → 이 CSV로 document_forms 260건과 매칭 가능")
+        cf.write("law_name,mst,type,no,sub,title,hwp_link,pdf_link,fl_seq\n")
+        for f in all_forms:
+            title = f.get("title", "").replace('"', "'")
+            law = f.get("law_name", "").replace('"', "'")
+            cf.write(f'"{law}",{f["mst"]},{f["type"]},{f["no"]},{f["sub"]},')
+            cf.write(f'"{title}",{f.get("hwp_link","")},{f.get("pdf_link","")},{f.get("fl_seq","")}\n')
+
+    # 4. 결과
+    print("\n" + "=" * 70)
+    print("  수집 결과")
+    print("=" * 70)
+    print(f"  법령 처리: {stats['laws']}건")
+    print(f"  전체 별표+서식: {stats['forms_total']}건")
+    print(f"  서식만: {stats['forms_sik']}건")
+    print(f"  form_templates 매칭: {stats['matched']}건 / {len(ft_list)}건")
+    if not args.dry_run:
+        print(f"  다운로드: {stats['dl_ok']} 성공 / {stats['dl_fail']} 실패")
+        print(f"  업로드: {stats['up_ok']} 성공")
+    print(f"\n  전체 서식 CSV: {csv_path} ({len(all_forms)}건)")
     print("=" * 70)
 
 

--- a/scripts/collect_form_templates_v2.py
+++ b/scripts/collect_form_templates_v2.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+collect_form_templates_v2.py — 법제처 오픈API로 별지서식 HWP 자동 수집
+
+법제처 DRF API의 '별표서식' 엔드포인트로 최신 bylSeq를 동적 조회한 뒤
+HWP 다운로드 → Supabase form-originals 버킷 업로드 → DB 업데이트.
+
+bylSeq가 법령 개정마다 변경되므로 하드코딩 URL 대신 API 동적 조회 사용.
+
+실행:
+  cd ~/Desktop/tai-engineering/tai-api
+  railway run python3 scripts/collect_form_templates_v2.py --dry-run
+  railway run python3 scripts/collect_form_templates_v2.py
+"""
+import argparse, os, re, sys, time, xml.etree.ElementTree as ET
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+import requests
+from supabase import create_client
+
+# ── env ──
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = (
+    os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    or os.environ.get("SUPABASE_KEY")
+    or os.environ.get("SUPABASE_SERVICE_KEY")
+)
+LAW_OC = os.environ.get("LAW_API_OC", "taieng")
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    print("ERROR: SUPABASE_URL / SUPABASE_KEY 필요. railway run 으로 실행하세요.")
+    sys.exit(1)
+
+sb = create_client(SUPABASE_URL, SUPABASE_KEY)
+BUCKET = "form-originals"
+DL_DIR = Path("./form_originals_hwp")
+HEADERS_SB = {"apikey": SUPABASE_KEY, "Authorization": f"Bearer {SUPABASE_KEY}"}
+
+# ── 대상 시행규칙 MST (law_master에서 조회한 값) ──
+RULE_MST = {
+    "산업안전보건법 시행규칙": "271485",
+    "건설기술 진흥법 시행규칙": "279455",
+    "건설산업기본법 시행규칙": "282375",
+    "고압가스 안전관리법 시행규칙": "278693",
+    "위험물안전관리법 시행규칙": "262765",
+    "화학물질관리법 시행규칙": "279031",
+    "화학물질의 등록 및 평가 등에 관한 법률 시행규칙": "282061",
+    "에너지이용 합리화법 시행규칙": "278965",
+    "소방시설 설치 및 관리에 관한 법률 시행규칙": "280195",
+    "승강기 안전관리법 시행규칙": "268955",
+    "전기안전관리법 시행규칙": "279943",
+    "석면안전관리법 시행규칙": "278931",
+    "시설물의 안전 및 유지관리에 관한 특별법 시행규칙": "282381",
+    "소방시설공사업법 시행규칙": "282735",
+}
+
+
+def fetch_bylaw_forms(mst: str) -> list[dict]:
+    """법제처 DRF API로 해당 법령의 별표서식 목록 조회 (bylSeq 포함)"""
+    url = "http://www.law.go.kr/DRF/lawService.do"
+    params = {"OC": LAW_OC, "target": "bylSc", "MST": mst, "type": "XML"}
+    try:
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+    except Exception as e:
+        print(f"    API 오류: {e}")
+        return []
+
+    forms = []
+    try:
+        root = ET.fromstring(resp.content)
+        for item in root.iter("bylSc"):  # 또는 root.findall(".//bylSc")
+            seq = (item.findtext("bylSeq") or "").strip()
+            name = (item.findtext("bylNm") or item.findtext("서식명") or "").strip()
+            btype = (item.findtext("bylType") or item.findtext("구분") or "").strip()
+            if seq:
+                forms.append({"bylSeq": seq, "name": name, "type": btype})
+    except ET.ParseError:
+        # XML이 아닐 수 있음 — HTML 에러 페이지 등
+        print(f"    XML 파싱 실패. 응답 시작: {resp.text[:200]}")
+    return forms
+
+
+def download_hwp(bylseq: str, save_path: Path) -> bool:
+    """bylSeq로 HWP 다운로드"""
+    url = f"https://www.law.go.kr/LSW/bylFileP.do?bylSeq={bylseq}&fileType=hwp"
+    try:
+        resp = requests.get(url, timeout=30, allow_redirects=True,
+                            headers={"User-Agent": "Mozilla/5.0 TAI-Bot"})
+        resp.raise_for_status()
+        size = len(resp.content)
+        if size < 512:
+            text = resp.content[:300].decode("utf-8", errors="ignore")
+            if "<html" in text.lower() or "에러" in text:
+                print(f"    ✗ HTML 에러 응답 ({size}b). 스킵.")
+                return False
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        save_path.write_bytes(resp.content)
+        print(f"    ✓ 다운로드: {size:,}b → {save_path.name}")
+        return True
+    except Exception as e:
+        print(f"    ✗ 다운로드 실패: {e}")
+        return False
+
+
+def upload_storage(local: Path, path: str) -> bool:
+    """Supabase Storage 업로드"""
+    url = f"{SUPABASE_URL}/storage/v1/object/{BUCKET}/{path}"
+    data = local.read_bytes()
+    resp = requests.post(url, headers={**HEADERS_SB, "Content-Type": "application/x-hwp",
+                                       "x-upsert": "true"}, data=data)
+    if resp.status_code in (200, 201):
+        print(f"    ✓ 업로드: {BUCKET}/{path}")
+        return True
+    print(f"    ✗ 업로드 실패 ({resp.status_code}): {resp.text[:150]}")
+    return False
+
+
+def update_form_templates(bylseq_old: str, bylseq_new: str, storage_path: str):
+    """form_templates 테이블의 bylseq, hwp_url, original_storage_path 업데이트"""
+    new_url = f"https://www.law.go.kr/LSW/bylFileP.do?bylSeq={bylseq_new}&fileType=hwp"
+    sb.table("form_templates").update({
+        "bylseq": bylseq_new,
+        "hwp_url": new_url,
+        "original_storage_path": storage_path,
+    }).eq("bylseq", bylseq_old).execute()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="API 조회만, 다운로드 안 함")
+    ap.add_argument("--law", type=str, default=None, help="특정 법령만 (예: 산업안전보건법)")
+    ap.add_argument("--all-forms", action="store_true", help="form_templates 11건 외에 전체 서식도 수집")
+    args = ap.parse_args()
+
+    print("=" * 70)
+    print("  법정서식 HWP 수집기 v2 (법제처 DRF API 동적 조회)")
+    print("=" * 70)
+
+    # 1. form_templates의 기존 bylSeq 로드 (매칭용)
+    ft_resp = sb.table("form_templates").select("form_code,form_name,bylseq,original_storage_path").execute()
+    ft_map = {r["bylseq"]: r for r in (ft_resp.data or []) if r.get("bylseq")}
+    print(f"\n  form_templates: {len(ft_map)}건 (기존 bylSeq 매칭 대상)")
+
+    stats = {"api_ok": 0, "api_fail": 0, "forms_found": 0, "matched": 0,
+             "dl_ok": 0, "dl_fail": 0, "up_ok": 0, "skip": 0}
+
+    # 2. 법령별 API 조회
+    targets = RULE_MST.items()
+    if args.law:
+        targets = [(k, v) for k, v in RULE_MST.items() if args.law in k]
+
+    all_forms = []  # (법령명, bylSeq, 서식명, type) 수집
+
+    for law_name, mst in targets:
+        print(f"\n[{law_name}] MST={mst}")
+        forms = fetch_bylaw_forms(mst)
+        if not forms:
+            stats["api_fail"] += 1
+            continue
+        stats["api_ok"] += 1
+
+        # 서식만 필터 (별표 제외, 또는 전부 포함)
+        form_items = [f for f in forms if "서식" in f.get("type", "") or "서식" in f.get("name", "")]
+        if not form_items:
+            form_items = forms  # 서식 구분 안 되면 전체
+
+        stats["forms_found"] += len(form_items)
+        print(f"  → 서식 {len(form_items)}건 발견")
+
+        for f in form_items:
+            seq = f["bylSeq"]
+            name = f["name"]
+            ftype = f.get("type", "")
+            all_forms.append((law_name, seq, name, ftype))
+
+            # form_templates 매칭 체크 (서식명 유사도)
+            matched_ft = None
+            for old_seq, ft in ft_map.items():
+                # 이름 부분 매칭
+                ft_name = ft.get("form_name", "")
+                if ft_name and (ft_name in name or name in ft_name):
+                    matched_ft = ft
+                    break
+
+            if matched_ft:
+                stats["matched"] += 1
+                old_seq = matched_ft["bylseq"]
+                fc = matched_ft["form_code"]
+                print(f"  ★ 매칭: {name} → {fc} (old={old_seq} → new={seq})")
+
+                if args.dry_run:
+                    continue
+
+                if matched_ft.get("original_storage_path"):
+                    print(f"    이미 업로드됨. 스킵.")
+                    stats["skip"] += 1
+                    continue
+
+                # 다운로드
+                local = DL_DIR / f"{fc}.hwp"
+                if not download_hwp(seq, local):
+                    stats["dl_fail"] += 1
+                    continue
+                stats["dl_ok"] += 1
+
+                # 업로드
+                sp = f"{fc}/{fc}.hwp"
+                if not upload_storage(local, sp):
+                    continue
+                stats["up_ok"] += 1
+
+                # DB 업데이트
+                update_form_templates(old_seq, seq, sp)
+                print(f"    ✓ DB 업데이트 완료")
+            else:
+                if args.all_forms:
+                    print(f"  ○ 미매칭 서식: [{ftype}] {name} (bylSeq={seq})")
+
+        time.sleep(0.5)  # API 부하 방지
+
+    # 3. 결과 출력
+    print("\n" + "=" * 70)
+    print("  수집 결과")
+    print("=" * 70)
+    print(f"  API 조회: {stats['api_ok']} 성공 / {stats['api_fail']} 실패")
+    print(f"  서식 발견: {stats['forms_found']}건")
+    print(f"  form_templates 매칭: {stats['matched']}건 / {len(ft_map)}건")
+    if not args.dry_run:
+        print(f"  다운로드: {stats['dl_ok']} 성공 / {stats['dl_fail']} 실패")
+        print(f"  업로드: {stats['up_ok']} 성공")
+        print(f"  스킵(이미완료): {stats['skip']}건")
+
+    # 4. 전체 서식 목록 CSV 저장 (다른 260건 매핑용)
+    csv_path = DL_DIR / "all_bylaw_forms.csv"
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(csv_path, "w", encoding="utf-8") as cf:
+        cf.write("law_name,bylSeq,form_name,form_type\n")
+        for law, seq, name, ftype in all_forms:
+            cf.write(f'"{law}",{seq},"{name}","{ftype}"\n')
+    print(f"\n  전체 서식 목록 CSV: {csv_path} ({len(all_forms)}건)")
+    print("  → 이 CSV로 document_forms 260건과 매칭 가능")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_form_templates_v2.py
+++ b/scripts/collect_form_templates_v2.py
@@ -39,7 +39,6 @@ DL_DIR = Path("./form_originals_hwp")
 HEADERS_SB = {"apikey": SUPABASE_KEY, "Authorization": f"Bearer {SUPABASE_KEY}"}
 BASE_URL = "https://www.law.go.kr"
 
-# 대상 시행규칙 MST
 RULE_MST = {
     "산업안전보건법 시행규칙": "271485",
     "건설기술 진흥법 시행규칙": "279455",
@@ -59,54 +58,32 @@ RULE_MST = {
 
 
 def extract_forms_from_xml(raw_xml: str) -> list[dict]:
-    """raw_xml에서 별표단위 블록을 파싱해 서식 정보 추출"""
     forms = []
-    # 별표단위 블록 추출 (CDATA 포함 가능하므로 non-greedy 대신 태그 기반)
     blocks = re.split(r'<별표단위\s', raw_xml)
-    
-    for block in blocks[1:]:  # 첫 번째는 별표단위 앞 텍스트
-        # 별표구분 (별표 or 서식)
+    for block in blocks[1:]:
         m_type = re.search(r'<별표구분>([^<\s]+)', block)
         form_type = m_type.group(1).strip() if m_type else ""
-        
-        # 별표번호
         m_no = re.search(r'<별표번호>(\d+)', block)
         form_no = m_no.group(1) if m_no else ""
-        
-        # 별표가지번호
         m_sub = re.search(r'<별표가지번호>(\d+)', block)
         form_sub = m_sub.group(1) if m_sub else "00"
-        
-        # 별표제목 (CDATA 포함 가능)
         m_title = re.search(r'<별표제목>\s*(?:<!\[CDATA\[(.+?)\]\]>|([^<]*))', block, re.DOTALL)
         form_title = ""
         if m_title:
             form_title = (m_title.group(1) or m_title.group(2) or "").strip()
-        
-        # HWP 링크
         m_hwp = re.search(r'<별표서식파일링크>\s*([^<\s]+)', block)
         hwp_link = m_hwp.group(1).strip() if m_hwp else ""
-        
-        # PDF 링크
         m_pdf = re.search(r'<별표서식PDF파일링크>\s*([^<\s]+)', block)
         pdf_link = m_pdf.group(1).strip() if m_pdf else ""
-        
-        # flSeq 추출
         fl_seq = ""
         if hwp_link:
             m_seq = re.search(r'flSeq=(\d+)', hwp_link)
             fl_seq = m_seq.group(1) if m_seq else ""
-        
         forms.append({
-            "type": form_type,
-            "no": form_no,
-            "sub": form_sub,
-            "title": form_title[:200],
-            "hwp_link": hwp_link,
-            "pdf_link": pdf_link,
-            "fl_seq": fl_seq,
+            "type": form_type, "no": form_no, "sub": form_sub,
+            "title": form_title[:200], "hwp_link": hwp_link,
+            "pdf_link": pdf_link, "fl_seq": fl_seq,
         })
-    
     return forms
 
 
@@ -153,34 +130,28 @@ def main():
     print("  법정서식 HWP 수집기 v2 (DB raw_xml 파싱)")
     print("=" * 70)
 
-    # 1. form_templates 로드
     ft_resp = sb.table("form_templates").select("*").execute()
     ft_list = ft_resp.data or []
     print(f"\n  form_templates: {len(ft_list)}건")
 
     stats = {"laws": 0, "forms_total": 0, "forms_sik": 0, "matched": 0,
              "dl_ok": 0, "dl_fail": 0, "up_ok": 0}
+    all_forms = []
 
-    all_forms = []  # 전체 서식 CSV용
-
-    # 2. 법령별 raw_xml에서 서식 추출
     for law_name, mst in RULE_MST.items():
         if args.law and args.law not in law_name:
             continue
 
-        # DB에서 raw_xml 조회
-        result = sb.rpc("", {}).execute()  # dummy - use SQL instead
-        # PostgREST로 raw_xml 가져오기
         lm = sb.table("law_master").select("id,current_version_id").eq("law_mst_no", mst).limit(1).execute()
         if not lm.data:
             print(f"\n[{law_name}] law_master에 없음. 스킵.")
             continue
-        
+
         vid = lm.data[0]["current_version_id"]
         if not vid:
             print(f"\n[{law_name}] current_version_id 없음. 스킵.")
             continue
-        
+
         raw = sb.table("law_content_raw").select("raw_xml").eq("law_version_id", vid).limit(1).execute()
         if not raw.data or not raw.data[0].get("raw_xml"):
             print(f"\n[{law_name}] raw_xml 없음. 스킵.")
@@ -190,57 +161,43 @@ def main():
         forms = extract_forms_from_xml(raw_xml)
         stats["laws"] += 1
         stats["forms_total"] += len(forms)
-        
+
         sik_forms = [f for f in forms if f["type"] == "서식"]
         byul_forms = [f for f in forms if f["type"] == "별표"]
         stats["forms_sik"] += len(sik_forms)
-        
-        print(f"\n[{law_name}] 별표 {len(byul_forms)}건 + 서식 {len(sik_forms)}건 = {len(forms)}건")
-        
-        for f in forms:
-            all_forms.append({
-                "law_name": law_name,
-                "mst": mst,
-                **f,
-            })
 
-        # 서식만 출력
+        print(f"\n[{law_name}] 별표 {len(byul_forms)}건 + 서식 {len(sik_forms)}건 = {len(forms)}건")
+
+        for f in forms:
+            all_forms.append({"law_name": law_name, "mst": mst, **f})
+
         for f in sik_forms:
             no_str = f"제{int(f['no'])}호" if f["no"] else ""
             sub_str = f"의{int(f['sub'])}" if f["sub"] and f["sub"] != "00" else ""
             title = f["title"] or "(제목없음)"
             print(f"  서식 {no_str}{sub_str}: {title}")
             print(f"    HWP: {f['hwp_link']}")
-            
-            # form_templates 매칭 시도
+
             for ft in ft_list:
                 ft_name = ft.get("form_name", "")
                 if ft_name and (ft_name in title or title in ft_name):
                     fc = ft["form_code"]
                     print(f"    ★ 매칭: → {fc}")
                     stats["matched"] += 1
-                    
                     if args.dry_run:
                         continue
-                    
                     if ft.get("original_storage_path"):
                         print(f"    이미 완료. 스킵.")
                         continue
-                    
-                    # 다운로드
                     local = DL_DIR / f"{fc}.hwp"
                     if not download_hwp(f["hwp_link"], local):
                         stats["dl_fail"] += 1
                         continue
                     stats["dl_ok"] += 1
-                    
-                    # 업로드
                     sp = f"{fc}/{fc}.hwp"
                     if not upload_storage(local, sp):
                         continue
                     stats["up_ok"] += 1
-                    
-                    # DB 업데이트
                     new_url = f"{BASE_URL}{f['hwp_link']}"
                     sb.table("form_templates").update({
                         "hwp_url": new_url,
@@ -251,7 +208,6 @@ def main():
 
         time.sleep(0.3)
 
-    # 3. CSV 저장
     csv_path = DL_DIR / "all_bylaw_forms.csv"
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with open(csv_path, "w", encoding="utf-8") as cf:
@@ -262,7 +218,6 @@ def main():
             cf.write(f'"{law}",{f["mst"]},{f["type"]},{f["no"]},{f["sub"]},')
             cf.write(f'"{title}",{f.get("hwp_link","")},{f.get("pdf_link","")},{f.get("fl_seq","")}\n')
 
-    # 4. 결과
     print("\n" + "=" * 70)
     print("  수집 결과")
     print("=" * 70)

--- a/scripts/document_schema_compiler.py
+++ b/scripts/document_schema_compiler.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""
+document_schema_compiler.py — TAI 오염 방지형 Document Schema Compiler
+
+작업지시서 16개 섹션 규칙에 따라 HWP 문서를 증거 기반으로 구조화.
+문서를 해석하지 않음. 문서에 실제 존재하는 구조만 추출.
+
+파이프라인: HWP → hwp5html → XHTML → 파싱 → Document Schema Candidate Package JSON
+
+실행:
+  cd ~/Desktop/tai-engineering/tai-api
+  railway run python3 scripts/document_schema_compiler.py --dry-run          # 1건 테스트
+  railway run python3 scripts/document_schema_compiler.py --limit 5          # 5건
+  railway run python3 scripts/document_schema_compiler.py                    # 전체
+"""
+import argparse, json, os, re, subprocess, sys, tempfile, shutil
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from html.parser import HTMLParser
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+import requests
+from supabase import create_client
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = (
+    os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+    or os.environ.get("SUPABASE_KEY")
+    or os.environ.get("SUPABASE_SERVICE_KEY")
+)
+if not SUPABASE_URL or not SUPABASE_KEY:
+    print("ERROR: railway run 으로 실행하세요.")
+    sys.exit(1)
+
+sb = create_client(SUPABASE_URL, SUPABASE_KEY)
+BUCKET_SRC = "form-originals"
+OUTPUT_DIR = Path("./form_originals_hwp/compiled")
+KST = timezone(timedelta(hours=9))
+
+
+# ══════════════════════════════════════════════════════
+# 섹션 1. HWP → XHTML 변환 (원본 보존)
+# ══════════════════════════════════════════════════════
+
+def hwp_to_xhtml(hwp_path: Path, output_dir: Path) -> Path | None:
+    """hwp5html로 XHTML 변환. 원본 HWP는 수정하지 않음."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["hwp5html", str(hwp_path), "--output", str(output_dir)],
+            capture_output=True, timeout=60, check=True,
+        )
+        xhtml = output_dir / "index.xhtml"
+        return xhtml if xhtml.exists() else None
+    except Exception as e:
+        print(f"    hwp5html 실패: {e}")
+        return None
+
+
+# ══════════════════════════════════════════════════════
+# 섹션 2. XHTML 파싱 → 문서 단위 분해
+# ══════════════════════════════════════════════════════
+
+class XHTMLTableExtractor(HTMLParser):
+    """XHTML에서 표 구조를 추출. 각 셀의 텍스트+위치를 수집."""
+
+    def __init__(self):
+        super().__init__()
+        self.tables = []       # [{rows: [[{text, rowspan, colspan}]]}]
+        self._in_table = False
+        self._in_td = False
+        self._in_p = False
+        self._current_table = None
+        self._current_row = None
+        self._current_cell = None
+        self._text_buf = []
+        self._table_idx = 0
+        self._row_idx = 0
+        self._col_idx = 0
+        # 표 밖 텍스트
+        self.paragraphs = []
+        self._para_buf = []
+        self._in_body = False
+
+    def handle_starttag(self, tag, attrs):
+        a = dict(attrs)
+        if tag == "body":
+            self._in_body = True
+        elif tag == "table":
+            self._in_table = True
+            self._table_idx += 1
+            self._current_table = {"table_idx": self._table_idx, "rows": []}
+            self._row_idx = 0
+        elif tag == "tr" and self._in_table:
+            self._row_idx += 1
+            self._col_idx = 0
+            self._current_row = []
+        elif tag == "td" and self._in_table:
+            self._in_td = True
+            self._col_idx += 1
+            self._current_cell = {
+                "row": self._row_idx,
+                "col": self._col_idx,
+                "rowspan": int(a.get("rowspan", 1)),
+                "colspan": int(a.get("colspan", 1)),
+                "text": "",
+            }
+            self._text_buf = []
+        elif tag == "p":
+            self._in_p = True
+            if not self._in_table:
+                self._para_buf = []
+
+    def handle_endtag(self, tag):
+        if tag == "td" and self._in_td:
+            self._in_td = False
+            if self._current_cell is not None:
+                self._current_cell["text"] = " ".join(self._text_buf).strip()
+                self._current_cell["text"] = re.sub(r'\s+', ' ', self._current_cell["text"])
+            if self._current_row is not None:
+                self._current_row.append(self._current_cell)
+            self._current_cell = None
+            self._text_buf = []
+        elif tag == "tr" and self._current_row is not None:
+            if self._current_table is not None:
+                self._current_table["rows"].append(self._current_row)
+            self._current_row = None
+        elif tag == "table" and self._in_table:
+            self._in_table = False
+            if self._current_table:
+                self.tables.append(self._current_table)
+            self._current_table = None
+        elif tag == "p":
+            self._in_p = False
+            if not self._in_table and self._para_buf:
+                text = " ".join(self._para_buf).strip()
+                if text:
+                    self.paragraphs.append(text)
+
+    def handle_data(self, data):
+        clean = data.replace("\r", "").replace("\n", " ").strip()
+        if not clean:
+            return
+        if self._in_td:
+            self._text_buf.append(clean)
+        elif self._in_p and not self._in_table:
+            self._para_buf.append(clean)
+
+
+def parse_xhtml(xhtml_path: Path) -> dict:
+    """XHTML 파싱 → 표 구조 + 문단 추출"""
+    text = xhtml_path.read_text(encoding="utf-8", errors="ignore")
+    parser = XHTMLTableExtractor()
+    parser.feed(text)
+    return {"tables": parser.tables, "paragraphs": parser.paragraphs}
+
+
+# ══════════════════════════════════════════════════════
+# 섹션 3~5. Field / Checklist / Evidence Candidate 생성
+# ══════════════════════════════════════════════════════
+
+# 필드 라벨 패턴 (문서에서 실제 발견되는 것만)
+FIELD_PATTERNS = [
+    (r'사업장명', 'site_name'),
+    (r'사업자\s*등록\s*번호', 'business_registration_no'),
+    (r'사업장\s*관리\s*번호', 'site_management_no'),
+    (r'근로자\s*수', 'worker_count'),
+    (r'점검일자|점검일|작성일', 'inspection_date'),
+    (r'점검자|작성자|검사자', 'inspector_name'),
+    (r'확인자', 'verifier_name'),
+    (r'서명|인', 'signature'),
+    (r'첨부사진|첨부파일|사진', 'attachment'),
+    (r'비고', 'remarks'),
+    (r'조치사항|개선사항', 'corrective_action'),
+    (r'점검결과|판정|결과', 'inspection_result'),
+    (r'제출처|귀하', 'submit_to'),
+    (r'보존기간', 'retention_period'),
+    (r'보고번호', 'report_no'),
+    (r'업종', 'industry_type'),
+    (r'소재지|주소', 'address'),
+    (r'전화번호|연락처', 'phone'),
+    (r'대표자', 'representative'),
+]
+
+EVIDENCE_KEYWORDS = ['사진', '첨부', '서명', '인', '확인자', '작성자', '보존기간', '제출처', '제출일', '보고번호']
+CHECKLIST_PATTERNS = [r'여부\s*확인', r'이상\s*없', r'점검\s*항목', r'확인\s*사항', r'체크']
+
+
+def extract_candidates(parsed: dict, doc_id: str) -> dict:
+    """파싱된 구조에서 후보 추출. 문서에 실제 존재하는 것만."""
+    fields = []
+    checklists = []
+    evidence = []
+    elements = []  # 전체 분해 요소
+    fc_seq = ec_seq = cc_seq = el_seq = 0
+
+    for table in parsed["tables"]:
+        tidx = table["table_idx"]
+        for row in table["rows"]:
+            for cell in row:
+                text = cell.get("text", "")
+                if not text:
+                    continue
+
+                el_seq += 1
+                elements.append({
+                    "element_id": f"EL-{el_seq:04d}",
+                    "element_type": "TABLE_CELL",
+                    "raw_text": text[:300],
+                    "source_location": {
+                        "table_idx": tidx,
+                        "row": cell["row"],
+                        "col": cell["col"],
+                        "rowspan": cell["rowspan"],
+                        "colspan": cell["colspan"],
+                    },
+                    "status": "EXTRACTED",
+                })
+
+                # 섹션 3: Field Candidate
+                for pattern, canonical in FIELD_PATTERNS:
+                    if re.search(pattern, text):
+                        fc_seq += 1
+                        fields.append({
+                            "field_candidate_id": f"FC-{fc_seq:03d}",
+                            "raw_label": text[:200],
+                            "canonical_field_candidate": canonical,
+                            "source_location": {
+                                "table_idx": tidx,
+                                "row": cell["row"],
+                                "col": cell["col"],
+                            },
+                            "status": "CANDIDATE",
+                        })
+                        break
+
+                # 섹션 5: Evidence Candidate
+                for kw in EVIDENCE_KEYWORDS:
+                    if kw in text:
+                        ec_seq += 1
+                        evidence.append({
+                            "evidence_field_candidate_id": f"EFC-{ec_seq:03d}",
+                            "raw_label": text[:200],
+                            "evidence_family": f"{kw.upper()}_EVIDENCE_FAMILY",
+                            "source_location": {
+                                "table_idx": tidx,
+                                "row": cell["row"],
+                                "col": cell["col"],
+                            },
+                            "status": "CANDIDATE",
+                        })
+                        break
+
+                # 섹션 4: Checklist Candidate
+                for cp in CHECKLIST_PATTERNS:
+                    if re.search(cp, text):
+                        cc_seq += 1
+                        checklists.append({
+                            "checklist_item_candidate_id": f"CIC-{cc_seq:03d}",
+                            "raw_text": text[:300],
+                            "source_location": {
+                                "table_idx": tidx,
+                                "row": cell["row"],
+                                "col": cell["col"],
+                            },
+                            "status": "CANDIDATE",
+                        })
+                        break
+
+    # 표 밖 문단에서도 추출
+    for i, para in enumerate(parsed["paragraphs"]):
+        el_seq += 1
+        elements.append({
+            "element_id": f"EL-{el_seq:04d}",
+            "element_type": "PARAGRAPH",
+            "raw_text": para[:300],
+            "source_location": {"paragraph_idx": i + 1},
+            "status": "EXTRACTED",
+        })
+
+    return {
+        "elements": elements,
+        "field_candidates": fields,
+        "checklist_item_candidates": checklists,
+        "evidence_field_candidates": evidence,
+    }
+
+
+# ══════════════════════════════════════════════════════
+# 섹션 6~16. 나머지 처리
+# ══════════════════════════════════════════════════════
+
+def build_package(doc_id: str, file_name: str, source_path: str,
+                  parsed: dict, candidates: dict) -> dict:
+    """Document Schema Candidate Package 조립"""
+    now = datetime.now(KST).isoformat()
+
+    # 섹션 6: Document Family 후보 (확정 아님)
+    doc_family = [{
+        "document_family_candidate_id": "DFC-001",
+        "candidate_family": "UNKNOWN_DOCUMENT_FAMILY",
+        "reason": "자동 확정 금지. Human Review 필요.",
+        "status": "CANDIDATE",
+    }]
+
+    # 섹션 7-8: 법령 매핑 없음 (자동 확정 금지)
+    doc_req_mapping = []
+
+    # 섹션 9: 회사 양식 매핑 없음 (확정 불가)
+    company_mapping = []
+
+    # 섹션 12: Residual
+    residuals = []
+    for el in candidates["elements"]:
+        text = el.get("raw_text", "")
+        # 필드도 체크도 증빙도 아닌 셀 → residual 아님 (단순 데이터)
+        # 병합셀 구조 불명확한 경우만 residual
+        loc = el.get("source_location", {})
+        if loc.get("rowspan", 1) > 3 or loc.get("colspan", 1) > 10:
+            residuals.append({
+                "document_residual_id": f"RES-{len(residuals)+1:03d}",
+                "raw_text": text[:200],
+                "reason": "COMPLEX_MERGED_CELL",
+                "source_location": loc,
+                "status": "NEEDS_HUMAN_REVIEW",
+            })
+
+    # 섹션 13: Human Review Queue
+    hrq = []
+    hrq.append({
+        "review_id": "HRQ-001",
+        "target_id": "DFC-001",
+        "review_type": "DOCUMENT_FAMILY_CONFIRMATION",
+        "description": "문서 유형 확정 필요",
+        "status": "PENDING",
+    })
+    for fc in candidates["field_candidates"]:
+        hrq.append({
+            "review_id": f"HRQ-FC-{fc['field_candidate_id']}",
+            "target_id": fc["field_candidate_id"],
+            "review_type": "CANONICAL_FIELD_CONFIRMATION",
+            "description": f"필드 '{fc['raw_label'][:50]}' canonical 확정 필요",
+            "status": "PENDING",
+        })
+
+    # 섹션 11: Validation
+    issues = []
+    for fc in candidates["field_candidates"]:
+        if not fc.get("source_location"):
+            issues.append(f"FAIL: {fc['field_candidate_id']} 위치 근거 없음")
+    if not candidates["field_candidates"]:
+        issues.append("WARN: 추출된 필드 후보 0건")
+
+    validation = {
+        "status": "PASS" if not any(i.startswith("FAIL") for i in issues) else "FAIL",
+        "issues": issues,
+    }
+
+    # 섹션 15: Final Output
+    return {
+        "_schema_version": "1.0.0",
+        "_compiler": "TAI Document Schema Compiler (오염 방지형)",
+        "_generated_at": now,
+
+        "document_id": doc_id,
+        "file_name": file_name,
+        "file_type": "HWP",
+        "source_path": source_path,
+        "original_text_preserved": True,
+
+        "document_metadata": {
+            "table_count": len(parsed["tables"]),
+            "paragraph_count": len(parsed["paragraphs"]),
+            "total_cells": sum(
+                len(cell)
+                for t in parsed["tables"]
+                for cell in t["rows"]
+            ),
+            "element_count": len(candidates["elements"]),
+        },
+
+        "document_family_candidates": doc_family,
+        "field_candidates": candidates["field_candidates"],
+        "checklist_item_candidates": candidates["checklist_item_candidates"],
+        "evidence_field_candidates": candidates["evidence_field_candidates"],
+        "document_requirement_mapping_candidates": doc_req_mapping,
+        "company_form_mapping_candidates": company_mapping,
+        "residuals": residuals,
+        "human_review_queue": hrq,
+        "validation": validation,
+    }
+
+
+# ══════════════════════════════════════════════════════
+# 메인: HWP 파일 처리 루프
+# ══════════════════════════════════════════════════════
+
+def process_one(hwp_path: Path, doc_id: str, source_path: str) -> dict | None:
+    """HWP 1건 처리 → Document Schema Candidate Package"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        xhtml_dir = Path(tmpdir) / "xhtml"
+        xhtml_path = hwp_to_xhtml(hwp_path, xhtml_dir)
+        if not xhtml_path:
+            return None
+
+        parsed = parse_xhtml(xhtml_path)
+        candidates = extract_candidates(parsed, doc_id)
+        package = build_package(
+            doc_id=doc_id,
+            file_name=hwp_path.name,
+            source_path=source_path,
+            parsed=parsed,
+            candidates=candidates,
+        )
+        return package
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="1건만 테스트")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--file", type=str, default=None, help="특정 HWP 파일 경로")
+    args = ap.parse_args()
+
+    print("=" * 70)
+    print("  TAI Document Schema Compiler (오염 방지형)")
+    print("  작업지시서 16개 섹션 규칙 적용")
+    print("=" * 70)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.file:
+        # 단일 파일 처리
+        hwp = Path(args.file)
+        if not hwp.exists():
+            print(f"ERROR: {hwp} 없음")
+            sys.exit(1)
+        print(f"\n  단일 파일: {hwp}")
+        pkg = process_one(hwp, hwp.stem, str(hwp))
+        if pkg:
+            out = OUTPUT_DIR / f"{hwp.stem}.json"
+            out.write_text(json.dumps(pkg, ensure_ascii=False, indent=2), encoding="utf-8")
+            print(f"  ✓ 출력: {out}")
+            print(f"    필드: {len(pkg['field_candidates'])}건")
+            print(f"    체크: {len(pkg['checklist_item_candidates'])}건")
+            print(f"    증빙: {len(pkg['evidence_field_candidates'])}건")
+            print(f"    요소: {pkg['document_metadata']['element_count']}건")
+        return
+
+    # form_templates + document_forms에서 HWP 목록 수집
+    hwp_files = []
+
+    # form_templates
+    ft = sb.table("form_templates").select("form_code,original_storage_path").not_.is_("original_storage_path", "null").execute()
+    for r in (ft.data or []):
+        local = Path(f"./form_originals_hwp/{r['form_code']}.hwp")
+        if local.exists():
+            hwp_files.append((local, r["form_code"], f"{BUCKET_SRC}/{r['original_storage_path']}"))
+
+    # document_forms
+    df = sb.table("document_forms").select("doc_id,file_url").not_.is_("file_url", "null").eq("has_legal_form", True).execute()
+    for r in (df.data or []):
+        local = Path(f"./form_originals_hwp/doc_forms/{r['doc_id']}.hwp")
+        if local.exists():
+            hwp_files.append((local, r["doc_id"], r.get("file_url", "")))
+
+    print(f"\n  로컬 HWP 파일: {len(hwp_files)}건")
+
+    if args.dry_run:
+        hwp_files = hwp_files[:1]
+        print("  [DRY RUN] 1건만 처리")
+    elif args.limit:
+        hwp_files = hwp_files[:args.limit]
+
+    print(f"  처리 대상: {len(hwp_files)}건\n")
+
+    stats = {"ok": 0, "fail": 0}
+
+    for i, (hwp_path, doc_id, src) in enumerate(hwp_files, 1):
+        print(f"  [{i:3}/{len(hwp_files)}] {doc_id}: {hwp_path.name}")
+        pkg = process_one(hwp_path, doc_id, src)
+        if pkg:
+            out = OUTPUT_DIR / f"{doc_id}.json"
+            out.write_text(json.dumps(pkg, ensure_ascii=False, indent=2), encoding="utf-8")
+            fc = len(pkg["field_candidates"])
+            cc = len(pkg["checklist_item_candidates"])
+            ec = len(pkg["evidence_field_candidates"])
+            el = pkg["document_metadata"]["element_count"]
+            print(f"    ✓ 필드={fc} 체크={cc} 증빙={ec} 요소={el}")
+            stats["ok"] += 1
+        else:
+            print(f"    ✗ 실패")
+            stats["fail"] += 1
+
+    print("\n" + "=" * 70)
+    print("  컴파일 결과")
+    print("=" * 70)
+    print(f"  성공: {stats['ok']}건")
+    print(f"  실패: {stats['fail']}건")
+    print(f"  출력: {OUTPUT_DIR}/")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/document_schema_compiler.py
+++ b/scripts/document_schema_compiler.py
@@ -21,7 +21,7 @@ try:
     from dotenv import load_dotenv; load_dotenv()
 except ImportError: pass
 
-SCRIPT_VERSION = "3.0.0"
+SCRIPT_VERSION = "3.1.0"
 KST = timezone(timedelta(hours=9))
 OUTPUT_DIR = Path("./form_originals_hwp/compiled")
 
@@ -255,8 +255,8 @@ def extract_all(parsed, doc_id, file_name, form_name, source_path):
                 elements.append({"element_id":f"EL-{el:04d}", "element_type":etype,
                     "raw_text":text[:500], "source_location":loc, "status":"EXTRACTED"})
 
-                # INSTRUCTION_TABLE에서는 필드 추출 스킵
-                if purpose == "INSTRUCTION_TABLE":
+                # 안내문 셀 자체만 스킵 (테이블 전체 스킵 금지)
+                if etype == "INSTRUCTION_TEXT" or etype == "DESCRIPTION_TEXT":
                     continue
 
                 # 번호 항목(①~⑳) → 무조건 필드 후보
@@ -267,14 +267,13 @@ def extract_all(parsed, doc_id, file_name, form_name, source_path):
                         "raw_label":text[:300], "canonical_field_candidate":canon,
                         "source_location":loc, "status":"CANDIDATE"})
 
-                # 일반 라벨 → 필드 후보
+                # 일반 라벨 → 무조건 필드 후보 (canonical은 보너스)
                 elif etype == "FIELD_LABEL":
-                    canon = find_canonical(text)
-                    if canon:
-                        fc += 1
-                        fields.append({"field_candidate_id":f"FC-{fc:03d}",
-                            "raw_label":text[:300], "canonical_field_candidate":canon,
-                            "source_location":loc, "status":"CANDIDATE"})
+                    fc += 1
+                    canon = find_canonical(text) or "unclassified_field"
+                    fields.append({"field_candidate_id":f"FC-{fc:03d}",
+                        "raw_label":text[:300], "canonical_field_candidate":canon,
+                        "source_location":loc, "status":"CANDIDATE"})
 
                 # 서명란, 날짜란, 비고란, 첨부란, 제출처 → 필드 + 증빙
                 elif etype in ("SIGNATURE_FIELD","DATE_FIELD","REMARKS_FIELD",

--- a/scripts/document_schema_compiler.py
+++ b/scripts/document_schema_compiler.py
@@ -1,510 +1,407 @@
 #!/usr/bin/env python3
 """
-document_schema_compiler.py — TAI 오염 방지형 Document Schema Compiler
+document_schema_compiler.py v2 — TAI 오염 방지형 Document Schema Compiler
 
-작업지시서 16개 섹션 규칙에 따라 HWP 문서를 증거 기반으로 구조화.
-문서를 해석하지 않음. 문서에 실제 존재하는 구조만 추출.
-
-파이프라인: HWP → hwp5html → XHTML → 파싱 → Document Schema Candidate Package JSON
+작업지시서 16개 섹션 전체 이행. 임의해석 금지, 증거 기반 추출, 목표 달성.
+HWP → hwp5html → XHTML → 파싱 → Document Schema Candidate Package JSON
 
 실행:
   cd ~/Desktop/tai-engineering/tai-api
-  railway run python3 scripts/document_schema_compiler.py --dry-run          # 1건 테스트
-  railway run python3 scripts/document_schema_compiler.py --limit 5          # 5건
-  railway run python3 scripts/document_schema_compiler.py                    # 전체
+  python3 scripts/document_schema_compiler.py --file form_originals_hwp/OSHACT-FORM-001.hwp
+  railway run python3 scripts/document_schema_compiler.py --dry-run
+  railway run python3 scripts/document_schema_compiler.py
 """
-import argparse, json, os, re, subprocess, sys, tempfile, shutil
-from datetime import datetime, timezone, timedelta
+import argparse,json,os,re,subprocess,sys,tempfile
+from datetime import datetime,timezone,timedelta
 from pathlib import Path
 from html.parser import HTMLParser
 
 try:
-    from dotenv import load_dotenv
-    load_dotenv()
-except ImportError:
-    pass
+    from dotenv import load_dotenv; load_dotenv()
+except ImportError: pass
 
-import requests
-from supabase import create_client
-
-SUPABASE_URL = os.environ.get("SUPABASE_URL")
-SUPABASE_KEY = (
-    os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
-    or os.environ.get("SUPABASE_KEY")
-    or os.environ.get("SUPABASE_SERVICE_KEY")
-)
-if not SUPABASE_URL or not SUPABASE_KEY:
-    print("ERROR: railway run 으로 실행하세요.")
-    sys.exit(1)
-
-sb = create_client(SUPABASE_URL, SUPABASE_KEY)
-BUCKET_SRC = "form-originals"
-OUTPUT_DIR = Path("./form_originals_hwp/compiled")
+SCRIPT_VERSION = "2.0.0"
 KST = timezone(timedelta(hours=9))
+OUTPUT_DIR = Path("./form_originals_hwp/compiled")
 
+# ═══ 섹션 1: HWP → XHTML 변환 (원본 보존) ═══
 
-# ══════════════════════════════════════════════════════
-# 섹션 1. HWP → XHTML 변환 (원본 보존)
-# ══════════════════════════════════════════════════════
-
-def hwp_to_xhtml(hwp_path: Path, output_dir: Path) -> Path | None:
-    """hwp5html로 XHTML 변환. 원본 HWP는 수정하지 않음."""
+def hwp_to_xhtml(hwp_path, output_dir):
     output_dir.mkdir(parents=True, exist_ok=True)
     try:
-        subprocess.run(
-            ["hwp5html", str(hwp_path), "--output", str(output_dir)],
-            capture_output=True, timeout=60, check=True,
-        )
-        xhtml = output_dir / "index.xhtml"
-        return xhtml if xhtml.exists() else None
+        subprocess.run(["hwp5html", str(hwp_path), "--output", str(output_dir)],
+                       capture_output=True, timeout=60, check=True)
+        x = output_dir / "index.xhtml"
+        return x if x.exists() else None
     except Exception as e:
-        print(f"    hwp5html 실패: {e}")
-        return None
+        print(f"    hwp5html 실패: {e}"); return None
 
+# ═══ 섹션 2: XHTML 파싱 → 문서 단위 분해 ═══
 
-# ══════════════════════════════════════════════════════
-# 섹션 2. XHTML 파싱 → 문서 단위 분해
-# ══════════════════════════════════════════════════════
-
-class XHTMLTableExtractor(HTMLParser):
-    """XHTML에서 표 구조를 추출. 각 셀의 텍스트+위치를 수집."""
-
+class XHTMLParser(HTMLParser):
     def __init__(self):
         super().__init__()
-        self.tables = []       # [{rows: [[{text, rowspan, colspan}]]}]
-        self._in_table = False
-        self._in_td = False
-        self._in_p = False
-        self._current_table = None
-        self._current_row = None
-        self._current_cell = None
-        self._text_buf = []
-        self._table_idx = 0
-        self._row_idx = 0
-        self._col_idx = 0
-        # 표 밖 텍스트
-        self.paragraphs = []
-        self._para_buf = []
-        self._in_body = False
-
+        self.tables = []; self.paragraphs = []
+        self._in_table = self._in_td = False
+        self._cur_table = self._cur_row = self._cur_cell = None
+        self._buf = []; self._pbuf = []; self._tidx = self._ridx = self._cidx = 0
     def handle_starttag(self, tag, attrs):
         a = dict(attrs)
-        if tag == "body":
-            self._in_body = True
-        elif tag == "table":
-            self._in_table = True
-            self._table_idx += 1
-            self._current_table = {"table_idx": self._table_idx, "rows": []}
-            self._row_idx = 0
+        if tag == "table":
+            self._in_table = True; self._tidx += 1; self._ridx = 0
+            self._cur_table = {"table_idx": self._tidx, "rows": []}
         elif tag == "tr" and self._in_table:
-            self._row_idx += 1
-            self._col_idx = 0
-            self._current_row = []
+            self._ridx += 1; self._cidx = 0; self._cur_row = []
         elif tag == "td" and self._in_table:
-            self._in_td = True
-            self._col_idx += 1
-            self._current_cell = {
-                "row": self._row_idx,
-                "col": self._col_idx,
-                "rowspan": int(a.get("rowspan", 1)),
-                "colspan": int(a.get("colspan", 1)),
-                "text": "",
-            }
-            self._text_buf = []
-        elif tag == "p":
-            self._in_p = True
-            if not self._in_table:
-                self._para_buf = []
-
+            self._in_td = True; self._cidx += 1; self._buf = []
+            self._cur_cell = {"row": self._ridx, "col": self._cidx,
+                "rowspan": int(a.get("rowspan",1)), "colspan": int(a.get("colspan",1)), "text": ""}
+        elif tag == "p" and not self._in_table: self._pbuf = []
     def handle_endtag(self, tag):
         if tag == "td" and self._in_td:
             self._in_td = False
-            if self._current_cell is not None:
-                self._current_cell["text"] = " ".join(self._text_buf).strip()
-                self._current_cell["text"] = re.sub(r'\s+', ' ', self._current_cell["text"])
-            if self._current_row is not None:
-                self._current_row.append(self._current_cell)
-            self._current_cell = None
-            self._text_buf = []
-        elif tag == "tr" and self._current_row is not None:
-            if self._current_table is not None:
-                self._current_table["rows"].append(self._current_row)
-            self._current_row = None
+            if self._cur_cell:
+                self._cur_cell["text"] = re.sub(r'\s+', ' ', " ".join(self._buf)).strip()
+            if self._cur_row is not None: self._cur_row.append(self._cur_cell)
+            self._cur_cell = None
+        elif tag == "tr" and self._cur_row is not None:
+            if self._cur_table: self._cur_table["rows"].append(self._cur_row)
+            self._cur_row = None
         elif tag == "table" and self._in_table:
             self._in_table = False
-            if self._current_table:
-                self.tables.append(self._current_table)
-            self._current_table = None
-        elif tag == "p":
-            self._in_p = False
-            if not self._in_table and self._para_buf:
-                text = " ".join(self._para_buf).strip()
-                if text:
-                    self.paragraphs.append(text)
-
+            if self._cur_table: self.tables.append(self._cur_table)
+        elif tag == "p" and not self._in_table:
+            t = " ".join(self._pbuf).strip()
+            if t: self.paragraphs.append(t)
     def handle_data(self, data):
-        clean = data.replace("\r", "").replace("\n", " ").strip()
-        if not clean:
-            return
-        if self._in_td:
-            self._text_buf.append(clean)
-        elif self._in_p and not self._in_table:
-            self._para_buf.append(clean)
+        c = data.replace("\r","").replace("\n"," ").strip()
+        if not c: return
+        if self._in_td: self._buf.append(c)
+        elif not self._in_table: self._pbuf.append(c)
 
+def parse_xhtml(path):
+    p = XHTMLParser(); p.feed(path.read_text(encoding="utf-8", errors="ignore"))
+    return {"tables": p.tables, "paragraphs": p.paragraphs}
 
-def parse_xhtml(xhtml_path: Path) -> dict:
-    """XHTML 파싱 → 표 구조 + 문단 추출"""
-    text = xhtml_path.read_text(encoding="utf-8", errors="ignore")
-    parser = XHTMLTableExtractor()
-    parser.feed(text)
-    return {"tables": parser.tables, "paragraphs": parser.paragraphs}
+# ═══ 섹션 2 확장: 셀 내용 기반 element_type 분류 (증거 기반) ═══
 
+def classify_element_type(text):
+    """셀 실제 내용으로 element_type 분류. 임의해석 아닌 패턴 매칭."""
+    t = text.strip()
+    if not t: return "EMPTY_CELL"
+    if re.search(r'[□☐☑✓✗■]', t): return "CHECKBOX"
+    if re.search(r'\(서명\s*(또는)?\s*인\)|\(인\)$', t): return "SIGNATURE_FIELD"
+    if re.search(r'년\s+월\s+일|__+|\.{5,}', t): return "INPUT_FIELD"
+    if re.search(r'^[①-⑳⑴-⒇Ⅰ-Ⅹ]\s', t): return "NUMBERED_LABEL"
+    if re.search(r'첨부|별첨', t): return "ATTACHMENT_FIELD"
+    if re.search(r'^비고$', t): return "REMARKS_FIELD"
+    if re.search(r'귀하$', t): return "SUBMIT_TO_FIELD"
+    if len(t) <= 30 and re.search(r'[가-힣]', t) and not re.search(r'[0-9]', t): return "FIELD_LABEL"
+    if re.search(r'작성방법|작성요령|유의사항', t): return "INSTRUCTION_TEXT"
+    return "DATA_CELL"
 
-# ══════════════════════════════════════════════════════
-# 섹션 3~5. Field / Checklist / Evidence Candidate 생성
-# ══════════════════════════════════════════════════════
+# ═══ 섹션 3: Field Candidate (정밀화) ═══
 
-# 필드 라벨 패턴 (문서에서 실제 발견되는 것만)
 FIELD_PATTERNS = [
-    (r'사업장명', 'site_name'),
+    (r'^①?\s*사업장명', 'site_name'),
     (r'사업자\s*등록\s*번호', 'business_registration_no'),
     (r'사업장\s*관리\s*번호', 'site_management_no'),
     (r'근로자\s*수', 'worker_count'),
-    (r'점검일자|점검일|작성일', 'inspection_date'),
-    (r'점검자|작성자|검사자', 'inspector_name'),
-    (r'확인자', 'verifier_name'),
-    (r'서명|인', 'signature'),
-    (r'첨부사진|첨부파일|사진', 'attachment'),
-    (r'비고', 'remarks'),
+    (r'점검일자|점검일$|작성일', 'date_field'),
+    (r'점검자$|작성자\s*소속', 'author_name'),
+    (r'확인자$', 'verifier_name'),
+    (r'\(서명\s*(또는)?\s*인\)|\(인\)', 'signature'),
+    (r'첨부사진|첨부파일', 'attachment'),
+    (r'^비고$', 'remarks'),
     (r'조치사항|개선사항', 'corrective_action'),
-    (r'점검결과|판정|결과', 'inspection_result'),
-    (r'제출처|귀하', 'submit_to'),
+    (r'점검결과|판정$|결과$', 'inspection_result'),
+    (r'귀하$', 'submit_to'),
     (r'보존기간', 'retention_period'),
     (r'보고번호', 'report_no'),
-    (r'업종', 'industry_type'),
-    (r'소재지|주소', 'address'),
+    (r'^업종$', 'industry_type'),
+    (r'소재지$|^주소$', 'address'),
     (r'전화번호|연락처', 'phone'),
-    (r'대표자', 'representative'),
+    (r'^대표자$', 'representative'),
+    (r'사고사망자\s*수', 'accident_death_count'),
+    (r'질병사망자\s*수', 'disease_death_count'),
+    (r'재해자\s*수', 'casualty_count'),
+    (r'재해율|만인율', 'accident_rate'),
+    (r'선임일자|선임일$', 'appointment_date'),
+    (r'자격증\s*번호|면허\s*번호', 'license_no'),
+    (r'허가번호|등록번호', 'permit_no'),
 ]
 
-EVIDENCE_KEYWORDS = ['사진', '첨부', '서명', '인', '확인자', '작성자', '보존기간', '제출처', '제출일', '보고번호']
-CHECKLIST_PATTERNS = [r'여부\s*확인', r'이상\s*없', r'점검\s*항목', r'확인\s*사항', r'체크']
+# ═══ 섹션 4: Checklist Candidate ═══
 
+CHECKLIST_PATTERNS = [
+    r'양호\s*/?\s*불량', r'적합\s*/?\s*부적합', r'정상\s*/?\s*이상',
+    r'합격\s*/?\s*불합격', r'여부\s*확인', r'이상\s*없',
+    r'[□☐]\s*예\s*[□☐]\s*아니', r'해당\s*/?\s*비해당',
+]
 
-def extract_candidates(parsed: dict, doc_id: str) -> dict:
-    """파싱된 구조에서 후보 추출. 문서에 실제 존재하는 것만."""
-    fields = []
-    checklists = []
-    evidence = []
-    elements = []  # 전체 분해 요소
-    fc_seq = ec_seq = cc_seq = el_seq = 0
+# ═══ 섹션 5: Evidence Candidate ═══
+
+EVIDENCE_PATTERNS = [
+    (r'첨부사진|사진첨부|증빙사진', 'PHOTO_EVIDENCE'),
+    (r'첨부파일|별첨', 'ATTACHMENT_EVIDENCE'),
+    (r'측정값|측정결과', 'MEASUREMENT_EVIDENCE'),
+    (r'\(서명\s*(또는)?\s*인\)|\(인\)', 'SIGNATURE_EVIDENCE'),
+    (r'확인자', 'VERIFIER_EVIDENCE'),
+    (r'작성자\s*소속', 'AUTHOR_EVIDENCE'),
+    (r'보존기간', 'RETENTION_EVIDENCE'),
+    (r'귀하', 'SUBMIT_TO_EVIDENCE'),
+    (r'보고번호', 'REPORT_NO_EVIDENCE'),
+]
+
+# ═══ 섹션 6: Document Family 후보 (서식명 기반, CANDIDATE) ═══
+
+def guess_doc_family(file_name):
+    """서식명에서 Document Family 후보 추론. 확정 아닌 CANDIDATE."""
+    n = file_name.lower()
+    families = []
+    if any(k in n for k in ['점검', 'inspect', '체크']): families.append("INSPECTION_DOCUMENT_FAMILY")
+    if any(k in n for k in ['교육', 'training', '수료']): families.append("TRAINING_RECORD_DOCUMENT_FAMILY")
+    if any(k in n for k in ['보고서', 'report', '조사표', '현황']): families.append("REPORT_DOCUMENT_FAMILY")
+    if any(k in n for k in ['선임', '신고', '보고서']): families.append("APPOINTMENT_REPORT_DOCUMENT_FAMILY")
+    if any(k in n for k in ['허가', '계획서', '신청']): families.append("WORK_PERMIT_DOCUMENT_FAMILY")
+    if any(k in n for k in ['사고', '재해', '재난']): families.append("ACCIDENT_REPORT_DOCUMENT_FAMILY")
+    if not families: families.append("UNKNOWN_DOCUMENT_FAMILY")
+    return [{"document_family_candidate_id": f"DFC-{i+1:03d}",
+             "candidate_family": f, "reason": f"서식명 '{file_name}' 패턴 매칭",
+             "status": "CANDIDATE"} for i, f in enumerate(families)]
+
+# ═══ 섹션 10: Official/Custom 분류 (출처 기반 사실) ═══
+
+def classify_form_origin(source_path):
+    """출처 기반 분류. law.go.kr 출처 = OFFICIAL_LEGAL_FORM 후보."""
+    if "law.go.kr" in (source_path or "") or "form-originals" in (source_path or ""):
+        return {"form_origin_candidate": "OFFICIAL_LEGAL_FORM",
+                "reason": "법제처(law.go.kr) 출처 서식", "status": "CANDIDATE"}
+    return {"form_origin_candidate": "UNKNOWN_FORM_ORIGIN",
+            "reason": "출처 확인 불가", "status": "NEEDS_HUMAN_REVIEW"}
+
+# ═══ 추출 엔진 ═══
+
+def extract_all(parsed, doc_id, file_name, source_path):
+    elements, fields, checklists, evidence = [], [], [], []
+    fc = ec = cc = el = 0
+    used_evidence = set()
 
     for table in parsed["tables"]:
         tidx = table["table_idx"]
         for row in table["rows"]:
             for cell in row:
                 text = cell.get("text", "")
-                if not text:
-                    continue
+                if not text: continue
+                el += 1
+                etype = classify_element_type(text)
+                loc = {"table_idx": tidx, "row": cell["row"], "col": cell["col"],
+                       "rowspan": cell["rowspan"], "colspan": cell["colspan"]}
+                elements.append({"element_id": f"EL-{el:04d}", "element_type": etype,
+                    "raw_text": text[:300], "source_location": loc, "status": "EXTRACTED"})
 
-                el_seq += 1
-                elements.append({
-                    "element_id": f"EL-{el_seq:04d}",
-                    "element_type": "TABLE_CELL",
-                    "raw_text": text[:300],
-                    "source_location": {
-                        "table_idx": tidx,
-                        "row": cell["row"],
-                        "col": cell["col"],
-                        "rowspan": cell["rowspan"],
-                        "colspan": cell["colspan"],
-                    },
-                    "status": "EXTRACTED",
-                })
-
-                # 섹션 3: Field Candidate
-                for pattern, canonical in FIELD_PATTERNS:
-                    if re.search(pattern, text):
-                        fc_seq += 1
-                        fields.append({
-                            "field_candidate_id": f"FC-{fc_seq:03d}",
-                            "raw_label": text[:200],
-                            "canonical_field_candidate": canonical,
-                            "source_location": {
-                                "table_idx": tidx,
-                                "row": cell["row"],
-                                "col": cell["col"],
-                            },
-                            "status": "CANDIDATE",
-                        })
+                # Field
+                for pat, canon in FIELD_PATTERNS:
+                    if re.search(pat, text):
+                        fc += 1
+                        fields.append({"field_candidate_id": f"FC-{fc:03d}",
+                            "raw_label": text[:200], "canonical_field_candidate": canon,
+                            "source_location": {"table_idx": tidx, "row": cell["row"], "col": cell["col"]},
+                            "status": "CANDIDATE"})
                         break
 
-                # 섹션 5: Evidence Candidate
-                for kw in EVIDENCE_KEYWORDS:
-                    if kw in text:
-                        ec_seq += 1
-                        evidence.append({
-                            "evidence_field_candidate_id": f"EFC-{ec_seq:03d}",
-                            "raw_label": text[:200],
-                            "evidence_family": f"{kw.upper()}_EVIDENCE_FAMILY",
-                            "source_location": {
-                                "table_idx": tidx,
-                                "row": cell["row"],
-                                "col": cell["col"],
-                            },
-                            "status": "CANDIDATE",
-                        })
+                # Evidence
+                for pat, family in EVIDENCE_PATTERNS:
+                    if re.search(pat, text) and family not in used_evidence:
+                        ec += 1; used_evidence.add(family)
+                        evidence.append({"evidence_field_candidate_id": f"EFC-{ec:03d}",
+                            "raw_label": text[:200], "evidence_family": family,
+                            "source_location": {"table_idx": tidx, "row": cell["row"], "col": cell["col"]},
+                            "status": "CANDIDATE"})
                         break
 
-                # 섹션 4: Checklist Candidate
+                # Checklist
                 for cp in CHECKLIST_PATTERNS:
                     if re.search(cp, text):
-                        cc_seq += 1
-                        checklists.append({
-                            "checklist_item_candidate_id": f"CIC-{cc_seq:03d}",
+                        cc += 1
+                        checklists.append({"checklist_item_candidate_id": f"CIC-{cc:03d}",
                             "raw_text": text[:300],
-                            "source_location": {
-                                "table_idx": tidx,
-                                "row": cell["row"],
-                                "col": cell["col"],
-                            },
-                            "status": "CANDIDATE",
-                        })
+                            "source_location": {"table_idx": tidx, "row": cell["row"], "col": cell["col"]},
+                            "status": "CANDIDATE"})
                         break
 
-    # 표 밖 문단에서도 추출
     for i, para in enumerate(parsed["paragraphs"]):
-        el_seq += 1
-        elements.append({
-            "element_id": f"EL-{el_seq:04d}",
-            "element_type": "PARAGRAPH",
-            "raw_text": para[:300],
-            "source_location": {"paragraph_idx": i + 1},
-            "status": "EXTRACTED",
-        })
-
-    return {
-        "elements": elements,
-        "field_candidates": fields,
-        "checklist_item_candidates": checklists,
-        "evidence_field_candidates": evidence,
-    }
-
-
-# ══════════════════════════════════════════════════════
-# 섹션 6~16. 나머지 처리
-# ══════════════════════════════════════════════════════
-
-def build_package(doc_id: str, file_name: str, source_path: str,
-                  parsed: dict, candidates: dict) -> dict:
-    """Document Schema Candidate Package 조립"""
-    now = datetime.now(KST).isoformat()
-
-    # 섹션 6: Document Family 후보 (확정 아님)
-    doc_family = [{
-        "document_family_candidate_id": "DFC-001",
-        "candidate_family": "UNKNOWN_DOCUMENT_FAMILY",
-        "reason": "자동 확정 금지. Human Review 필요.",
-        "status": "CANDIDATE",
-    }]
-
-    # 섹션 7-8: 법령 매핑 없음 (자동 확정 금지)
-    doc_req_mapping = []
-
-    # 섹션 9: 회사 양식 매핑 없음 (확정 불가)
-    company_mapping = []
+        el += 1
+        elements.append({"element_id": f"EL-{el:04d}", "element_type": "PARAGRAPH",
+            "raw_text": para[:300], "source_location": {"paragraph_idx": i+1}, "status": "EXTRACTED"})
 
     # 섹션 12: Residual
     residuals = []
-    for el in candidates["elements"]:
-        text = el.get("raw_text", "")
-        # 필드도 체크도 증빙도 아닌 셀 → residual 아님 (단순 데이터)
-        # 병합셀 구조 불명확한 경우만 residual
-        loc = el.get("source_location", {})
+    for e in elements:
+        loc = e.get("source_location", {})
         if loc.get("rowspan", 1) > 3 or loc.get("colspan", 1) > 10:
-            residuals.append({
-                "document_residual_id": f"RES-{len(residuals)+1:03d}",
-                "raw_text": text[:200],
-                "reason": "COMPLEX_MERGED_CELL",
-                "source_location": loc,
-                "status": "NEEDS_HUMAN_REVIEW",
-            })
+            residuals.append({"document_residual_id": f"RES-{len(residuals)+1:03d}",
+                "raw_text": e["raw_text"][:200], "reason": "COMPLEX_MERGED_CELL",
+                "source_location": loc, "status": "NEEDS_HUMAN_REVIEW"})
+        if e["element_type"] == "DATA_CELL" and len(e["raw_text"]) > 200:
+            residuals.append({"document_residual_id": f"RES-{len(residuals)+1:03d}",
+                "raw_text": e["raw_text"][:200], "reason": "LONG_UNCLASSIFIED_TEXT",
+                "source_location": loc, "status": "NEEDS_HUMAN_REVIEW"})
+
+    # 섹션 6
+    doc_families = guess_doc_family(file_name)
+
+    # 섹션 10
+    form_origin = classify_form_origin(source_path)
 
     # 섹션 13: Human Review Queue
     hrq = []
-    hrq.append({
-        "review_id": "HRQ-001",
-        "target_id": "DFC-001",
-        "review_type": "DOCUMENT_FAMILY_CONFIRMATION",
-        "description": "문서 유형 확정 필요",
-        "status": "PENDING",
-    })
-    for fc in candidates["field_candidates"]:
-        hrq.append({
-            "review_id": f"HRQ-FC-{fc['field_candidate_id']}",
-            "target_id": fc["field_candidate_id"],
-            "review_type": "CANONICAL_FIELD_CONFIRMATION",
-            "description": f"필드 '{fc['raw_label'][:50]}' canonical 확정 필요",
-            "status": "PENDING",
-        })
+    for df in doc_families:
+        hrq.append({"review_id": f"HRQ-{df['document_family_candidate_id']}",
+            "target_id": df["document_family_candidate_id"],
+            "review_type": "DOCUMENT_FAMILY_CONFIRMATION", "status": "PENDING"})
+    hrq.append({"review_id": "HRQ-FORM-ORIGIN",
+        "target_id": "form_origin", "review_type": "OFFICIAL_CUSTOM_CONFIRMATION",
+        "description": form_origin["reason"], "status": "PENDING"})
+    for f in fields:
+        hrq.append({"review_id": f"HRQ-{f['field_candidate_id']}",
+            "target_id": f["field_candidate_id"],
+            "review_type": "CANONICAL_FIELD_CONFIRMATION", "status": "PENDING"})
+    for c in checklists:
+        hrq.append({"review_id": f"HRQ-{c['checklist_item_candidate_id']}",
+            "target_id": c["checklist_item_candidate_id"],
+            "review_type": "CHECKLIST_ITEM_CONFIRMATION", "status": "PENDING"})
+    for r in residuals:
+        hrq.append({"review_id": f"HRQ-{r['document_residual_id']}",
+            "target_id": r["document_residual_id"],
+            "review_type": "RESIDUAL_RESOLUTION", "status": "PENDING"})
 
     # 섹션 11: Validation
     issues = []
-    for fc in candidates["field_candidates"]:
-        if not fc.get("source_location"):
-            issues.append(f"FAIL: {fc['field_candidate_id']} 위치 근거 없음")
-    if not candidates["field_candidates"]:
-        issues.append("WARN: 추출된 필드 후보 0건")
+    for f in fields:
+        if not f.get("source_location"): issues.append(f"FAIL: {f['field_candidate_id']} 위치근거없음")
+    if not fields: issues.append("WARN: 필드 후보 0건")
+    total_el = len(elements)
+    classified = sum(1 for e in elements if e["element_type"] not in ("DATA_CELL","PARAGRAPH"))
+    if total_el > 0 and classified / total_el < 0.1:
+        issues.append(f"WARN: 분류율 {classified}/{total_el} = {classified/total_el:.0%} (낮음)")
+    status = "FAIL" if any(i.startswith("FAIL") for i in issues) else "PASS"
 
-    validation = {
-        "status": "PASS" if not any(i.startswith("FAIL") for i in issues) else "FAIL",
-        "issues": issues,
-    }
+    # 섹션 14: Audit
+    audit = {"compiler_version": SCRIPT_VERSION, "compiled_at": datetime.now(KST).isoformat(),
+        "source_file": file_name, "hwp5html_used": True,
+        "extraction_counts": {"elements": len(elements), "fields": len(fields),
+            "checklists": len(checklists), "evidence": len(evidence), "residuals": len(residuals)},
+        "rollback_possible": True, "rollback_method": "JSON 파일 삭제 시 원상복구"}
 
-    # 섹션 15: Final Output
     return {
-        "_schema_version": "1.0.0",
-        "_compiler": "TAI Document Schema Compiler (오염 방지형)",
-        "_generated_at": now,
-
-        "document_id": doc_id,
-        "file_name": file_name,
-        "file_type": "HWP",
-        "source_path": source_path,
-        "original_text_preserved": True,
-
-        "document_metadata": {
-            "table_count": len(parsed["tables"]),
+        "_schema_version": "2.0.0", "_compiler": "TAI Document Schema Compiler v2 (오염방지형)",
+        "_generated_at": datetime.now(KST).isoformat(),
+        "document_id": doc_id, "file_name": file_name, "file_type": "HWP",
+        "source_path": source_path, "original_text_preserved": True,
+        "document_metadata": {"table_count": len(parsed["tables"]),
             "paragraph_count": len(parsed["paragraphs"]),
-            "total_cells": sum(
-                len(cell)
-                for t in parsed["tables"]
-                for cell in t["rows"]
-            ),
-            "element_count": len(candidates["elements"]),
+            "total_cells": sum(len(c) for t in parsed["tables"] for c in t["rows"]),
+            "element_count": len(elements),
+            "element_type_distribution": {},
         },
-
-        "document_family_candidates": doc_family,
-        "field_candidates": candidates["field_candidates"],
-        "checklist_item_candidates": candidates["checklist_item_candidates"],
-        "evidence_field_candidates": candidates["evidence_field_candidates"],
-        "document_requirement_mapping_candidates": doc_req_mapping,
-        "company_form_mapping_candidates": company_mapping,
+        "form_origin_candidate": form_origin,
+        "document_family_candidates": doc_families,
+        "field_candidates": fields,
+        "checklist_item_candidates": checklists,
+        "evidence_field_candidates": evidence,
+        "document_requirement_mapping_candidates": [],
+        "company_form_mapping_candidates": [],
         "residuals": residuals,
         "human_review_queue": hrq,
-        "validation": validation,
+        "validation": {"status": status, "issues": issues},
+        "audit": audit,
     }
 
+# ═══ element_type 분포 후처리 ═══
 
-# ══════════════════════════════════════════════════════
-# 메인: HWP 파일 처리 루프
-# ══════════════════════════════════════════════════════
+def add_type_distribution(pkg):
+    dist = {}
+    for section in ["field_candidates","checklist_item_candidates","evidence_field_candidates"]:
+        dist[section] = len(pkg.get(section, []))
+    # elements는 별도 저장 안 함 (용량), 분포만 기록
+    return pkg
 
-def process_one(hwp_path: Path, doc_id: str, source_path: str) -> dict | None:
-    """HWP 1건 처리 → Document Schema Candidate Package"""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        xhtml_dir = Path(tmpdir) / "xhtml"
-        xhtml_path = hwp_to_xhtml(hwp_path, xhtml_dir)
-        if not xhtml_path:
-            return None
+# ═══ 메인 ═══
 
-        parsed = parse_xhtml(xhtml_path)
-        candidates = extract_candidates(parsed, doc_id)
-        package = build_package(
-            doc_id=doc_id,
-            file_name=hwp_path.name,
-            source_path=source_path,
-            parsed=parsed,
-            candidates=candidates,
-        )
-        return package
-
+def process_one(hwp_path, doc_id, source_path):
+    with tempfile.TemporaryDirectory() as tmp:
+        xhtml = hwp_to_xhtml(hwp_path, Path(tmp)/"xhtml")
+        if not xhtml: return None
+        parsed = parse_xhtml(xhtml)
+        pkg = extract_all(parsed, doc_id, hwp_path.name, source_path)
+        return add_type_distribution(pkg)
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--dry-run", action="store_true", help="1건만 테스트")
+    ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--limit", type=int, default=None)
-    ap.add_argument("--file", type=str, default=None, help="특정 HWP 파일 경로")
+    ap.add_argument("--file", type=str, default=None)
     args = ap.parse_args()
 
-    print("=" * 70)
-    print("  TAI Document Schema Compiler (오염 방지형)")
-    print("  작업지시서 16개 섹션 규칙 적용")
-    print("=" * 70)
-
+    print("="*70)
+    print(f"  TAI Document Schema Compiler v{SCRIPT_VERSION}")
+    print("  작업지시서 16개 섹션 전체 이행")
+    print("="*70)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
     if args.file:
-        # 단일 파일 처리
         hwp = Path(args.file)
-        if not hwp.exists():
-            print(f"ERROR: {hwp} 없음")
-            sys.exit(1)
-        print(f"\n  단일 파일: {hwp}")
+        if not hwp.exists(): print(f"ERROR: {hwp} 없음"); sys.exit(1)
         pkg = process_one(hwp, hwp.stem, str(hwp))
         if pkg:
             out = OUTPUT_DIR / f"{hwp.stem}.json"
             out.write_text(json.dumps(pkg, ensure_ascii=False, indent=2), encoding="utf-8")
-            print(f"  ✓ 출력: {out}")
-            print(f"    필드: {len(pkg['field_candidates'])}건")
-            print(f"    체크: {len(pkg['checklist_item_candidates'])}건")
-            print(f"    증빙: {len(pkg['evidence_field_candidates'])}건")
-            print(f"    요소: {pkg['document_metadata']['element_count']}건")
+            m = pkg["audit"]["extraction_counts"]
+            print(f"\n  ✓ {out}")
+            print(f"    필드={m['fields']} 체크={m['checklists']} 증빙={m['evidence']} 요소={m['elements']} 잔여={m['residuals']}")
+            print(f"    Family: {[d['candidate_family'] for d in pkg['document_family_candidates']]}")
+            print(f"    Origin: {pkg['form_origin_candidate']['form_origin_candidate']}")
+            print(f"    Validation: {pkg['validation']['status']}")
+            for i in pkg["validation"]["issues"]: print(f"      → {i}")
         return
 
-    # form_templates + document_forms에서 HWP 목록 수집
-    hwp_files = []
+    # DB에서 HWP 목록
+    try:
+        from supabase import create_client
+        SUPABASE_URL = os.environ.get("SUPABASE_URL")
+        SUPABASE_KEY = (os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+            or os.environ.get("SUPABASE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"))
+        sb = create_client(SUPABASE_URL, SUPABASE_KEY)
+        BUCKET_SRC = "form-originals"
+    except: print("ERROR: DB 연결 필요. railway run 으로 실행."); sys.exit(1)
 
-    # form_templates
-    ft = sb.table("form_templates").select("form_code,original_storage_path").not_.is_("original_storage_path", "null").execute()
+    hwp_files = []
+    ft = sb.table("form_templates").select("form_code,original_storage_path").not_.is_("original_storage_path","null").execute()
     for r in (ft.data or []):
         local = Path(f"./form_originals_hwp/{r['form_code']}.hwp")
-        if local.exists():
-            hwp_files.append((local, r["form_code"], f"{BUCKET_SRC}/{r['original_storage_path']}"))
-
-    # document_forms
-    df = sb.table("document_forms").select("doc_id,file_url").not_.is_("file_url", "null").eq("has_legal_form", True).execute()
+        if local.exists(): hwp_files.append((local, r["form_code"], f"{BUCKET_SRC}/{r['original_storage_path']}"))
+    df = sb.table("document_forms").select("doc_id,file_url").not_.is_("file_url","null").eq("has_legal_form",True).execute()
     for r in (df.data or []):
         local = Path(f"./form_originals_hwp/doc_forms/{r['doc_id']}.hwp")
-        if local.exists():
-            hwp_files.append((local, r["doc_id"], r.get("file_url", "")))
+        if local.exists(): hwp_files.append((local, r["doc_id"], r.get("file_url","")))
 
-    print(f"\n  로컬 HWP 파일: {len(hwp_files)}건")
-
-    if args.dry_run:
-        hwp_files = hwp_files[:1]
-        print("  [DRY RUN] 1건만 처리")
-    elif args.limit:
-        hwp_files = hwp_files[:args.limit]
-
+    print(f"\n  로컬 HWP: {len(hwp_files)}건")
+    if args.dry_run: hwp_files = hwp_files[:1]; print("  [DRY RUN] 1건")
+    elif args.limit: hwp_files = hwp_files[:args.limit]
     print(f"  처리 대상: {len(hwp_files)}건\n")
 
-    stats = {"ok": 0, "fail": 0}
-
-    for i, (hwp_path, doc_id, src) in enumerate(hwp_files, 1):
-        print(f"  [{i:3}/{len(hwp_files)}] {doc_id}: {hwp_path.name}")
-        pkg = process_one(hwp_path, doc_id, src)
+    ok = fail = 0
+    for i,(hp,did,src) in enumerate(hwp_files,1):
+        print(f"  [{i:3}/{len(hwp_files)}] {did}")
+        pkg = process_one(hp, did, src)
         if pkg:
-            out = OUTPUT_DIR / f"{doc_id}.json"
-            out.write_text(json.dumps(pkg, ensure_ascii=False, indent=2), encoding="utf-8")
-            fc = len(pkg["field_candidates"])
-            cc = len(pkg["checklist_item_candidates"])
-            ec = len(pkg["evidence_field_candidates"])
-            el = pkg["document_metadata"]["element_count"]
-            print(f"    ✓ 필드={fc} 체크={cc} 증빙={ec} 요소={el}")
-            stats["ok"] += 1
-        else:
-            print(f"    ✗ 실패")
-            stats["fail"] += 1
+            (OUTPUT_DIR/f"{did}.json").write_text(json.dumps(pkg,ensure_ascii=False,indent=2),encoding="utf-8")
+            m = pkg["audit"]["extraction_counts"]
+            print(f"    ✓ F={m['fields']} C={m['checklists']} E={m['evidence']} EL={m['elements']} R={m['residuals']}")
+            ok += 1
+        else: print(f"    ✗ 실패"); fail += 1
 
-    print("\n" + "=" * 70)
-    print("  컴파일 결과")
-    print("=" * 70)
-    print(f"  성공: {stats['ok']}건")
-    print(f"  실패: {stats['fail']}건")
-    print(f"  출력: {OUTPUT_DIR}/")
-    print("=" * 70)
+    print(f"\n{'='*70}\n  성공: {ok}건 / 실패: {fail}건\n  출력: {OUTPUT_DIR}/\n{'='*70}")
 
-
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__": main()

--- a/scripts/document_schema_compiler.py
+++ b/scripts/document_schema_compiler.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """
-document_schema_compiler.py v2 — TAI 오염 방지형 Document Schema Compiler
+document_schema_compiler.py v3 — TAI 오염 방지형 Document Schema Compiler
 
-작업지시서 16개 섹션 전체 이행. 임의해석 금지, 증거 기반 추출, 목표 달성.
-HWP → hwp5html → XHTML → 파싱 → Document Schema Candidate Package JSON
+v2 대비 핵심 개선:
+- 구조적 분석: 라벨-입력칸 쌍, 행 패턴, 테이블 목적 분류
+- 번호 항목(①~⑳) 전수 추출
+- 작성방법 테이블 자동 분리
+- DB form_name 활용 Document Family 분류
 
 실행:
-  cd ~/Desktop/tai-engineering/tai-api
   python3 scripts/document_schema_compiler.py --file form_originals_hwp/OSHACT-FORM-001.hwp
-  railway run python3 scripts/document_schema_compiler.py --dry-run
   railway run python3 scripts/document_schema_compiler.py
 """
 import argparse,json,os,re,subprocess,sys,tempfile
@@ -20,11 +21,11 @@ try:
     from dotenv import load_dotenv; load_dotenv()
 except ImportError: pass
 
-SCRIPT_VERSION = "2.0.0"
+SCRIPT_VERSION = "3.0.0"
 KST = timezone(timedelta(hours=9))
 OUTPUT_DIR = Path("./form_originals_hwp/compiled")
 
-# ═══ 섹션 1: HWP → XHTML 변환 (원본 보존) ═══
+# ═══ HWP → XHTML ═══
 
 def hwp_to_xhtml(hwp_path, output_dir):
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -36,306 +37,373 @@ def hwp_to_xhtml(hwp_path, output_dir):
     except Exception as e:
         print(f"    hwp5html 실패: {e}"); return None
 
-# ═══ 섹션 2: XHTML 파싱 → 문서 단위 분해 ═══
+# ═══ XHTML 파서 ═══
 
 class XHTMLParser(HTMLParser):
     def __init__(self):
         super().__init__()
-        self.tables = []; self.paragraphs = []
-        self._in_table = self._in_td = False
-        self._cur_table = self._cur_row = self._cur_cell = None
-        self._buf = []; self._pbuf = []; self._tidx = self._ridx = self._cidx = 0
-    def handle_starttag(self, tag, attrs):
-        a = dict(attrs)
-        if tag == "table":
-            self._in_table = True; self._tidx += 1; self._ridx = 0
-            self._cur_table = {"table_idx": self._tidx, "rows": []}
-        elif tag == "tr" and self._in_table:
-            self._ridx += 1; self._cidx = 0; self._cur_row = []
-        elif tag == "td" and self._in_table:
-            self._in_td = True; self._cidx += 1; self._buf = []
-            self._cur_cell = {"row": self._ridx, "col": self._cidx,
-                "rowspan": int(a.get("rowspan",1)), "colspan": int(a.get("colspan",1)), "text": ""}
-        elif tag == "p" and not self._in_table: self._pbuf = []
-    def handle_endtag(self, tag):
-        if tag == "td" and self._in_td:
-            self._in_td = False
+        self.tables=[]; self.paragraphs=[]
+        self._in_table=self._in_td=False
+        self._cur_table=self._cur_row=self._cur_cell=None
+        self._buf=[]; self._pbuf=[]; self._tidx=self._ridx=self._cidx=0
+    def handle_starttag(self,tag,attrs):
+        a=dict(attrs)
+        if tag=="table":
+            self._in_table=True;self._tidx+=1;self._ridx=0
+            self._cur_table={"table_idx":self._tidx,"rows":[]}
+        elif tag=="tr" and self._in_table:
+            self._ridx+=1;self._cidx=0;self._cur_row=[]
+        elif tag=="td" and self._in_table:
+            self._in_td=True;self._cidx+=1;self._buf=[]
+            self._cur_cell={"row":self._ridx,"col":self._cidx,
+                "rowspan":int(a.get("rowspan",1)),"colspan":int(a.get("colspan",1)),"text":""}
+        elif tag=="p" and not self._in_table: self._pbuf=[]
+    def handle_endtag(self,tag):
+        if tag=="td" and self._in_td:
+            self._in_td=False
             if self._cur_cell:
-                self._cur_cell["text"] = re.sub(r'\s+', ' ', " ".join(self._buf)).strip()
+                self._cur_cell["text"]=re.sub(r'\s+',' '," ".join(self._buf)).strip()
             if self._cur_row is not None: self._cur_row.append(self._cur_cell)
-            self._cur_cell = None
-        elif tag == "tr" and self._cur_row is not None:
+        elif tag=="tr" and self._cur_row is not None:
             if self._cur_table: self._cur_table["rows"].append(self._cur_row)
-            self._cur_row = None
-        elif tag == "table" and self._in_table:
-            self._in_table = False
+            self._cur_row=None
+        elif tag=="table" and self._in_table:
+            self._in_table=False
             if self._cur_table: self.tables.append(self._cur_table)
-        elif tag == "p" and not self._in_table:
-            t = " ".join(self._pbuf).strip()
+        elif tag=="p" and not self._in_table:
+            t=" ".join(self._pbuf).strip()
             if t: self.paragraphs.append(t)
-    def handle_data(self, data):
-        c = data.replace("\r","").replace("\n"," ").strip()
+    def handle_data(self,data):
+        c=data.replace("\r","").replace("\n"," ").strip()
         if not c: return
         if self._in_td: self._buf.append(c)
         elif not self._in_table: self._pbuf.append(c)
 
 def parse_xhtml(path):
-    p = XHTMLParser(); p.feed(path.read_text(encoding="utf-8", errors="ignore"))
-    return {"tables": p.tables, "paragraphs": p.paragraphs}
+    p=XHTMLParser(); p.feed(path.read_text(encoding="utf-8",errors="ignore"))
+    return {"tables":p.tables,"paragraphs":p.paragraphs}
 
-# ═══ 섹션 2 확장: 셀 내용 기반 element_type 분류 (증거 기반) ═══
+# ═══ 테이블 목적 분류 ═══
 
-def classify_element_type(text):
-    """셀 실제 내용으로 element_type 분류. 임의해석 아닌 패턴 매칭."""
+def classify_table_purpose(table):
+    """테이블의 전체 텍스트를 보고 목적 분류. 증거 기반."""
+    all_text = " ".join(c.get("text","") for r in table["rows"] for c in r)
+    if re.search(r'작성방법|작성요령|유의사항|기재요령', all_text):
+        return "INSTRUCTION_TABLE"
+    return "FORM_TABLE"
+
+# ═══ 셀 분류 ═══
+
+NUMBERED_RE = re.compile(r'^[①-⑳⑴-⒇㉠-㉻]\s*|^\([0-9]+\)\s*|^[0-9]+[\.\)]\s*|^[Ⅰ-Ⅹ]+[\.\s]')
+SECTION_RE = re.compile(r'^[Ⅰ-Ⅹ]+\.\s')
+PLACEHOLDER_RE = re.compile(r'^\s*$|^_+$|^\.{4,}$|^년\s*월\s*일\s*$|^명\s*$|^%\s*$|^‱\s*$|^원\s*$')
+
+def classify_cell(text, rowspan, colspan):
     t = text.strip()
     if not t: return "EMPTY_CELL"
+    if PLACEHOLDER_RE.match(t): return "INPUT_FIELD"
     if re.search(r'[□☐☑✓✗■]', t): return "CHECKBOX"
-    if re.search(r'\(서명\s*(또는)?\s*인\)|\(인\)$', t): return "SIGNATURE_FIELD"
-    if re.search(r'년\s+월\s+일|__+|\.{5,}', t): return "INPUT_FIELD"
-    if re.search(r'^[①-⑳⑴-⒇Ⅰ-Ⅹ]\s', t): return "NUMBERED_LABEL"
+    if re.search(r'\(서명\s*(또는)?\s*인\)', t): return "SIGNATURE_FIELD"
+    if SECTION_RE.match(t): return "SECTION_HEADER"
+    if NUMBERED_RE.match(t): return "NUMBERED_LABEL"
+    if re.search(r'작성방법|작성요령|유의사항', t): return "INSTRUCTION_TEXT"
+    if re.search(r'귀하\s*$', t): return "SUBMIT_TO_FIELD"
+    if re.search(r'년\s+월\s+일', t): return "DATE_FIELD"
     if re.search(r'첨부|별첨', t): return "ATTACHMENT_FIELD"
     if re.search(r'^비고$', t): return "REMARKS_FIELD"
-    if re.search(r'귀하$', t): return "SUBMIT_TO_FIELD"
-    if len(t) <= 30 and re.search(r'[가-힣]', t) and not re.search(r'[0-9]', t): return "FIELD_LABEL"
-    if re.search(r'작성방법|작성요령|유의사항', t): return "INSTRUCTION_TEXT"
+    # 짧은 텍스트(≤30자)이고 한글 포함 → 라벨 가능성
+    if len(t) <= 30 and re.search(r'[가-힣]', t): return "FIELD_LABEL"
+    # 긴 텍스트 → 설명문 or 데이터
+    if len(t) > 100: return "DESCRIPTION_TEXT"
     return "DATA_CELL"
 
-# ═══ 섹션 3: Field Candidate (정밀화) ═══
+# ═══ 라벨-입력칸 쌍 감지 ═══
 
-FIELD_PATTERNS = [
-    (r'^①?\s*사업장명', 'site_name'),
-    (r'사업자\s*등록\s*번호', 'business_registration_no'),
-    (r'사업장\s*관리\s*번호', 'site_management_no'),
-    (r'근로자\s*수', 'worker_count'),
-    (r'점검일자|점검일$|작성일', 'date_field'),
-    (r'점검자$|작성자\s*소속', 'author_name'),
-    (r'확인자$', 'verifier_name'),
-    (r'\(서명\s*(또는)?\s*인\)|\(인\)', 'signature'),
-    (r'첨부사진|첨부파일', 'attachment'),
-    (r'^비고$', 'remarks'),
-    (r'조치사항|개선사항', 'corrective_action'),
-    (r'점검결과|판정$|결과$', 'inspection_result'),
-    (r'귀하$', 'submit_to'),
-    (r'보존기간', 'retention_period'),
-    (r'보고번호', 'report_no'),
-    (r'^업종$', 'industry_type'),
-    (r'소재지$|^주소$', 'address'),
-    (r'전화번호|연락처', 'phone'),
-    (r'^대표자$', 'representative'),
-    (r'사고사망자\s*수', 'accident_death_count'),
-    (r'질병사망자\s*수', 'disease_death_count'),
-    (r'재해자\s*수', 'casualty_count'),
-    (r'재해율|만인율', 'accident_rate'),
-    (r'선임일자|선임일$', 'appointment_date'),
-    (r'자격증\s*번호|면허\s*번호', 'license_no'),
-    (r'허가번호|등록번호', 'permit_no'),
+def detect_label_input_pairs(table):
+    """같은 행에서 라벨 셀 다음에 빈/플레이스홀더 셀이 오면 쌍으로 연결"""
+    pairs = []
+    for row in table["rows"]:
+        for i, cell in enumerate(row):
+            ctype = classify_cell(cell["text"], cell["rowspan"], cell["colspan"])
+            if ctype in ("FIELD_LABEL", "NUMBERED_LABEL"):
+                # 다음 셀이 입력칸/빈칸인지 확인
+                if i + 1 < len(row):
+                    next_cell = row[i + 1]
+                    ntype = classify_cell(next_cell["text"], next_cell["rowspan"], next_cell["colspan"])
+                    if ntype in ("INPUT_FIELD", "EMPTY_CELL", "DATA_CELL"):
+                        pairs.append({
+                            "label_cell": cell,
+                            "input_cell": next_cell,
+                            "label_type": ctype,
+                        })
+    return pairs
+
+# ═══ 필드 canonical 매핑 ═══
+
+CANONICAL_MAP = [
+    (r'사업장명', 'site_name'), (r'사업자\s*등록\s*번호', 'business_registration_no'),
+    (r'사업장\s*관리\s*번호', 'site_management_no'), (r'사업개시번호', 'business_start_no'),
+    (r'근로자\s*수', 'worker_count'), (r'점검일|작성일|보고일', 'date_field'),
+    (r'점검자|작성자|검사자|조사자', 'author_name'), (r'확인자', 'verifier_name'),
+    (r'\(서명\s*(또는)?\s*인\)', 'signature'), (r'첨부사진|첨부파일|별첨', 'attachment'),
+    (r'^비고$', 'remarks'), (r'조치사항|개선사항|시정조치', 'corrective_action'),
+    (r'점검결과|판정|결과', 'inspection_result'), (r'귀하', 'submit_to'),
+    (r'보존기간', 'retention_period'), (r'보고번호|접수번호', 'report_no'),
+    (r'^업종$|업종명', 'industry_type'), (r'소재지|^주소$', 'address'),
+    (r'전화번호|연락처|팩스', 'phone'), (r'^대표자$|대표이사', 'representative'),
+    (r'사고사망자\s*수', 'accident_death_count'), (r'질병사망자\s*수', 'disease_death_count'),
+    (r'사고재해자\s*수', 'accident_casualty_count'), (r'질병재해자\s*수', 'disease_casualty_count'),
+    (r'재해율|산업재해율', 'accident_rate'), (r'사망만인율|만인율', 'death_rate_per_10k'),
+    (r'선임일|위촉일', 'appointment_date'), (r'자격증\s*번호|면허\s*번호', 'license_no'),
+    (r'허가번호|등록번호|인가번호', 'permit_no'), (r'공사명|공사 명칭', 'construction_name'),
+    (r'공사기간|공사 기간', 'construction_period'), (r'공사금액|도급금액', 'construction_amount'),
+    (r'발주자|발주처', 'client_name'), (r'시공자|시공업체', 'contractor_name'),
+    (r'감리자|감리원', 'supervisor_name'), (r'설계자|설계업체', 'designer_name'),
 ]
 
-# ═══ 섹션 4: Checklist Candidate ═══
-
-CHECKLIST_PATTERNS = [
-    r'양호\s*/?\s*불량', r'적합\s*/?\s*부적합', r'정상\s*/?\s*이상',
-    r'합격\s*/?\s*불합격', r'여부\s*확인', r'이상\s*없',
-    r'[□☐]\s*예\s*[□☐]\s*아니', r'해당\s*/?\s*비해당',
+EVIDENCE_MAP = [
+    (r'첨부사진|증빙사진|사진첨부', 'PHOTO_EVIDENCE'),
+    (r'첨부파일|별첨|첨부서류', 'FILE_ATTACHMENT_EVIDENCE'),
+    (r'측정값|측정결과|측정수치', 'MEASUREMENT_EVIDENCE'),
+    (r'\(서명\s*(또는)?\s*인\)', 'SIGNATURE_EVIDENCE'),
+    (r'확인자|검토자|승인자', 'VERIFIER_EVIDENCE'),
+    (r'작성자\s*소속|작성자\s*성명', 'AUTHOR_EVIDENCE'),
+    (r'보존기간|보관기간', 'RETENTION_EVIDENCE'),
+    (r'귀하|제출처', 'SUBMIT_TO_EVIDENCE'),
+    (r'보고번호|접수번호|관리번호', 'REPORT_NO_EVIDENCE'),
 ]
 
-# ═══ 섹션 5: Evidence Candidate ═══
-
-EVIDENCE_PATTERNS = [
-    (r'첨부사진|사진첨부|증빙사진', 'PHOTO_EVIDENCE'),
-    (r'첨부파일|별첨', 'ATTACHMENT_EVIDENCE'),
-    (r'측정값|측정결과', 'MEASUREMENT_EVIDENCE'),
-    (r'\(서명\s*(또는)?\s*인\)|\(인\)', 'SIGNATURE_EVIDENCE'),
-    (r'확인자', 'VERIFIER_EVIDENCE'),
-    (r'작성자\s*소속', 'AUTHOR_EVIDENCE'),
-    (r'보존기간', 'RETENTION_EVIDENCE'),
-    (r'귀하', 'SUBMIT_TO_EVIDENCE'),
-    (r'보고번호', 'REPORT_NO_EVIDENCE'),
+CHECKLIST_RE = [
+    re.compile(p) for p in [
+        r'양호\s*/?\s*불량', r'적합\s*/?\s*부적합', r'정상\s*/?\s*이상',
+        r'합격\s*/?\s*불합격', r'여부\s*(확인|점검)', r'이상\s*(없|유)',
+        r'[□☐]\s*예\s*[□☐]\s*아니', r'해당\s*/?\s*비해당',
+    ]
 ]
 
-# ═══ 섹션 6: Document Family 후보 (서식명 기반, CANDIDATE) ═══
+def find_canonical(text):
+    for pat, canon in CANONICAL_MAP:
+        if re.search(pat, text): return canon
+    return None
 
-def guess_doc_family(file_name):
-    """서식명에서 Document Family 후보 추론. 확정 아닌 CANDIDATE."""
-    n = file_name.lower()
+def find_evidence(text):
+    for pat, family in EVIDENCE_MAP:
+        if re.search(pat, text): return family
+    return None
+
+def is_checklist(text):
+    return any(p.search(text) for p in CHECKLIST_RE)
+
+# ═══ Document Family (서식명 기반) ═══
+
+FAMILY_RULES = [
+    (r'점검|체크|check', "INSPECTION_DOCUMENT_FAMILY"),
+    (r'교육|훈련|training|수료', "TRAINING_RECORD_DOCUMENT_FAMILY"),
+    (r'보고서|조사표|현황|report|통보서|결과서', "REPORT_DOCUMENT_FAMILY"),
+    (r'선임|신고서|해임', "APPOINTMENT_REPORT_DOCUMENT_FAMILY"),
+    (r'허가|신청서|계획서', "WORK_PERMIT_DOCUMENT_FAMILY"),
+    (r'사고|재해|재난', "ACCIDENT_REPORT_DOCUMENT_FAMILY"),
+    (r'기록부|대장|일지|관리대장', "RECORD_RETENTION_DOCUMENT_FAMILY"),
+]
+
+def classify_family(form_name):
     families = []
-    if any(k in n for k in ['점검', 'inspect', '체크']): families.append("INSPECTION_DOCUMENT_FAMILY")
-    if any(k in n for k in ['교육', 'training', '수료']): families.append("TRAINING_RECORD_DOCUMENT_FAMILY")
-    if any(k in n for k in ['보고서', 'report', '조사표', '현황']): families.append("REPORT_DOCUMENT_FAMILY")
-    if any(k in n for k in ['선임', '신고', '보고서']): families.append("APPOINTMENT_REPORT_DOCUMENT_FAMILY")
-    if any(k in n for k in ['허가', '계획서', '신청']): families.append("WORK_PERMIT_DOCUMENT_FAMILY")
-    if any(k in n for k in ['사고', '재해', '재난']): families.append("ACCIDENT_REPORT_DOCUMENT_FAMILY")
+    fn = (form_name or "").lower()
+    for pat, fam in FAMILY_RULES:
+        if re.search(pat, fn) and fam not in families:
+            families.append(fam)
     if not families: families.append("UNKNOWN_DOCUMENT_FAMILY")
     return [{"document_family_candidate_id": f"DFC-{i+1:03d}",
-             "candidate_family": f, "reason": f"서식명 '{file_name}' 패턴 매칭",
+             "candidate_family": f, "reason": f"서식명 '{form_name}' 패턴",
              "status": "CANDIDATE"} for i, f in enumerate(families)]
 
-# ═══ 섹션 10: Official/Custom 분류 (출처 기반 사실) ═══
-
-def classify_form_origin(source_path):
-    """출처 기반 분류. law.go.kr 출처 = OFFICIAL_LEGAL_FORM 후보."""
+def classify_origin(source_path):
     if "law.go.kr" in (source_path or "") or "form-originals" in (source_path or ""):
         return {"form_origin_candidate": "OFFICIAL_LEGAL_FORM",
-                "reason": "법제처(law.go.kr) 출처 서식", "status": "CANDIDATE"}
+                "reason": "법제처(law.go.kr) 출처", "status": "CANDIDATE"}
     return {"form_origin_candidate": "UNKNOWN_FORM_ORIGIN",
-            "reason": "출처 확인 불가", "status": "NEEDS_HUMAN_REVIEW"}
+            "reason": "출처 미확인", "status": "NEEDS_HUMAN_REVIEW"}
 
-# ═══ 추출 엔진 ═══
+# ═══ 핵심: 전수 추출 엔진 ═══
 
-def extract_all(parsed, doc_id, file_name, source_path):
-    elements, fields, checklists, evidence = [], [], [], []
-    fc = ec = cc = el = 0
-    used_evidence = set()
+def extract_all(parsed, doc_id, file_name, form_name, source_path):
+    elements = []; fields = []; checklists = []; evidence = []
+    pairs_list = []; residuals = []
+    fc=ec=cc=el=0
+    seen_evidence = set()
+    type_dist = {}
 
     for table in parsed["tables"]:
         tidx = table["table_idx"]
+        purpose = classify_table_purpose(table)
+
+        # 라벨-입력칸 쌍 감지
+        table_pairs = detect_label_input_pairs(table)
+        pairs_list.extend(table_pairs)
+
         for row in table["rows"]:
             for cell in row:
-                text = cell.get("text", "")
+                text = cell.get("text","")
                 if not text: continue
                 el += 1
-                etype = classify_element_type(text)
-                loc = {"table_idx": tidx, "row": cell["row"], "col": cell["col"],
-                       "rowspan": cell["rowspan"], "colspan": cell["colspan"]}
-                elements.append({"element_id": f"EL-{el:04d}", "element_type": etype,
-                    "raw_text": text[:300], "source_location": loc, "status": "EXTRACTED"})
+                etype = classify_cell(text, cell["rowspan"], cell["colspan"])
+                loc = {"table_idx":tidx, "table_purpose":purpose,
+                       "row":cell["row"], "col":cell["col"],
+                       "rowspan":cell["rowspan"], "colspan":cell["colspan"]}
 
-                # Field
-                for pat, canon in FIELD_PATTERNS:
-                    if re.search(pat, text):
+                type_dist[etype] = type_dist.get(etype, 0) + 1
+                elements.append({"element_id":f"EL-{el:04d}", "element_type":etype,
+                    "raw_text":text[:500], "source_location":loc, "status":"EXTRACTED"})
+
+                # INSTRUCTION_TABLE에서는 필드 추출 스킵
+                if purpose == "INSTRUCTION_TABLE":
+                    continue
+
+                # 번호 항목(①~⑳) → 무조건 필드 후보
+                if etype == "NUMBERED_LABEL":
+                    fc += 1
+                    canon = find_canonical(text) or "numbered_field"
+                    fields.append({"field_candidate_id":f"FC-{fc:03d}",
+                        "raw_label":text[:300], "canonical_field_candidate":canon,
+                        "source_location":loc, "status":"CANDIDATE"})
+
+                # 일반 라벨 → 필드 후보
+                elif etype == "FIELD_LABEL":
+                    canon = find_canonical(text)
+                    if canon:
                         fc += 1
-                        fields.append({"field_candidate_id": f"FC-{fc:03d}",
-                            "raw_label": text[:200], "canonical_field_candidate": canon,
-                            "source_location": {"table_idx": tidx, "row": cell["row"], "col": cell["col"]},
-                            "status": "CANDIDATE"})
-                        break
+                        fields.append({"field_candidate_id":f"FC-{fc:03d}",
+                            "raw_label":text[:300], "canonical_field_candidate":canon,
+                            "source_location":loc, "status":"CANDIDATE"})
 
-                # Evidence
-                for pat, family in EVIDENCE_PATTERNS:
-                    if re.search(pat, text) and family not in used_evidence:
-                        ec += 1; used_evidence.add(family)
-                        evidence.append({"evidence_field_candidate_id": f"EFC-{ec:03d}",
-                            "raw_label": text[:200], "evidence_family": family,
-                            "source_location": {"table_idx": tidx, "row": cell["row"], "col": cell["col"]},
-                            "status": "CANDIDATE"})
-                        break
+                # 서명란, 날짜란, 비고란, 첨부란, 제출처 → 필드 + 증빙
+                elif etype in ("SIGNATURE_FIELD","DATE_FIELD","REMARKS_FIELD",
+                               "ATTACHMENT_FIELD","SUBMIT_TO_FIELD"):
+                    fc += 1
+                    canon = find_canonical(text) or etype.lower().replace("_field","")
+                    fields.append({"field_candidate_id":f"FC-{fc:03d}",
+                        "raw_label":text[:300], "canonical_field_candidate":canon,
+                        "source_location":loc, "status":"CANDIDATE"})
 
-                # Checklist
-                for cp in CHECKLIST_PATTERNS:
-                    if re.search(cp, text):
-                        cc += 1
-                        checklists.append({"checklist_item_candidate_id": f"CIC-{cc:03d}",
-                            "raw_text": text[:300],
-                            "source_location": {"table_idx": tidx, "row": cell["row"], "col": cell["col"]},
-                            "status": "CANDIDATE"})
-                        break
+                # 증빙 감지
+                ev_fam = find_evidence(text)
+                if ev_fam and ev_fam not in seen_evidence:
+                    ec += 1; seen_evidence.add(ev_fam)
+                    evidence.append({"evidence_field_candidate_id":f"EFC-{ec:03d}",
+                        "raw_label":text[:300], "evidence_family":ev_fam,
+                        "source_location":loc, "status":"CANDIDATE"})
 
+                # 체크리스트 감지
+                if is_checklist(text):
+                    cc += 1
+                    checklists.append({"checklist_item_candidate_id":f"CIC-{cc:03d}",
+                        "raw_text":text[:300], "source_location":loc, "status":"CANDIDATE"})
+
+                # Residual: 복잡 병합셀
+                if cell["rowspan"] > 3 or cell["colspan"] > 10:
+                    residuals.append({"document_residual_id":f"RES-{len(residuals)+1:03d}",
+                        "raw_text":text[:200], "reason":"COMPLEX_MERGED_CELL",
+                        "source_location":loc, "status":"NEEDS_HUMAN_REVIEW"})
+
+                # Residual: 긴 미분류 텍스트
+                if etype == "DATA_CELL" and len(text) > 150:
+                    residuals.append({"document_residual_id":f"RES-{len(residuals)+1:03d}",
+                        "raw_text":text[:200], "reason":"LONG_UNCLASSIFIED_TEXT",
+                        "source_location":loc, "status":"NEEDS_HUMAN_REVIEW"})
+
+    # 문단
     for i, para in enumerate(parsed["paragraphs"]):
         el += 1
-        elements.append({"element_id": f"EL-{el:04d}", "element_type": "PARAGRAPH",
-            "raw_text": para[:300], "source_location": {"paragraph_idx": i+1}, "status": "EXTRACTED"})
+        elements.append({"element_id":f"EL-{el:04d}", "element_type":"PARAGRAPH",
+            "raw_text":para[:300], "source_location":{"paragraph_idx":i+1}, "status":"EXTRACTED"})
 
-    # 섹션 12: Residual
-    residuals = []
-    for e in elements:
-        loc = e.get("source_location", {})
-        if loc.get("rowspan", 1) > 3 or loc.get("colspan", 1) > 10:
-            residuals.append({"document_residual_id": f"RES-{len(residuals)+1:03d}",
-                "raw_text": e["raw_text"][:200], "reason": "COMPLEX_MERGED_CELL",
-                "source_location": loc, "status": "NEEDS_HUMAN_REVIEW"})
-        if e["element_type"] == "DATA_CELL" and len(e["raw_text"]) > 200:
-            residuals.append({"document_residual_id": f"RES-{len(residuals)+1:03d}",
-                "raw_text": e["raw_text"][:200], "reason": "LONG_UNCLASSIFIED_TEXT",
-                "source_location": loc, "status": "NEEDS_HUMAN_REVIEW"})
+    # 라벨-입력칸 쌍
+    field_pairs = []
+    for p in pairs_list:
+        field_pairs.append({
+            "label": p["label_cell"]["text"][:200],
+            "label_type": p["label_type"],
+            "input_value": p["input_cell"]["text"][:200] if p["input_cell"]["text"] else "(빈칸)",
+            "label_location": {"row":p["label_cell"]["row"], "col":p["label_cell"]["col"]},
+            "input_location": {"row":p["input_cell"]["row"], "col":p["input_cell"]["col"]},
+        })
 
-    # 섹션 6
-    doc_families = guess_doc_family(file_name)
+    # 문서 Family
+    name_for_family = form_name or file_name
+    doc_families = classify_family(name_for_family)
+    form_origin = classify_origin(source_path)
 
-    # 섹션 10
-    form_origin = classify_form_origin(source_path)
-
-    # 섹션 13: Human Review Queue
+    # Human Review Queue
     hrq = []
     for df in doc_families:
-        hrq.append({"review_id": f"HRQ-{df['document_family_candidate_id']}",
-            "target_id": df["document_family_candidate_id"],
-            "review_type": "DOCUMENT_FAMILY_CONFIRMATION", "status": "PENDING"})
-    hrq.append({"review_id": "HRQ-FORM-ORIGIN",
-        "target_id": "form_origin", "review_type": "OFFICIAL_CUSTOM_CONFIRMATION",
-        "description": form_origin["reason"], "status": "PENDING"})
+        hrq.append({"review_id":f"HRQ-{df['document_family_candidate_id']}",
+            "target_id":df["document_family_candidate_id"],
+            "review_type":"DOCUMENT_FAMILY_CONFIRMATION","status":"PENDING"})
+    hrq.append({"review_id":"HRQ-ORIGIN","target_id":"form_origin",
+        "review_type":"OFFICIAL_CUSTOM_CONFIRMATION","status":"PENDING"})
     for f in fields:
-        hrq.append({"review_id": f"HRQ-{f['field_candidate_id']}",
-            "target_id": f["field_candidate_id"],
-            "review_type": "CANONICAL_FIELD_CONFIRMATION", "status": "PENDING"})
+        hrq.append({"review_id":f"HRQ-{f['field_candidate_id']}",
+            "target_id":f["field_candidate_id"],
+            "review_type":"CANONICAL_FIELD_CONFIRMATION","status":"PENDING"})
     for c in checklists:
-        hrq.append({"review_id": f"HRQ-{c['checklist_item_candidate_id']}",
-            "target_id": c["checklist_item_candidate_id"],
-            "review_type": "CHECKLIST_ITEM_CONFIRMATION", "status": "PENDING"})
+        hrq.append({"review_id":f"HRQ-{c['checklist_item_candidate_id']}",
+            "target_id":c["checklist_item_candidate_id"],
+            "review_type":"CHECKLIST_CONFIRMATION","status":"PENDING"})
     for r in residuals:
-        hrq.append({"review_id": f"HRQ-{r['document_residual_id']}",
-            "target_id": r["document_residual_id"],
-            "review_type": "RESIDUAL_RESOLUTION", "status": "PENDING"})
+        hrq.append({"review_id":f"HRQ-{r['document_residual_id']}",
+            "target_id":r["document_residual_id"],
+            "review_type":"RESIDUAL_RESOLUTION","status":"PENDING"})
 
-    # 섹션 11: Validation
+    # Validation
     issues = []
-    for f in fields:
-        if not f.get("source_location"): issues.append(f"FAIL: {f['field_candidate_id']} 위치근거없음")
     if not fields: issues.append("WARN: 필드 후보 0건")
+    classified = sum(1 for e in elements if e["element_type"] not in ("DATA_CELL","PARAGRAPH","EMPTY_CELL"))
     total_el = len(elements)
-    classified = sum(1 for e in elements if e["element_type"] not in ("DATA_CELL","PARAGRAPH"))
-    if total_el > 0 and classified / total_el < 0.1:
-        issues.append(f"WARN: 분류율 {classified}/{total_el} = {classified/total_el:.0%} (낮음)")
+    if total_el > 0:
+        ratio = classified / total_el
+        if ratio < 0.3: issues.append(f"WARN: 분류율 {ratio:.0%} ({classified}/{total_el})")
     status = "FAIL" if any(i.startswith("FAIL") for i in issues) else "PASS"
 
-    # 섹션 14: Audit
-    audit = {"compiler_version": SCRIPT_VERSION, "compiled_at": datetime.now(KST).isoformat(),
-        "source_file": file_name, "hwp5html_used": True,
-        "extraction_counts": {"elements": len(elements), "fields": len(fields),
-            "checklists": len(checklists), "evidence": len(evidence), "residuals": len(residuals)},
-        "rollback_possible": True, "rollback_method": "JSON 파일 삭제 시 원상복구"}
+    # Audit
+    audit = {"compiler_version":SCRIPT_VERSION,"compiled_at":datetime.now(KST).isoformat(),
+        "source_file":file_name,"form_name_used":name_for_family,
+        "extraction_counts":{"elements":len(elements),"fields":len(fields),
+            "checklists":len(checklists),"evidence":len(evidence),
+            "field_pairs":len(field_pairs),"residuals":len(residuals)},
+        "rollback_possible":True}
 
     return {
-        "_schema_version": "2.0.0", "_compiler": "TAI Document Schema Compiler v2 (오염방지형)",
-        "_generated_at": datetime.now(KST).isoformat(),
-        "document_id": doc_id, "file_name": file_name, "file_type": "HWP",
-        "source_path": source_path, "original_text_preserved": True,
-        "document_metadata": {"table_count": len(parsed["tables"]),
-            "paragraph_count": len(parsed["paragraphs"]),
-            "total_cells": sum(len(c) for t in parsed["tables"] for c in t["rows"]),
-            "element_count": len(elements),
-            "element_type_distribution": {},
-        },
-        "form_origin_candidate": form_origin,
-        "document_family_candidates": doc_families,
-        "field_candidates": fields,
-        "checklist_item_candidates": checklists,
-        "evidence_field_candidates": evidence,
-        "document_requirement_mapping_candidates": [],
-        "company_form_mapping_candidates": [],
-        "residuals": residuals,
-        "human_review_queue": hrq,
-        "validation": {"status": status, "issues": issues},
-        "audit": audit,
+        "_schema_version":"3.0.0","_compiler":f"TAI Document Schema Compiler v{SCRIPT_VERSION}",
+        "_generated_at":datetime.now(KST).isoformat(),
+        "document_id":doc_id,"file_name":file_name,"file_type":"HWP",
+        "form_name":name_for_family,"source_path":source_path,
+        "original_text_preserved":True,
+        "document_metadata":{"table_count":len(parsed["tables"]),
+            "paragraph_count":len(parsed["paragraphs"]),
+            "total_cells":sum(len(c) for t in parsed["tables"] for c in t["rows"]),
+            "element_count":len(elements),"element_type_distribution":type_dist},
+        "form_origin_candidate":form_origin,
+        "document_family_candidates":doc_families,
+        "field_candidates":fields,
+        "field_label_input_pairs":field_pairs,
+        "checklist_item_candidates":checklists,
+        "evidence_field_candidates":evidence,
+        "document_requirement_mapping_candidates":[],
+        "company_form_mapping_candidates":[],
+        "residuals":residuals,
+        "human_review_queue":hrq,
+        "validation":{"status":status,"issues":issues},
+        "audit":audit,
     }
-
-# ═══ element_type 분포 후처리 ═══
-
-def add_type_distribution(pkg):
-    dist = {}
-    for section in ["field_candidates","checklist_item_candidates","evidence_field_candidates"]:
-        dist[section] = len(pkg.get(section, []))
-    # elements는 별도 저장 안 함 (용량), 분포만 기록
-    return pkg
 
 # ═══ 메인 ═══
 
-def process_one(hwp_path, doc_id, source_path):
+def process_one(hwp_path, doc_id, form_name, source_path):
     with tempfile.TemporaryDirectory() as tmp:
         xhtml = hwp_to_xhtml(hwp_path, Path(tmp)/"xhtml")
         if not xhtml: return None
         parsed = parse_xhtml(xhtml)
-        pkg = extract_all(parsed, doc_id, hwp_path.name, source_path)
-        return add_type_distribution(pkg)
+        return extract_all(parsed, doc_id, hwp_path.name, form_name, source_path)
 
 def main():
     ap = argparse.ArgumentParser()
@@ -346,61 +414,65 @@ def main():
 
     print("="*70)
     print(f"  TAI Document Schema Compiler v{SCRIPT_VERSION}")
-    print("  작업지시서 16개 섹션 전체 이행")
+    print("  작업지시서 16개 섹션 이행 · 전수 추출")
     print("="*70)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
     if args.file:
         hwp = Path(args.file)
         if not hwp.exists(): print(f"ERROR: {hwp} 없음"); sys.exit(1)
-        pkg = process_one(hwp, hwp.stem, str(hwp))
+        pkg = process_one(hwp, hwp.stem, hwp.stem, str(hwp))
         if pkg:
             out = OUTPUT_DIR / f"{hwp.stem}.json"
             out.write_text(json.dumps(pkg, ensure_ascii=False, indent=2), encoding="utf-8")
             m = pkg["audit"]["extraction_counts"]
+            td = pkg["document_metadata"]["element_type_distribution"]
             print(f"\n  ✓ {out}")
-            print(f"    필드={m['fields']} 체크={m['checklists']} 증빙={m['evidence']} 요소={m['elements']} 잔여={m['residuals']}")
+            print(f"    필드={m['fields']} 체크={m['checklists']} 증빙={m['evidence']} 요소={m['elements']} 쌍={m['field_pairs']} 잔여={m['residuals']}")
             print(f"    Family: {[d['candidate_family'] for d in pkg['document_family_candidates']]}")
             print(f"    Origin: {pkg['form_origin_candidate']['form_origin_candidate']}")
+            print(f"    요소분포: {td}")
             print(f"    Validation: {pkg['validation']['status']}")
             for i in pkg["validation"]["issues"]: print(f"      → {i}")
         return
 
-    # DB에서 HWP 목록
+    # DB 모드
     try:
         from supabase import create_client
-        SUPABASE_URL = os.environ.get("SUPABASE_URL")
-        SUPABASE_KEY = (os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
-            or os.environ.get("SUPABASE_KEY") or os.environ.get("SUPABASE_SERVICE_KEY"))
-        sb = create_client(SUPABASE_URL, SUPABASE_KEY)
-        BUCKET_SRC = "form-originals"
-    except: print("ERROR: DB 연결 필요. railway run 으로 실행."); sys.exit(1)
+        SB_URL = os.environ.get("SUPABASE_URL")
+        SB_KEY = (os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_KEY"))
+        sb = create_client(SB_URL, SB_KEY)
+    except: print("ERROR: DB 연결 필요."); sys.exit(1)
 
+    # form_templates (form_name DB에서 가져옴)
     hwp_files = []
-    ft = sb.table("form_templates").select("form_code,original_storage_path").not_.is_("original_storage_path","null").execute()
+    ft = sb.table("form_templates").select("form_code,form_name,original_storage_path").not_.is_("original_storage_path","null").execute()
     for r in (ft.data or []):
         local = Path(f"./form_originals_hwp/{r['form_code']}.hwp")
-        if local.exists(): hwp_files.append((local, r["form_code"], f"{BUCKET_SRC}/{r['original_storage_path']}"))
-    df = sb.table("document_forms").select("doc_id,file_url").not_.is_("file_url","null").eq("has_legal_form",True).execute()
+        if local.exists():
+            hwp_files.append((local, r["form_code"], r.get("form_name",""), f"form-originals/{r['original_storage_path']}"))
+
+    # document_forms (doc_name DB에서 가져옴)
+    df = sb.table("document_forms").select("doc_id,doc_name,file_url").not_.is_("file_url","null").eq("has_legal_form",True).execute()
     for r in (df.data or []):
         local = Path(f"./form_originals_hwp/doc_forms/{r['doc_id']}.hwp")
-        if local.exists(): hwp_files.append((local, r["doc_id"], r.get("file_url","")))
+        if local.exists():
+            hwp_files.append((local, r["doc_id"], r.get("doc_name",""), r.get("file_url","")))
 
     print(f"\n  로컬 HWP: {len(hwp_files)}건")
-    if args.dry_run: hwp_files = hwp_files[:1]; print("  [DRY RUN] 1건")
-    elif args.limit: hwp_files = hwp_files[:args.limit]
-    print(f"  처리 대상: {len(hwp_files)}건\n")
+    if args.dry_run: hwp_files=hwp_files[:1]; print("  [DRY RUN] 1건")
+    elif args.limit: hwp_files=hwp_files[:args.limit]
+    print(f"  처리: {len(hwp_files)}건\n")
 
-    ok = fail = 0
-    for i,(hp,did,src) in enumerate(hwp_files,1):
-        print(f"  [{i:3}/{len(hwp_files)}] {did}")
-        pkg = process_one(hp, did, src)
+    ok=fail=0
+    for i,(hp,did,fname,src) in enumerate(hwp_files,1):
+        pkg = process_one(hp, did, fname, src)
         if pkg:
             (OUTPUT_DIR/f"{did}.json").write_text(json.dumps(pkg,ensure_ascii=False,indent=2),encoding="utf-8")
             m = pkg["audit"]["extraction_counts"]
-            print(f"    ✓ F={m['fields']} C={m['checklists']} E={m['evidence']} EL={m['elements']} R={m['residuals']}")
+            print(f"  [{i:3}/{len(hwp_files)}] {did:30} F={m['fields']:2d} C={m['checklists']:2d} E={m['evidence']:2d} P={m['field_pairs']:2d} R={m['residuals']:2d}")
             ok += 1
-        else: print(f"    ✗ 실패"); fail += 1
+        else: print(f"  [{i:3}/{len(hwp_files)}] {did:30} ✗ 실패"); fail += 1
 
     print(f"\n{'='*70}\n  성공: {ok}건 / 실패: {fail}건\n  출력: {OUTPUT_DIR}/\n{'='*70}")
 

--- a/scripts/load_document_schema.py
+++ b/scripts/load_document_schema.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+load_document_schema.py — compiled JSON → document_schema_registry DB 적재
+
+compiled JSON의 field_candidates를 document_schema_registry에 적재.
+AI 추론 없음. 컴파일된 데이터 그대로 적재.
+
+실행:
+  cd ~/Desktop/tai-engineering/tai-api
+  railway run python3 scripts/load_document_schema.py --dry-run
+  railway run python3 scripts/load_document_schema.py
+"""
+import argparse, json, os, sys, glob, re
+from pathlib import Path
+from datetime import datetime, timezone, timedelta
+
+try:
+    from dotenv import load_dotenv; load_dotenv()
+except ImportError: pass
+
+from supabase import create_client
+
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_KEY")
+if not SUPABASE_URL or not SUPABASE_KEY:
+    print("ERROR: railway run 으로 실행하세요."); sys.exit(1)
+
+sb = create_client(SUPABASE_URL, SUPABASE_KEY)
+KST = timezone(timedelta(hours=9))
+COMPILED_DIR = Path("./form_originals_hwp/compiled")
+
+# 섹션 추론 규칙 (필드 위치 기반, deterministic)
+SECTION_MAP = {
+    'site_name': ('BASIC_INFO', '기본정보'),
+    'business_registration_no': ('BASIC_INFO', '기본정보'),
+    'site_management_no': ('BASIC_INFO', '기본정보'),
+    'address': ('BASIC_INFO', '기본정보'),
+    'industry_type': ('BASIC_INFO', '기본정보'),
+    'representative': ('BASIC_INFO', '기본정보'),
+    'phone': ('BASIC_INFO', '기본정보'),
+    'worker_count': ('BASIC_INFO', '기본정보'),
+    'business_start_no': ('BASIC_INFO', '기본정보'),
+    'author_name': ('AUTHOR_INFO', '작성자정보'),
+    'verifier_name': ('AUTHOR_INFO', '작성자정보'),
+    'date_field': ('AUTHOR_INFO', '작성자정보'),
+    'signature': ('SIGNATURE', '서명'),
+    'submit_to': ('SUBMISSION', '제출'),
+    'attachment': ('EVIDENCE', '증빙자료'),
+    'remarks': ('REMARKS', '비고'),
+    'corrective_action': ('ACTION', '조치사항'),
+    'inspection_result': ('INSPECTION', '점검결과'),
+    'accident_death_count': ('ACCIDENT_STATS', '재해현황'),
+    'disease_death_count': ('ACCIDENT_STATS', '재해현황'),
+    'accident_casualty_count': ('ACCIDENT_STATS', '재해현황'),
+    'disease_casualty_count': ('ACCIDENT_STATS', '재해현황'),
+    'accident_rate': ('ACCIDENT_STATS', '재해현황'),
+    'death_rate_per_10k': ('ACCIDENT_STATS', '재해현황'),
+    'appointment_date': ('APPOINTMENT', '선임정보'),
+    'license_no': ('APPOINTMENT', '선임정보'),
+    'permit_no': ('PERMIT', '허가정보'),
+    'construction_name': ('CONSTRUCTION', '공사정보'),
+    'construction_period': ('CONSTRUCTION', '공사정보'),
+    'construction_amount': ('CONSTRUCTION', '공사정보'),
+    'client_name': ('CONSTRUCTION', '공사정보'),
+    'contractor_name': ('CONSTRUCTION', '공사정보'),
+    'supervisor_name': ('CONSTRUCTION', '공사정보'),
+    'designer_name': ('CONSTRUCTION', '공사정보'),
+    'retention_period': ('ADMIN', '관리정보'),
+    'report_no': ('ADMIN', '관리정보'),
+}
+
+FIELD_TYPE_MAP = {
+    'date_field': 'date',
+    'signature': 'signature',
+    'attachment': 'image',
+    'worker_count': 'number',
+    'accident_death_count': 'number',
+    'disease_death_count': 'number',
+    'accident_casualty_count': 'number',
+    'disease_casualty_count': 'number',
+    'accident_rate': 'number',
+    'death_rate_per_10k': 'number',
+    'construction_amount': 'number',
+}
+
+RENDER_MAP = {
+    'text': 'text-input',
+    'number': 'number-input',
+    'date': 'date-picker',
+    'signature': 'signature-pad',
+    'image': 'image-gallery',
+    'select': 'select-dropdown',
+    'checkbox': 'checkbox-group',
+    'table': 'data-table',
+    'evidence_ref': 'evidence-viewer',
+}
+
+
+def convert_document_type(doc_id: str) -> str:
+    """doc_id를 document_type으로 변환 (하이픈→언더스코어)"""
+    return doc_id.replace('-', '_').upper()
+
+
+def load_compiled_json(path: Path) -> dict:
+    return json.load(open(path, encoding='utf-8'))
+
+
+def process_one(pkg: dict) -> list[dict]:
+    """compiled JSON 1건 → document_schema_registry 행들"""
+    doc_id = pkg.get('document_id', '')
+    doc_type = convert_document_type(doc_id)
+    form_name = pkg.get('form_name', doc_id)
+    fields = pkg.get('field_candidates', [])
+
+    rows = []
+    sections_seen = set()
+    section_rows = []
+
+    for i, fc in enumerate(fields):
+        canon = fc.get('canonical_field_candidate', 'unclassified_field')
+        raw_label = fc.get('raw_label', '')
+        # 긴 라벨에서 핵심만 추출
+        label = raw_label[:80].strip()
+
+        # 섹션 결정 (deterministic)
+        sec_code, sec_title = SECTION_MAP.get(canon, ('GENERAL', '일반'))
+        if canon in ('numbered_field', 'unclassified_field'):
+            sec_code, sec_title = 'FORM_BODY', '서식본문'
+
+        # 필드 타입
+        field_type = FIELD_TYPE_MAP.get(canon, 'text')
+
+        # 렌더 컴포넌트
+        render = RENDER_MAP.get(field_type, 'text-input')
+
+        # 필수 수준 (서명/작성자/날짜는 MANDATORY 후보)
+        req_level = 'OPTIONAL'
+        if canon in ('signature', 'author_name', 'date_field', 'site_name'):
+            req_level = 'MANDATORY'
+        elif canon in ('worker_count', 'business_registration_no', 'address'):
+            req_level = 'RECOMMENDED'
+
+        # field_code: canonical + 순번 (중복 방지)
+        field_code = f"{canon}_{i+1:03d}"
+
+        rows.append({
+            'document_type': doc_type,
+            'schema_version': '1.0.0',
+            'section_code': sec_code,
+            'section_title': sec_title,
+            'field_code': field_code,
+            'field_label': label,
+            'field_type': field_type,
+            'field_order': i + 1,
+            'required_level': req_level,
+            'repeatable': False,
+            'source_mapping': None,
+            'validation_rule': json.dumps({'rules': ['required']}) if req_level == 'MANDATORY' else None,
+            'render_component': render,
+            'source_trace': None,
+            'source_reason': f"HWP 원문 추출: {raw_label[:100]}",
+            'enabled': True,
+            'status': 'CANDIDATE',
+        })
+
+        # 섹션 수집
+        if sec_code not in sections_seen:
+            sections_seen.add(sec_code)
+            section_rows.append({
+                'document_type': doc_type,
+                'schema_version': '1.0.0',
+                'section_code': sec_code,
+                'section_title': sec_title,
+                'section_order': len(sections_seen),
+                'enabled': True,
+            })
+
+    return rows, section_rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--dry-run', action='store_true')
+    ap.add_argument('--limit', type=int, default=None)
+    ap.add_argument('--file', type=str, default=None)
+    args = ap.parse_args()
+
+    print('='*70)
+    print('  Document Schema Registry Loader')
+    print('='*70)
+
+    if args.file:
+        files = [Path(args.file)]
+    else:
+        files = sorted(COMPILED_DIR.glob('*.json'))
+    if args.limit:
+        files = files[:args.limit]
+
+    print(f'\n  대상: {len(files)}건')
+
+    total_fields = 0
+    total_sections = 0
+
+    for i, f in enumerate(files, 1):
+        pkg = load_compiled_json(f)
+        doc_id = pkg.get('document_id', f.stem)
+        rows, sec_rows = process_one(pkg)
+
+        if args.dry_run:
+            print(f'  [{i:3}/{len(files)}] {doc_id:30} fields={len(rows):3d} sections={len(sec_rows)}')
+        else:
+            doc_type = convert_document_type(doc_id)
+            # 기존 데이터 삭제 (upsert 대신 replace)
+            sb.table('document_schema_registry').delete().eq('document_type', doc_type).execute()
+            sb.table('document_schema_section').delete().eq('document_type', doc_type).execute()
+
+            # 섹션 INSERT
+            if sec_rows:
+                for chunk in [sec_rows[i:i+50] for i in range(0, len(sec_rows), 50)]:
+                    sb.table('document_schema_section').insert(chunk).execute()
+
+            # 필드 INSERT (100건씩 청크)
+            for chunk in [rows[i:i+100] for i in range(0, len(rows), 100)]:
+                sb.table('document_schema_registry').insert(chunk).execute()
+
+            print(f'  [{i:3}/{len(files)}] {doc_id:30} ✓ F={len(rows)} S={len(sec_rows)}')
+
+        total_fields += len(rows)
+        total_sections += len(sec_rows)
+
+    print(f'\n{"="*70}')
+    print(f'  완료: {len(files)}건')
+    print(f'  총 필드: {total_fields}건')
+    print(f'  총 섹션: {total_sections}건')
+    print(f'  상태: 전부 CANDIDATE (Human Review 필요)')
+    print(f'={""*69}')
+
+
+if __name__ == '__main__':
+    main()

--- a/services/conditional_rendering_resolver.py
+++ b/services/conditional_rendering_resolver.py
@@ -1,0 +1,70 @@
+"""conditional_rendering_resolver.py — Conditional Rendering (PHASE C)
+
+조건부 section/field 활성화. deterministic 연산만.
+절대 금지: AI 조건 해석
+"""
+import json
+from typing import Any, Optional
+
+
+def evaluate_condition(rule: dict, context: dict) -> bool:
+    """conditional_rule 평가. deterministic operators only."""
+    if not rule:
+        return True  # 조건 없으면 항상 표시
+
+    field = rule.get("condition") or rule.get("field")
+    operator = rule.get("operator", "=")
+    expected = rule.get("value")
+
+    if not field:
+        return True
+
+    actual = context.get(field)
+
+    # NULL 처리
+    if actual is None:
+        if operator == "EXISTS":
+            return False
+        return False  # 데이터 없으면 조건 미충족
+
+    try:
+        if operator == "=":
+            return actual == expected
+        elif operator == "!=":
+            return actual != expected
+        elif operator == ">":
+            return float(actual) > float(expected)
+        elif operator == ">=":
+            return float(actual) >= float(expected)
+        elif operator == "<":
+            return float(actual) < float(expected)
+        elif operator == "<=":
+            return float(actual) <= float(expected)
+        elif operator == "IN":
+            if isinstance(expected, list):
+                return actual in expected
+            return str(actual) in str(expected)
+        elif operator == "EXISTS":
+            return actual is not None
+        else:
+            return True  # 알 수 없는 연산자 → 표시 (안전 쪽)
+    except (ValueError, TypeError):
+        return False
+
+
+def resolve_conditional_fields(fields: list, context: dict) -> list:
+    """필드 목록에서 조건부 필드를 필터링"""
+    result = []
+    for f in fields:
+        rule_str = f.get("conditional_rule")
+        if rule_str:
+            rule = rule_str if isinstance(rule_str, dict) else json.loads(rule_str)
+            visible = evaluate_condition(rule, context)
+            f["visible"] = visible
+            f["condition_evaluated"] = True
+            f["condition_result"] = visible
+        else:
+            f["visible"] = True
+            f["condition_evaluated"] = False
+        result.append(f)
+    return result

--- a/services/diagnosis_service.py
+++ b/services/diagnosis_service.py
@@ -1,0 +1,191 @@
+"""법령진단서비스 — 결과 출력까지만.
+
+법령진단은 판단 엔진이 아니다.
+결과를 출력할 뿐, 반복설정/스케줄/업무/위반을 확정하지 않는다.
+"""
+import os, json
+from datetime import datetime, timezone
+
+
+def _get_sb():
+    from supabase import create_client
+    return create_client(os.environ.get('SUPABASE_URL',''),
+                         os.environ.get('SUPABASE_SERVICE_ROLE_KEY',''))
+
+
+class DiagnosisService:
+    """법령진단서비스 핵심. Input → Compiler Core → Candidate 출력."""
+
+    @staticmethod
+    def evaluate(sb, factory_id: str, input_data: dict) -> dict:
+        """[1] 법령진단 실행. 결과 출력까지만."""
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Session 생성
+        session = sb.table('diagnosis_session').insert({
+            'factory_id': factory_id,
+            'diagnosis_status': 'PROCESSING',
+            'input_snapshot': json.dumps(input_data),
+            'created_at': now,
+        }).execute()
+        sid = session.data[0]['id']
+
+        try:
+            # ── Compiler Core 호출 ──
+            # Applicability
+            app_r = sb.table('facility_applicability').select(
+                'id, draft_id, applicability_status, part_id'
+            ).eq('factory_id', factory_id).in_(
+                'applicability_status', ['MATCH_CANDIDATE','POSSIBLE_CANDIDATE']
+            ).execute()
+            applicability = app_r.data or []
+
+            # Task → Obligation/Prohibition 분류
+            task_r = sb.table('task_candidate').select(
+                'id, task_type, source_action_family, obligation_family, status'
+            ).eq('factory_id', factory_id).execute()
+            tasks = task_r.data or []
+
+            # Schedule hints
+            sched_r = sb.table('schedule_candidate').select(
+                'id, schedule_type, source_family, source_relation_type, task_type, status'
+            ).eq('factory_id', factory_id).execute()
+            schedules = sched_r.data or []
+
+            # Penalty
+            penalty_r = sb.table('penalty_obligation_relation').select(
+                'id, penalty_candidate_id, rule_candidate_id, obligation_family, status'
+            ).limit(200).execute()
+            penalties = penalty_r.data or []
+
+            # Residuals (factory 관련)
+            compliance_r = sb.table('compliance_review_queue').select(
+                'id, issue_type, detail, status'
+            ).eq('factory_id', factory_id).execute()
+            residuals = compliance_r.data or []
+
+            # ── Candidate 저장 ──
+            obligations = []
+            prohibitions = []
+            TYPE_MAP = {
+                'REPORT':'REPORT','INSTALL':'GENERAL','APPOINTMENT':'APPOINTMENT',
+                'INSPECTION':'INSPECTION','EDUCATION':'EDUCATION','RECORD':'RECORD',
+                'MEASUREMENT':'MEASUREMENT','PRESERVATION':'PRESERVATION',
+                'SUBMIT':'REPORT','MAINTAIN':'GENERAL'
+            }
+
+            for t in tasks:
+                ctype = 'OBLIGATION'
+                sub = TYPE_MAP.get(t.get('task_type'), 'GENERAL')
+                dc = sb.table('diagnosis_candidate').insert({
+                    'session_id': sid,
+                    'candidate_type': ctype,
+                    'sub_type': sub,
+                    'title_candidate': f"{t.get('task_type','')}: {t.get('source_action_family','')}",
+                    'source_law': t.get('obligation_family'),
+                    'status': 'CANDIDATE' if t.get('status')!='NEEDS_HUMAN_REVIEW' else 'NEEDS_HUMAN_REVIEW',
+                }).execute()
+                obligations.append(dc.data[0] if dc.data else {})
+
+            for a in applicability:
+                sb.table('diagnosis_candidate').insert({
+                    'session_id': sid,
+                    'candidate_type': 'APPLICABILITY',
+                    'title_candidate': f"Applicability: {a.get('applicability_status','')}",
+                    'status': 'CANDIDATE',
+                }).execute()
+
+            # Schedule Hints 저장
+            for s in schedules:
+                freq = 'PERIODIC' if 'PERIODIC' in (s.get('schedule_type') or '') else 'UNKNOWN'
+                if 'YEARLY' in (s.get('schedule_type') or ''): freq = 'YEARLY'
+                sb.table('diagnosis_schedule_hint').insert({
+                    'session_id': sid,
+                    'frequency_family': freq,
+                    'trigger_family': s.get('source_relation_type', 'UNKNOWN'),
+                    'deadline_family': 'UNKNOWN',
+                    'raw_text': s.get('source_family'),
+                    'status': 'CANDIDATE',
+                }).execute()
+
+            # Penalty Links
+            for p in penalties[:50]:
+                sb.table('diagnosis_penalty_link').insert({
+                    'session_id': sid,
+                    'penalty_type': p.get('obligation_family'),
+                    'penalty_family': p.get('obligation_family'),
+                    'status': 'PENALTY_LINK_CANDIDATE',
+                }).execute()
+
+            # Missing data 수집
+            missing = []
+            if not input_data.get('employee_count'): missing.append('employee_count')
+            if not input_data.get('industry_code'): missing.append('industry_code')
+            if not input_data.get('equipment_list'): missing.append('equipment_list')
+
+            # Validation
+            has_unknown = any(s.get('status')=='NEEDS_HUMAN_REVIEW' for s in tasks)
+            val_status = 'AMBIGUOUS' if has_unknown else ('UNRESOLVED' if residuals else 'PASS')
+
+            # Session 업데이트
+            diag_status = 'COMPLETED_WITH_CANDIDATES' if (obligations or applicability) else 'COMPLETED_CLEAN'
+            if has_unknown: diag_status = 'NEEDS_HUMAN_REVIEW'
+
+            sb.table('diagnosis_session').update({
+                'diagnosis_status': diag_status,
+                'validation_status': val_status,
+                'validation_issues': json.dumps([{'type':'NEEDS_REVIEW','count':sum(1 for t in tasks if t.get('status')=='NEEDS_HUMAN_REVIEW')}]) if has_unknown else None,
+                'missing_data': json.dumps(missing) if missing else None,
+                'total_applicability': len(applicability),
+                'total_obligations': len(obligations),
+                'total_prohibitions': len(prohibitions),
+                'total_penalties': min(len(penalties),50),
+                'total_residuals': len(residuals),
+                'completed_at': datetime.now(timezone.utc).isoformat(),
+            }).eq('id', sid).execute()
+
+            return {
+                'diagnosis_id': sid,
+                'facility_id': factory_id,
+                'diagnosis_status': diag_status,
+                'applicability_candidates': applicability,
+                'obligation_candidates': [o for o in obligations if o],
+                'prohibition_candidates': prohibitions,
+                'penalty_candidates': penalties[:50],
+                'schedule_candidate_hints': schedules,
+                'missing_data': missing,
+                'residuals': residuals,
+                'human_review_queue': [t for t in tasks if t.get('status')=='NEEDS_HUMAN_REVIEW'],
+                'validation': {'status': val_status, 'issues': []},
+            }
+
+        except Exception as e:
+            sb.table('diagnosis_session').update({
+                'diagnosis_status': 'FAILED',
+                'validation_issues': json.dumps({'error': str(e)}),
+                'completed_at': datetime.now(timezone.utc).isoformat(),
+            }).eq('id', sid).execute()
+            raise
+
+    @staticmethod
+    def get_session(sb, session_id: str) -> dict:
+        s = sb.table('diagnosis_session').select('*').eq('id', session_id).execute()
+        if not s.data: return None
+        session = s.data[0]
+        candidates = sb.table('diagnosis_candidate').select('*').eq('session_id', session_id).execute()
+        penalties = sb.table('diagnosis_penalty_link').select('*').eq('session_id', session_id).execute()
+        hints = sb.table('diagnosis_schedule_hint').select('*').eq('session_id', session_id).execute()
+        return {
+            'session': session,
+            'candidates': candidates.data or [],
+            'penalty_links': penalties.data or [],
+            'schedule_hints': hints.data or [],
+        }
+
+    @staticmethod
+    def list_sessions(sb, factory_id: str = None, limit: int = 20) -> dict:
+        q = sb.table('diagnosis_session').select('*', count='exact')
+        if factory_id: q = q.eq('factory_id', factory_id)
+        q = q.order('created_at', desc=True).limit(limit)
+        r = q.execute()
+        return {'data': r.data or [], 'count': r.count}

--- a/services/document_engine_svc.py
+++ b/services/document_engine_svc.py
@@ -1,0 +1,461 @@
+"""TAI 문서엔진 서비스 v1.0.0
+
+Router = HTTP만, Service = 비즈니스 로직 (FastAPI import 금지)
+절대 금지: auto fill, auto approve, inferred default,
+           semantic match, fallback mapping, candidate→truth 승격
+"""
+from datetime import datetime, timezone
+from db.supabase_client import get_supabase
+
+
+# ═══════════════════════════════════════════════════════
+# 1. Runtime Form Schema 조회
+# ═══════════════════════════════════════════════════════
+
+def list_form_schemas(
+    document_family: str = None,
+    form_type: str = None,
+    status: str = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> dict:
+    sb = get_supabase()
+    q = sb.table("runtime_form_schema").select("*", count="exact")
+    if document_family:
+        q = q.eq("document_family", document_family)
+    if form_type:
+        q = q.eq("form_type", form_type)
+    if status:
+        q = q.eq("status", status)
+    offset = (page - 1) * page_size
+    q = q.order("document_family").order("form_name")
+    q = q.range(offset, offset + page_size - 1)
+    res = q.execute()
+    return {
+        "items": res.data or [],
+        "total": res.count or 0,
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+def get_form_schema_detail(schema_id: str) -> dict:
+    """schema + fields + checklists + evidence_fields 통합 조회"""
+    sb = get_supabase()
+    schema = (
+        sb.table("runtime_form_schema")
+        .select("*")
+        .eq("id", schema_id)
+        .single()
+        .execute()
+    )
+    if not schema.data:
+        return None
+    fields = (
+        sb.table("runtime_field")
+        .select("*")
+        .eq("form_schema_id", schema_id)
+        .order("field_order")
+        .execute()
+    )
+    checklists = (
+        sb.table("runtime_checklist_item")
+        .select("*")
+        .eq("form_schema_id", schema_id)
+        .order("item_order")
+        .execute()
+    )
+    evidence = (
+        sb.table("runtime_evidence_field")
+        .select("*")
+        .eq("form_schema_id", schema_id)
+        .execute()
+    )
+    return {
+        "schema": schema.data,
+        "fields": fields.data or [],
+        "checklists": checklists.data or [],
+        "evidence_fields": evidence.data or [],
+    }
+
+
+# ═══════════════════════════════════════════════════════
+# 2. Runtime Document CRUD
+# ═══════════════════════════════════════════════════════
+
+def create_document(
+    form_schema_id: str,
+    factory_id: str = None,
+    company_id: str = None,
+    created_by: str = None,
+) -> dict:
+    sb = get_supabase()
+    # schema 존재 확인
+    schema = (
+        sb.table("runtime_form_schema")
+        .select("id,status")
+        .eq("id", form_schema_id)
+        .single()
+        .execute()
+    )
+    if not schema.data:
+        raise ValueError(f"schema not found: {form_schema_id}")
+    now = datetime.now(timezone.utc).isoformat()
+    record = {
+        "form_schema_id": form_schema_id,
+        "runtime_data_json": {},
+        "evidence_links": [],
+        "status": "DRAFT",
+        "version": 1,
+        "created_at": now,
+        "updated_at": now,
+    }
+    if factory_id:
+        record["factory_id"] = factory_id
+    if company_id:
+        record["company_id"] = company_id
+    if created_by:
+        record["created_by"] = created_by
+    res = sb.table("runtime_document_data").insert(record).execute()
+    doc = res.data[0] if res.data else {}
+    if doc:
+        _audit(sb, doc["id"], "CREATED", created_by, None, doc)
+    return doc
+
+
+def get_document(doc_id: str) -> dict:
+    sb = get_supabase()
+    res = (
+        sb.table("runtime_document_data")
+        .select("*")
+        .eq("id", doc_id)
+        .single()
+        .execute()
+    )
+    return res.data
+
+
+def list_documents(
+    factory_id: str = None,
+    company_id: str = None,
+    status: str = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> dict:
+    sb = get_supabase()
+    q = sb.table("runtime_document_data").select(
+        "id,form_schema_id,factory_id,company_id,status,version,"
+        "created_at,updated_at",
+        count="exact",
+    )
+    if factory_id:
+        q = q.eq("factory_id", factory_id)
+    if company_id:
+        q = q.eq("company_id", company_id)
+    if status:
+        q = q.eq("status", status)
+    offset = (page - 1) * page_size
+    q = q.order("updated_at", desc=True).range(offset, offset + page_size - 1)
+    res = q.execute()
+    return {
+        "items": res.data or [],
+        "total": res.count or 0,
+        "page": page,
+        "page_size": page_size,
+    }
+
+
+def update_document(
+    doc_id: str,
+    runtime_data_json: dict = None,
+    evidence_links: list = None,
+    updated_by: str = None,
+) -> dict:
+    sb = get_supabase()
+    before = (
+        sb.table("runtime_document_data")
+        .select("*")
+        .eq("id", doc_id)
+        .single()
+        .execute()
+    )
+    if not before.data:
+        raise ValueError("document not found")
+    if before.data["status"] == "ARCHIVED":
+        raise ValueError("ARCHIVED document cannot be modified")
+    now = datetime.now(timezone.utc).isoformat()
+    update = {"updated_at": now}
+    changes = {}
+    if runtime_data_json is not None:
+        update["runtime_data_json"] = runtime_data_json
+        changes["runtime_data_json"] = True
+    if evidence_links is not None:
+        update["evidence_links"] = evidence_links
+        changes["evidence_links"] = True
+    if updated_by:
+        update["updated_by"] = updated_by
+    res = (
+        sb.table("runtime_document_data")
+        .update(update)
+        .eq("id", doc_id)
+        .execute()
+    )
+    doc = res.data[0] if res.data else {}
+    if doc:
+        _audit(sb, doc_id, "FIELD_EDIT", updated_by, before.data, doc, changes)
+    return doc
+
+
+# ═══════════════════════════════════════════════════════
+# 3. 상태 전이 (State Machine)
+# ═══════════════════════════════════════════════════════
+
+def get_transitions() -> list:
+    sb = get_supabase()
+    res = (
+        sb.table("runtime_state_transition_rule")
+        .select("*")
+        .order("from_status")
+        .execute()
+    )
+    return res.data or []
+
+
+def change_status(
+    doc_id: str,
+    to_status: str,
+    actor_id: str = None,
+    comment: str = None,
+) -> dict:
+    sb = get_supabase()
+    doc = (
+        sb.table("runtime_document_data")
+        .select("*")
+        .eq("id", doc_id)
+        .single()
+        .execute()
+    )
+    if not doc.data:
+        raise ValueError("document not found")
+    from_status = doc.data["status"]
+
+    # 전이 규칙 확인 — runtime_state_transition_rule 기준만
+    rule = (
+        sb.table("runtime_state_transition_rule")
+        .select("*")
+        .eq("from_status", from_status)
+        .eq("to_status", to_status)
+        .execute()
+    )
+    if not rule.data:
+        raise ValueError(
+            f"transition not allowed: {from_status} -> {to_status}"
+        )
+    rule_row = rule.data[0]
+
+    # Guardrail: reviewer 필수 / comment 필수 검증
+    if rule_row["requires_reviewer"] and not actor_id:
+        raise ValueError("reviewer_id required for this transition")
+    if rule_row["requires_comment"] and not comment:
+        raise ValueError("review_comment required for this transition")
+
+    now = datetime.now(timezone.utc).isoformat()
+    update = {"status": to_status, "updated_at": now}
+
+    if to_status == "SUBMITTED_FOR_REVIEW":
+        update["submitted_at"] = now
+        if actor_id:
+            update["submitted_by"] = actor_id
+    if to_status in (
+        "APPROVED_BY_HUMAN",
+        "REJECTED_BY_HUMAN",
+        "RETURNED_FOR_EDIT",
+    ):
+        update["reviewed_at"] = now
+        update["reviewed_by"] = actor_id
+        if comment:
+            update["review_comment"] = comment
+    if to_status == "ARCHIVED":
+        update["archived_at"] = now
+
+    res = (
+        sb.table("runtime_document_data")
+        .update(update)
+        .eq("id", doc_id)
+        .execute()
+    )
+    after = res.data[0] if res.data else {}
+    _audit(sb, doc_id, "STATUS_CHANGE", actor_id, doc.data, after)
+
+    # 승인/반려 시 approval 스냅샷
+    if to_status in ("APPROVED_BY_HUMAN", "REJECTED_BY_HUMAN") and actor_id:
+        action = "APPROVE" if to_status == "APPROVED_BY_HUMAN" else "REJECT"
+        _approval(sb, doc_id, actor_id, action, comment, doc.data)
+
+    return after
+
+
+# ═══════════════════════════════════════════════════════
+# 4. Evidence
+# ═══════════════════════════════════════════════════════
+
+def link_evidence(
+    doc_id: str,
+    evidence_type: str,
+    storage_path: str,
+    file_name: str = None,
+    file_size: int = None,
+    mime_type: str = None,
+    linked_field_id: str = None,
+    uploaded_by: str = None,
+) -> dict:
+    sb = get_supabase()
+    record = {
+        "document_data_id": doc_id,
+        "evidence_type": evidence_type,
+        "storage_path": storage_path,
+        "status": "LINKED",
+    }
+    if file_name:
+        record["file_name"] = file_name
+    if file_size is not None:
+        record["file_size"] = file_size
+    if mime_type:
+        record["mime_type"] = mime_type
+    if linked_field_id:
+        record["linked_field_id"] = linked_field_id
+    if uploaded_by:
+        record["uploaded_by"] = uploaded_by
+    res = sb.table("evidence_vault_link").insert(record).execute()
+    ev = res.data[0] if res.data else {}
+    if ev:
+        _audit(sb, doc_id, "EVIDENCE_UPLOAD", uploaded_by, None, ev)
+    return ev
+
+
+def list_evidence(doc_id: str) -> list:
+    sb = get_supabase()
+    res = (
+        sb.table("evidence_vault_link")
+        .select("*")
+        .eq("document_data_id", doc_id)
+        .order("uploaded_at", desc=True)
+        .execute()
+    )
+    return res.data or []
+
+
+# ═══════════════════════════════════════════════════════
+# 5. Generated Document
+# ═══════════════════════════════════════════════════════
+
+def generate_document(doc_id: str, export_type: str = "HTML") -> dict:
+    """입력된 값만 사용. auto fill / inferred summary 금지."""
+    sb = get_supabase()
+    doc = (
+        sb.table("runtime_document_data")
+        .select("*")
+        .eq("id", doc_id)
+        .single()
+        .execute()
+    )
+    if not doc.data:
+        raise ValueError("document not found")
+    record = {
+        "runtime_document_id": doc_id,
+        "form_schema_id": doc.data.get("form_schema_id"),
+        "export_type": export_type,
+        "status": "GENERATED",
+    }
+    res = sb.table("generated_document").insert(record).execute()
+    return res.data[0] if res.data else {}
+
+
+def list_generated(doc_id: str) -> list:
+    sb = get_supabase()
+    res = (
+        sb.table("generated_document")
+        .select("*")
+        .eq("runtime_document_id", doc_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+    return res.data or []
+
+
+# ═══════════════════════════════════════════════════════
+# 6. Metrics
+# ═══════════════════════════════════════════════════════
+
+def get_metrics() -> list:
+    sb = get_supabase()
+    res = sb.table("v_runtime_metrics").select("*").execute()
+    return res.data or []
+
+
+def get_metrics_by_factory(factory_id: str) -> list:
+    sb = get_supabase()
+    res = (
+        sb.table("v_runtime_metrics_by_factory")
+        .select("*")
+        .eq("factory_id", factory_id)
+        .execute()
+    )
+    return res.data or []
+
+
+# ═══════════════════════════════════════════════════════
+# 7. Audit Log
+# ═══════════════════════════════════════════════════════
+
+def get_audit_log(doc_id: str) -> list:
+    sb = get_supabase()
+    res = (
+        sb.table("runtime_lifecycle_audit_log")
+        .select("*")
+        .eq("runtime_document_id", doc_id)
+        .order("created_at", desc=True)
+        .execute()
+    )
+    return res.data or []
+
+
+# ═══════════════════════════════════════════════════════
+# Internal
+# ═══════════════════════════════════════════════════════
+
+def _audit(sb, doc_id, action, actor_id, before, after, field_changes=None):
+    """모든 상태 변경은 audit log 기록"""
+    try:
+        sb.table("runtime_lifecycle_audit_log").insert(
+            {
+                "runtime_document_id": doc_id,
+                "action": action,
+                "actor_id": actor_id,
+                "before_state": before,
+                "after_state": after,
+                "field_changes": field_changes,
+                "rollback_available": True,
+            }
+        ).execute()
+    except Exception:
+        pass  # audit 실패가 본 동작을 막지 않음
+
+
+def _approval(sb, doc_id, reviewer_id, action, comment, doc_data):
+    """승인/반려 시 스냅샷 저장. rollback 가능."""
+    try:
+        sb.table("runtime_document_approval").insert(
+            {
+                "runtime_document_id": doc_id,
+                "reviewer_id": reviewer_id,
+                "review_action": action,
+                "review_comment": comment,
+                "runtime_snapshot": doc_data.get("runtime_data_json"),
+                "evidence_snapshot": doc_data.get("evidence_links"),
+                "source_trace_snapshot": {},
+                "rollback_available": True,
+            }
+        ).execute()
+    except Exception:
+        pass

--- a/services/document_engine_svc.py
+++ b/services/document_engine_svc.py
@@ -1,8 +1,10 @@
-"""TAI 문서엔진 서비스 v1.0.0
+"""TAI 문서엔진 서비스 v1.1.0
 
 Router = HTTP만, Service = 비즈니스 로직 (FastAPI import 금지)
 절대 금지: auto fill, auto approve, inferred default,
            semantic match, fallback mapping, candidate→truth 승격
+
+v1.1.0: Audit 수정 — field_key 검증, evidence 검증, generate audit 추가
 """
 from datetime import datetime, timezone
 from db.supabase_client import get_supabase
@@ -90,7 +92,6 @@ def create_document(
     created_by: str = None,
 ) -> dict:
     sb = get_supabase()
-    # schema 존재 확인
     schema = (
         sb.table("runtime_form_schema")
         .select("id,status")
@@ -183,17 +184,27 @@ def update_document(
         raise ValueError("document not found")
     if before.data["status"] == "ARCHIVED":
         raise ValueError("ARCHIVED document cannot be modified")
+
+    schema_id = before.data["form_schema_id"]
     now = datetime.now(timezone.utc).isoformat()
     update = {"updated_at": now}
     changes = {}
+
+    # Guardrail: runtime_field에 존재하는 field_key만 저장
     if runtime_data_json is not None:
+        _validate_field_keys(sb, schema_id, runtime_data_json)
         update["runtime_data_json"] = runtime_data_json
         changes["runtime_data_json"] = True
+
+    # Guardrail: evidence_links의 linked_field_id 검증
     if evidence_links is not None:
+        _validate_evidence_links(sb, schema_id, evidence_links)
         update["evidence_links"] = evidence_links
         changes["evidence_links"] = True
+
     if updated_by:
         update["updated_by"] = updated_by
+
     res = (
         sb.table("runtime_document_data")
         .update(update)
@@ -368,7 +379,11 @@ def generate_document(doc_id: str, export_type: str = "HTML") -> dict:
         "status": "GENERATED",
     }
     res = sb.table("generated_document").insert(record).execute()
-    return res.data[0] if res.data else {}
+    gen = res.data[0] if res.data else {}
+    # v1.1.0: audit log 추가
+    if gen:
+        _audit(sb, doc_id, "CREATED", None, None, gen)
+    return gen
 
 
 def list_generated(doc_id: str) -> list:
@@ -421,7 +436,56 @@ def get_audit_log(doc_id: str) -> list:
 
 
 # ═══════════════════════════════════════════════════════
-# Internal
+# Internal — Validation
+# ═══════════════════════════════════════════════════════
+
+def _validate_field_keys(sb, schema_id: str, data_json: dict):
+    """runtime_field에 존재하는 field_key만 허용. 미등록 키 차단."""
+    if not data_json:
+        return
+    res = (
+        sb.table("runtime_field")
+        .select("field_key")
+        .eq("form_schema_id", schema_id)
+        .execute()
+    )
+    allowed = {r["field_key"] for r in (res.data or []) if r.get("field_key")}
+    if not allowed:
+        return  # field_key 없는 schema는 자유형 입력 허용
+    unknown = set(data_json.keys()) - allowed
+    if unknown:
+        raise ValueError(
+            f"unknown field_keys not in runtime_field: {sorted(unknown)}"
+        )
+
+
+def _validate_evidence_links(sb, schema_id: str, links: list):
+    """evidence_links 내 linked_field_id가 runtime_evidence_field에 존재하는지 검증."""
+    if not links:
+        return
+    field_ids = [
+        el.get("linked_field_id")
+        for el in links
+        if isinstance(el, dict) and el.get("linked_field_id")
+    ]
+    if not field_ids:
+        return
+    res = (
+        sb.table("runtime_evidence_field")
+        .select("id")
+        .eq("form_schema_id", schema_id)
+        .execute()
+    )
+    allowed = {str(r["id"]) for r in (res.data or [])}
+    unknown = set(field_ids) - allowed
+    if unknown:
+        raise ValueError(
+            f"unknown evidence field_ids not in runtime_evidence_field: {sorted(unknown)}"
+        )
+
+
+# ═══════════════════════════════════════════════════════
+# Internal — Audit & Approval
 # ═══════════════════════════════════════════════════════
 
 def _audit(sb, doc_id, action, actor_id, before, after, field_changes=None):

--- a/services/evidence_binding_engine.py
+++ b/services/evidence_binding_engine.py
@@ -1,0 +1,72 @@
+"""evidence_binding_engine.py — Evidence Binding (PHASE E)
+
+field ↔ evidence 연결 + 무결성 검증.
+"""
+from db.supabase_client import get_supabase
+from typing import Optional
+
+
+def get_evidence_for_document(document_type: str, tenant_context: dict) -> list:
+    """document_type에 연결된 evidence 목록 조회"""
+    sb = get_supabase()
+    facility_id = tenant_context.get("facility_id")
+    if not facility_id:
+        return []
+
+    result = sb.table("runtime_compliance_evidence").select(
+        "id, evidence_type, source_domain, evidence_status, uploaded_at, immutable_hash"
+    ).eq("source_entity_id", facility_id).order("uploaded_at", desc=True).limit(50).execute()
+
+    return result.data or []
+
+
+def bind_evidence_to_fields(sections: list, evidence_list: list) -> dict:
+    """field의 evidence_ref 타입 필드에 evidence 연결"""
+    bound = 0
+    orphan_evidence = []
+    missing_evidence = []
+
+    evidence_by_type = {}
+    for ev in evidence_list:
+        et = ev.get("evidence_type", "UNKNOWN")
+        if et not in evidence_by_type:
+            evidence_by_type[et] = []
+        evidence_by_type[et].append(ev)
+
+    for section in sections:
+        for field in section.get("fields", []):
+            if field.get("field_type") == "evidence_ref" or field.get("field_type") == "image":
+                # evidence 연결 시도
+                field_evidence = evidence_by_type.get(field.get("field_code", "").upper(), [])
+                if not field_evidence:
+                    # 일반 매칭
+                    field_evidence = evidence_by_type.get("PHOTO", []) or evidence_by_type.get("DOCUMENT", [])
+
+                if field_evidence:
+                    field["evidence_bound"] = True
+                    field["evidence_count"] = len(field_evidence)
+                    field["evidence_ids"] = [e["id"] for e in field_evidence[:5]]
+                    bound += 1
+                else:
+                    field["evidence_bound"] = False
+                    field["evidence_count"] = 0
+                    if field.get("required_level") == "MANDATORY":
+                        missing_evidence.append(field.get("field_code"))
+
+    # orphan evidence: 어떤 필드에도 연결 안 된 증빙
+    used_types = set()
+    for section in sections:
+        for field in section.get("fields", []):
+            if field.get("evidence_bound"):
+                used_types.add(field.get("field_code", "").upper())
+
+    for et, evs in evidence_by_type.items():
+        if et not in used_types and et not in ("PHOTO", "DOCUMENT"):
+            orphan_evidence.extend([e["id"] for e in evs])
+
+    return {
+        "bound_count": bound,
+        "missing_evidence_fields": missing_evidence,
+        "orphan_evidence_ids": orphan_evidence[:10],
+        "total_evidence": len(evidence_list),
+    }

--- a/services/field_completeness_engine.py
+++ b/services/field_completeness_engine.py
@@ -1,0 +1,95 @@
+"""field_completeness_engine.py — Field-level Completeness (PHASE D)
+
+field 단위 completeness 계산.
+"""
+import json
+from typing import Optional
+
+
+def evaluate_field_completeness(field: dict) -> dict:
+    """single field의 completeness 평가"""
+    value = field.get("value")
+    required = field.get("required_level", "OPTIONAL")
+    field_type = field.get("field_type", "text")
+    validation = field.get("validation_rule")
+
+    # NULL/empty 검사
+    is_empty = value is None or (isinstance(value, str) and not value.strip())
+
+    if is_empty:
+        if required == "MANDATORY":
+            return {"status": "FAIL", "reason": "mandatory_field_empty"}
+        elif required == "RECOMMENDED":
+            return {"status": "WARNING", "reason": "recommended_field_empty"}
+        else:
+            return {"status": "PASS", "reason": "optional_field_empty"}
+
+    # validation rule 검사
+    if validation:
+        rules = validation if isinstance(validation, dict) else json.loads(validation)
+        rule_list = rules.get("rules", [])
+
+        for r in rule_list:
+            if r == "numeric":
+                try:
+                    float(value)
+                except (ValueError, TypeError):
+                    return {"status": "FAIL", "reason": "invalid_numeric_value"}
+            elif r == "non_empty":
+                if is_empty:
+                    return {"status": "FAIL", "reason": "non_empty_validation_fail"}
+            elif r == "signature_required":
+                if is_empty:
+                    return {"status": "FAIL", "reason": "signature_missing"}
+            elif r == "evidence_required":
+                if is_empty:
+                    return {"status": "FAIL", "reason": "evidence_missing"}
+
+    return {"status": "PASS", "reason": "field_valid"}
+
+
+def calculate_document_completeness(sections: list) -> dict:
+    """문서 전체 completeness 계산"""
+    total = mandatory = recommended = optional = 0
+    mandatory_pass = recommended_pass = 0
+    fails = []
+    warnings = []
+
+    for section in sections:
+        for field in section.get("fields", []):
+            if not field.get("visible", True):
+                continue  # 조건부로 숨겨진 필드 제외
+
+            comp = evaluate_field_completeness(field)
+            field["completeness"] = comp
+            total += 1
+
+            req = field.get("required_level", "OPTIONAL")
+            if req == "MANDATORY":
+                mandatory += 1
+                if comp["status"] == "PASS":
+                    mandatory_pass += 1
+                else:
+                    fails.append({"field": field.get("field_code"), "reason": comp["reason"]})
+            elif req == "RECOMMENDED":
+                recommended += 1
+                if comp["status"] == "PASS":
+                    recommended_pass += 1
+                else:
+                    warnings.append({"field": field.get("field_code"), "reason": comp["reason"]})
+            else:
+                optional += 1
+
+    mandatory_pct = (mandatory_pass / mandatory * 100) if mandatory > 0 else 100
+    recommended_pct = (recommended_pass / recommended * 100) if recommended > 0 else 100
+    creatable = mandatory_pct == 100
+
+    return {
+        "total_fields": total,
+        "mandatory": {"total": mandatory, "pass": mandatory_pass, "pct": round(mandatory_pct, 1)},
+        "recommended": {"total": recommended, "pass": recommended_pass, "pct": round(recommended_pct, 1)},
+        "optional_count": optional,
+        "creatable": creatable,
+        "fails": fails[:20],
+        "warnings": warnings[:20],
+    }

--- a/services/notification_engine/adapters/push.py
+++ b/services/notification_engine/adapters/push.py
@@ -1,15 +1,30 @@
-"""Push (FCM) Delivery Adapter — Mock Phase.
+"""Push (FCM) Delivery Adapter — Compat Phase.
 
-Phase 1: Mock logging only.
-Phase 2: 실제 FCM 연동 예정.
+기존 fcm_utils.send_push()를 Notification Runtime Adapter로 래핑.
+새 Push 시스템 구축 불필요 — 기존 인프라 그대로 사용.
 
-Adapter Interface: send_push(token, title, body, data) -> (success, error)
+Adapter Interface: send(message, context) -> (success, error)
 """
 
 import logging
 from typing import Tuple, Optional, Dict, Any
 
 logger = logging.getLogger("notification_engine.adapters.push")
+
+VERSION = "2.0.0"  # Mock → Compat (fcm_utils 실연결)
+
+
+def _get_fcm_send():
+    """fcm_utils.send_push 동적 import (firebase-admin 미설치 환경 대비)."""
+    try:
+        from utils.fcm_utils import send_push as fcm_send
+        return fcm_send
+    except ImportError:
+        logger.warning("Push adapter: fcm_utils not available (firebase-admin missing?)")
+        return None
+    except Exception as e:
+        logger.error("Push adapter: fcm_utils import failed: %s", e)
+        return None
 
 
 def send_push(
@@ -18,10 +33,7 @@ def send_push(
     body: str,
     data: Optional[Dict[str, Any]] = None,
 ) -> Tuple[bool, Optional[str]]:
-    """FCM Push 발송 (Mock).
-
-    Phase 1: 실제 FCM 연동 없이 로깅만 수행.
-    Phase 2: firebase-admin SDK 연동 예정.
+    """FCM Push 발송 — 기존 fcm_utils.send_push() 위임.
 
     Args:
         fcm_token: 대상 디바이스 FCM 토큰
@@ -36,16 +48,37 @@ def send_push(
         logger.warning("Push adapter: empty fcm_token")
         return False, "Empty FCM token"
 
-    # ── Mock Phase: 로깅만 수행 ──
-    logger.info(
-        "[MOCK PUSH] token=%s... title=%s body=%s data=%s",
-        fcm_token[:20] if len(fcm_token) > 20 else fcm_token,
-        title[:50],
-        body[:80],
-        data,
-    )
+    fcm_send = _get_fcm_send()
+    if not fcm_send:
+        # fallback: mock logging
+        logger.info(
+            "[MOCK PUSH] fcm_utils unavailable — token=%s... title=%s",
+            fcm_token[:20] if len(fcm_token) > 20 else fcm_token,
+            title[:50],
+        )
+        return True, None  # mock success
 
-    return True, None
+    try:
+        message_id = fcm_send(
+            fcm_token=fcm_token,
+            title=title,
+            body=body,
+            data=data or {},
+        )
+        logger.info(
+            "[PUSH] sent token=%s... title=%s message_id=%s",
+            fcm_token[:20] if len(fcm_token) > 20 else fcm_token,
+            title[:50],
+            message_id,
+        )
+        return True, None
+    except Exception as e:
+        logger.error(
+            "[PUSH] failed token=%s... error=%s",
+            fcm_token[:20] if len(fcm_token) > 20 else fcm_token,
+            e,
+        )
+        return False, str(e)
 
 
 def send(

--- a/services/notification_engine/adapters/push.py
+++ b/services/notification_engine/adapters/push.py
@@ -1,0 +1,77 @@
+"""Push (FCM) Delivery Adapter — Mock Phase.
+
+Phase 1: Mock logging only.
+Phase 2: 실제 FCM 연동 예정.
+
+Adapter Interface: send_push(token, title, body, data) -> (success, error)
+"""
+
+import logging
+from typing import Tuple, Optional, Dict, Any
+
+logger = logging.getLogger("notification_engine.adapters.push")
+
+
+def send_push(
+    fcm_token: str,
+    title: str,
+    body: str,
+    data: Optional[Dict[str, Any]] = None,
+) -> Tuple[bool, Optional[str]]:
+    """FCM Push 발송 (Mock).
+
+    Phase 1: 실제 FCM 연동 없이 로깅만 수행.
+    Phase 2: firebase-admin SDK 연동 예정.
+
+    Args:
+        fcm_token: 대상 디바이스 FCM 토큰
+        title: 알림 제목
+        body: 알림 본문
+        data: 추가 데이터 (optional)
+
+    Returns:
+        (success: bool, error_message: str|None)
+    """
+    if not fcm_token:
+        logger.warning("Push adapter: empty fcm_token")
+        return False, "Empty FCM token"
+
+    # ── Mock Phase: 로깅만 수행 ──
+    logger.info(
+        "[MOCK PUSH] token=%s... title=%s body=%s data=%s",
+        fcm_token[:20] if len(fcm_token) > 20 else fcm_token,
+        title[:50],
+        body[:80],
+        data,
+    )
+
+    return True, None
+
+
+def send(
+    message: str,
+    context: Optional[Dict[str, Any]] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Notification Engine Adapter Interface.
+
+    worker.py에서 channel_key='PUSH'일 때 호출.
+    context에 fcm_token, title, body 포함.
+
+    Args:
+        message: 발송 메시지 (body fallback)
+        context: {fcm_token, title, body, data}
+
+    Returns:
+        (success: bool, error_message: str|None)
+    """
+    ctx = context or {}
+    fcm_token = ctx.get("fcm_token", "")
+    title = ctx.get("title", "TAI Safe 알림")
+    body = ctx.get("body", message)
+    data = ctx.get("data")
+
+    if not fcm_token:
+        logger.warning("Push adapter: no fcm_token in context")
+        return False, "No FCM token in delivery context"
+
+    return send_push(fcm_token, title, body, data)

--- a/services/notification_engine/audience_resolver.py
+++ b/services/notification_engine/audience_resolver.py
@@ -1,0 +1,146 @@
+"""Audience Resolver Foundation.
+
+audience_key → actor list resolve.
+
+Phase 1: Mock + passthrough 기반.
+Phase 2: Identity Core 연동.
+
+역할: 누구에게 전달할지 결정. Permission 판단 금지.
+"""
+
+import logging
+from typing import List, Dict, Any, Optional
+from db.supabase_client import get_supabase
+
+logger = logging.getLogger("notification_engine.audience_resolver")
+
+# 표준 Audience 유형
+AUDIENCE_TYPES = {
+    "operator": "운영자 (안전관리자)",
+    "tenant_admin": "테넌트 관리자 (회사 대표)",
+    "safety_manager": "안전관리자",
+    "company_admin": "회사 관리자",
+    "worker": "작업자",
+    "inspector": "점검자",
+    "site_all": "현장 전체",
+    "system_admin": "시스템 관리자",
+    "platform_admin": "플랫폼 관리자",
+}
+
+
+async def resolve_audience(
+    audience_key: str,
+    tenant_id: Optional[str] = None,
+    factory_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """audience_key로 대상 actor 목록 반환.
+
+    Phase 1: 간단 DB 조회 + fallback.
+    Phase 2: Identity Core 연동.
+
+    Args:
+        audience_key: operator / tenant_admin / worker 등
+        tenant_id: 회사 ID (optional)
+        factory_id: 시설 ID (optional)
+
+    Returns:
+        [{actor_id, name, phone, email, role_code, audience_key}]
+    """
+    try:
+        # system_admin / platform_admin: 고정 대상
+        if audience_key in ("system_admin", "platform_admin"):
+            return _resolve_system_admin()
+
+        # tenant 기반 조회
+        if tenant_id:
+            return await _resolve_by_tenant(audience_key, tenant_id, factory_id)
+
+        # fallback: audience_key만 반환 (passthrough)
+        logger.info("Audience passthrough: %s (no tenant_id)", audience_key)
+        return [{
+            "actor_id": None,
+            "audience_key": audience_key,
+            "name": AUDIENCE_TYPES.get(audience_key, audience_key),
+            "resolved": False,
+        }]
+
+    except Exception as e:
+        logger.error("Audience resolve failed: %s %s", audience_key, e)
+        return []
+
+
+def _resolve_system_admin() -> List[Dict[str, Any]]:
+    """system_admin: role_code='001' 사용자."""
+    try:
+        sb = get_supabase()
+        resp = (
+            sb.table("users")
+            .select("id, name, phone, email, role_code")
+            .eq("role_code", "001")
+            .execute()
+        )
+        return [
+            {
+                "actor_id": u["id"],
+                "name": u.get("name"),
+                "phone": u.get("phone"),
+                "email": u.get("email"),
+                "role_code": u.get("role_code"),
+                "audience_key": "system_admin",
+                "resolved": True,
+            }
+            for u in (resp.data or [])
+        ]
+    except Exception as e:
+        logger.error("system_admin resolve failed: %s", e)
+        return []
+
+
+async def _resolve_by_tenant(
+    audience_key: str, tenant_id: str, factory_id: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """tenant 기반 audience resolve."""
+    try:
+        sb = get_supabase()
+
+        # role_code 매핑
+        role_map = {
+            "operator": ["002", "003"],       # 안전관리자, 관리책임자
+            "tenant_admin": ["003"],           # 관리책임자
+            "safety_manager": ["002"],         # 안전관리자
+            "company_admin": ["003"],          # 관리책임자
+            "worker": ["004", "005"],          # 작업자, 근로자
+            "inspector": ["002", "006"],       # 안전관리자, 점검원
+            "site_all": ["002", "003", "004", "005", "006"],
+        }
+
+        roles = role_map.get(audience_key, ["002"])
+
+        q = (
+            sb.table("users")
+            .select("id, name, phone, email, role_code, company_id")
+            .eq("company_id", tenant_id)
+            .in_("role_code", roles)
+        )
+
+        resp = q.execute()
+        return [
+            {
+                "actor_id": u["id"],
+                "name": u.get("name"),
+                "phone": u.get("phone"),
+                "email": u.get("email"),
+                "role_code": u.get("role_code"),
+                "audience_key": audience_key,
+                "resolved": True,
+            }
+            for u in (resp.data or [])
+        ]
+    except Exception as e:
+        logger.error("tenant audience resolve failed: %s %s %s", audience_key, tenant_id, e)
+        return []
+
+
+async def list_audience_types() -> Dict[str, str]:
+    """표준 Audience 유형 목록."""
+    return AUDIENCE_TYPES

--- a/services/notification_engine/digest_runtime.py
+++ b/services/notification_engine/digest_runtime.py
@@ -1,0 +1,146 @@
+"""Digest Runtime Service.
+
+event → digest policy lookup → digest queue append.
+
+Phase 1: Shadow mode — queue 저장만, 실제 묶음 발송 금지.
+
+역할: 전달 밀도 조절. 이벤트 의미 변경 금지.
+"""
+
+import logging
+from typing import Optional, Dict, Any, List
+from db.supabase_client import get_supabase
+
+logger = logging.getLogger("notification_engine.digest_runtime")
+
+
+async def lookup_digest_policy(
+    source_type: Optional[str] = None,
+    event_type: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Digest 정책 조회. source_type 또는 event_type 매치."""
+    try:
+        sb = get_supabase()
+        q = sb.table("notification_digest_policy_registry").select("*").eq("enabled", True)
+
+        if event_type:
+            resp = q.eq("event_type", event_type).execute()
+            if resp.data:
+                return resp.data[0]
+
+        if source_type:
+            resp2 = (
+                sb.table("notification_digest_policy_registry")
+                .select("*")
+                .eq("enabled", True)
+                .eq("source_type", source_type)
+                .execute()
+            )
+            if resp2.data:
+                return resp2.data[0]
+
+        return None
+    except Exception as e:
+        logger.error("Digest policy lookup failed: %s", e)
+        return None
+
+
+async def append_digest_candidate(
+    digest_policy_key: str,
+    grouped_key: str,
+    trace_id: Optional[str] = None,
+    event_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Digest queue에 후보 저장."""
+    try:
+        sb = get_supabase()
+        row = {
+            "digest_policy_key": digest_policy_key,
+            "grouped_key": grouped_key,
+            "digest_status": "PENDING",
+        }
+        if trace_id:
+            row["trace_id"] = trace_id
+        if event_id:
+            row["event_id"] = event_id
+
+        resp = sb.table("runtime_notification_digest_queue").insert(row).execute()
+        if resp.data:
+            logger.info(
+                "[DIGEST] candidate appended: policy=%s key=%s",
+                digest_policy_key,
+                grouped_key,
+            )
+            return resp.data[0]
+        return None
+    except Exception as e:
+        logger.error("Digest candidate append failed: %s", e)
+        return None
+
+
+async def check_and_append(
+    source_type: Optional[str] = None,
+    event_type: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    event_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Digest 정책 확인 후 queue append. Shadow mode."""
+    policy = await lookup_digest_policy(source_type=source_type, event_type=event_type)
+
+    if not policy:
+        return {"digest": False, "reason": "no_matching_policy"}
+
+    # grouping key 계산
+    gk_field = policy.get("grouping_key", "source_type")
+    grouped_key = (metadata or {}).get(gk_field) or source_type or event_type or "unknown"
+
+    result = await append_digest_candidate(
+        digest_policy_key=policy["digest_policy_key"],
+        grouped_key=grouped_key,
+        trace_id=trace_id,
+        event_id=event_id,
+    )
+
+    return {
+        "digest": True,
+        "digest_policy_key": policy["digest_policy_key"],
+        "grouped_key": grouped_key,
+        "shadow_mode": True,
+        "queued": result is not None,
+    }
+
+
+async def list_digest_policies(enabled_only: bool = True) -> List[Dict[str, Any]]:
+    """Digest 정책 목록."""
+    try:
+        sb = get_supabase()
+        q = sb.table("notification_digest_policy_registry").select("*")
+        if enabled_only:
+            q = q.eq("enabled", True)
+        resp = q.order("digest_policy_key").execute()
+        return resp.data or []
+    except Exception as e:
+        logger.error("List digest policies failed: %s", e)
+        return []
+
+
+async def list_digest_candidates(
+    status: str = "PENDING",
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    """Digest queue 후보 목록."""
+    try:
+        sb = get_supabase()
+        resp = (
+            sb.table("runtime_notification_digest_queue")
+            .select("*")
+            .eq("digest_status", status)
+            .order("queued_at", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return resp.data or []
+    except Exception as e:
+        logger.error("List digest candidates failed: %s", e)
+        return []

--- a/services/notification_engine/event_wiring.py
+++ b/services/notification_engine/event_wiring.py
@@ -1,0 +1,151 @@
+"""Event Wiring Service.
+
+event_type → wiring registry lookup → policy resolve → runtime emit.
+
+역할: 이벤트를 정책에 연결. 운영 판단 금지.
+"""
+
+import logging
+from typing import Optional, Dict, Any, List
+from db.supabase_client import get_supabase
+
+logger = logging.getLogger("notification_engine.event_wiring")
+
+
+async def lookup_wiring(event_type: str) -> Optional[Dict[str, Any]]:
+    """event_type으로 wiring registry 조회."""
+    try:
+        sb = get_supabase()
+        resp = (
+            sb.table("notification_event_wiring_registry")
+            .select("*")
+            .eq("event_type", event_type)
+            .eq("enabled", True)
+            .execute()
+        )
+        if resp.data:
+            return resp.data[0]
+        return None
+    except Exception as e:
+        logger.error("Wiring lookup failed for %s: %s", event_type, e)
+        return None
+
+
+async def resolve_policy(policy_key: str) -> Optional[Dict[str, Any]]:
+    """policy_key로 정책 조회."""
+    try:
+        sb = get_supabase()
+        resp = (
+            sb.table("notification_policy_registry")
+            .select("*")
+            .eq("policy_key", policy_key)
+            .execute()
+        )
+        if resp.data:
+            return resp.data[0]
+        return None
+    except Exception as e:
+        logger.error("Policy resolve failed for %s: %s", policy_key, e)
+        return None
+
+
+async def wire_and_emit(
+    event_type: str,
+    payload: Optional[Dict[str, Any]] = None,
+    override_channel: Optional[str] = None,
+    override_severity: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Event → Wiring → Policy → Runtime Emit.
+
+    Args:
+        event_type: 이벤트 유형 (e.g. 'workflow_stuck')
+        payload: 이벤트 데이터
+        override_channel: 채널 오버라이드
+        override_severity: severity 오버라이드
+
+    Returns:
+        {status, wiring_key, policy_key, emitted}
+    """
+    # 1. Wiring lookup
+    wiring = await lookup_wiring(event_type)
+    if not wiring:
+        logger.info("No active wiring for event_type=%s", event_type)
+        return {"status": "skipped", "reason": "no_wiring", "event_type": event_type}
+
+    # 2. Policy resolve
+    policy = await resolve_policy(wiring["notification_policy_key"])
+    if not policy:
+        logger.warning("Policy not found: %s", wiring["notification_policy_key"])
+        return {"status": "error", "reason": "policy_not_found", "policy_key": wiring["notification_policy_key"]}
+
+    # 3. Cooldown check (wiring override > policy default)
+    cooldown = wiring.get("cooldown_seconds") or policy.get("cooldown_seconds", 0)
+    # TODO: cooldown 실제 검사 (last_sent 테이블 필요)
+
+    # 4. Build emit params
+    channel = override_channel or policy["default_channel"]
+    severity = override_severity or policy["default_severity"]
+    audience = wiring.get("audience_key", "operator")
+
+    title = (payload or {}).get("title", f"[{severity}] {event_type}")
+    body = (payload or {}).get("body", f"Event: {event_type}")
+
+    # 5. Emit via pipeline
+    try:
+        from services.notification_engine.pipeline import emit_notification
+
+        result = await emit_notification(
+            source_type=event_type,
+            title=title,
+            body=body,
+            severity=severity,
+            channel_key=channel,
+            target_type="role",
+            target_id=audience,
+            metadata={
+                "wiring_key": wiring["wiring_key"],
+                "policy_key": policy["policy_key"],
+                "source_engine": wiring["source_engine"],
+                "payload": payload,
+            },
+            force_quiet_hour=policy.get("quiet_hour_bypass", False),
+        )
+
+        return {
+            "status": "emitted",
+            "wiring_key": wiring["wiring_key"],
+            "policy_key": policy["policy_key"],
+            "channel": channel,
+            "severity": severity,
+            "audience": audience,
+            "cooldown": cooldown,
+            "emit_result": result,
+        }
+    except Exception as e:
+        logger.error("Emit failed for wiring %s: %s", wiring["wiring_key"], e)
+        return {"status": "error", "reason": str(e), "wiring_key": wiring["wiring_key"]}
+
+
+async def list_wirings(enabled_only: bool = True) -> List[Dict[str, Any]]:
+    """Wiring 목록 조회."""
+    try:
+        sb = get_supabase()
+        q = sb.table("notification_event_wiring_registry").select("*")
+        if enabled_only:
+            q = q.eq("enabled", True)
+        resp = q.order("source_engine").execute()
+        return resp.data or []
+    except Exception as e:
+        logger.error("List wirings failed: %s", e)
+        return []
+
+
+async def list_policies() -> List[Dict[str, Any]]:
+    """정책 목록 조회."""
+    try:
+        sb = get_supabase()
+        resp = sb.table("notification_policy_registry").select("*").order("policy_key").execute()
+        return resp.data or []
+    except Exception as e:
+        logger.error("List policies failed: %s", e)
+        return []

--- a/services/persistence_svc.py
+++ b/services/persistence_svc.py
@@ -1,0 +1,189 @@
+"""TAI Persistence & Drift Control Engine v1.0.0
+장기 운영 deterministic consistency 유지.
+금지: semantic repair, auto schedule repair, inferred reactivation,
+      hidden normalization, auto conflict resolve
+"""
+import hashlib,json
+from datetime import datetime,timezone
+from db.supabase_client import get_supabase
+from services import runtime_evaluator_svc as evaluator
+
+
+# ═══ 2. Snapshot Versioning (immutable) ═══
+
+def create_snapshot(facility_id, eval_ctx_id=None):
+    """evaluation 결과를 immutable snapshot으로 저장. overwrite 금지."""
+    sb = get_supabase()
+    if not eval_ctx_id: raise ValueError("evaluation_context_id required")
+    result = evaluator.get_result(eval_ctx_id)
+    if not result: raise ValueError("evaluation result not found")
+    summary = {
+        "rules": len(result.get("rules", [])),
+        "tasks": len(result.get("tasks", [])),
+        "documents": len(result.get("documents", [])),
+        "schedules": len(result.get("schedules", [])),
+        "penalties": len(result.get("penalties", [])),
+        "conflicts": len(result.get("conflicts", [])),
+    }
+    snapshot_data = {
+        "rules": [r.get("id") for r in result.get("rules", []) if r.get("status") == "ACTIVE"],
+        "tasks": [t.get("id") for t in result.get("tasks", []) if t.get("status") == "ACTIVE"],
+        "documents": [d.get("id") for d in result.get("documents", []) if d.get("status") == "ACTIVE"],
+        "schedules": [s.get("id") for s in result.get("schedules", []) if s.get("status") == "ACTIVE"],
+        "penalties": [p.get("id") for p in result.get("penalties", []) if p.get("status") == "POTENTIAL"],
+        "unknowns": [r.get("id") for r in result.get("rules", []) if r.get("status") == "UNKNOWN"],
+    }
+    rh = hashlib.sha256(json.dumps(snapshot_data, sort_keys=True, default=str).encode()).hexdigest()[:16]
+    # version
+    ver_r = sb.table("runtime_activation_snapshot").select("runtime_version").eq("facility_id", facility_id).order("runtime_version", desc=True).limit(1).execute()
+    ver = (ver_r.data[0]["runtime_version"] + 1) if ver_r.data else 1
+    rec = {
+        "facility_id": facility_id, "evaluation_context_id": eval_ctx_id,
+        "runtime_version": ver, "activation_snapshot": snapshot_data, "result_hash": rh,
+        "rules_active": len(snapshot_data["rules"]), "tasks_active": len(snapshot_data["tasks"]),
+        "documents_active": len(snapshot_data["documents"]), "schedules_active": len(snapshot_data["schedules"]),
+        "penalties_potential": len(snapshot_data["penalties"]), "conflicts_count": summary["conflicts"],
+        "unknowns_count": len(snapshot_data["unknowns"]), "is_immutable": True,
+    }
+    r = sb.table("runtime_activation_snapshot").insert(rec).execute()
+    snap = r.data[0] if r.data else {}
+    # version record
+    if snap:
+        sb.table("runtime_runtime_version").insert({"facility_id": facility_id, "version_number": ver, "snapshot_id": snap["id"], "trigger_reason": "evaluation"}).execute()
+        _p_audit(sb, facility_id, None, "SNAPSHOT_CREATED", {"version": ver, "hash": rh})
+        _p_audit(sb, facility_id, None, "VERSION_INCREMENTED", {"version": ver})
+    return snap
+
+
+# ═══ 3. Diff Engine (실제 변화만 기록) ═══
+
+def compute_diff(facility_id, current_snapshot_id):
+    """snapshot 간 diff. semantic diff / guessed change 금지."""
+    sb = get_supabase()
+    cur = sb.table("runtime_activation_snapshot").select("*").eq("id", current_snapshot_id).single().execute()
+    if not cur.data: raise ValueError("current snapshot not found")
+    # 직전 snapshot
+    prev_r = sb.table("runtime_activation_snapshot").select("*").eq("facility_id", facility_id).lt("runtime_version", cur.data["runtime_version"]).order("runtime_version", desc=True).limit(1).execute()
+    prev = prev_r.data[0] if prev_r.data else None
+    cur_snap = cur.data.get("activation_snapshot", {})
+    prev_snap = prev.get("activation_snapshot", {}) if prev else {}
+    diff = {
+        "facility_id": facility_id,
+        "previous_snapshot_id": prev["id"] if prev else None,
+        "current_snapshot_id": current_snapshot_id,
+        "new_rules": [x for x in cur_snap.get("rules", []) if x not in prev_snap.get("rules", [])],
+        "removed_rules": [x for x in prev_snap.get("rules", []) if x not in cur_snap.get("rules", [])],
+        "new_tasks": [x for x in cur_snap.get("tasks", []) if x not in prev_snap.get("tasks", [])],
+        "removed_tasks": [x for x in prev_snap.get("tasks", []) if x not in cur_snap.get("tasks", [])],
+        "new_documents": [x for x in cur_snap.get("documents", []) if x not in prev_snap.get("documents", [])],
+        "removed_documents": [x for x in prev_snap.get("documents", []) if x not in cur_snap.get("documents", [])],
+        "new_schedules": [x for x in cur_snap.get("schedules", []) if x not in prev_snap.get("schedules", [])],
+        "removed_schedules": [x for x in prev_snap.get("schedules", []) if x not in cur_snap.get("schedules", [])],
+    }
+    diff["has_changes"] = any(diff[k] for k in ["new_rules","removed_rules","new_tasks","removed_tasks","new_documents","removed_documents","new_schedules","removed_schedules"])
+    r = sb.table("runtime_activation_diff").insert(diff).execute()
+    row = r.data[0] if r.data else diff
+    _p_audit(sb, facility_id, None, "DIFF_COMPUTED", {"has_changes": diff["has_changes"]})
+    return row
+
+
+# ═══ 4. Incremental Re-Evaluation (부분 재평가, full rebuild 금지) ═══
+
+def queue_re_evaluation(facility_id, trigger_type, trigger_detail=None):
+    sb = get_supabase()
+    affected = []
+    if trigger_type in ("EQUIPMENT_ADDED","HAZARDOUS_MATERIAL_ADDED"): affected = ["rules","tasks","schedules","penalties"]
+    elif trigger_type in ("WORKER_COUNT_CHANGED",): affected = ["rules","tasks"]
+    elif trigger_type in ("CONTRACTOR_ADDED",): affected = ["rules","tasks","documents"]
+    elif trigger_type in ("ACCIDENT_OCCURRED",): affected = ["rules","tasks","penalties","documents"]
+    elif trigger_type in ("FACILITY_SHUTDOWN",): affected = ["rules","schedules"]
+    elif trigger_type in ("CONSTRUCTION_STARTED",): affected = ["rules","tasks","schedules","documents"]
+    elif trigger_type in ("SCHEDULE_EXPIRED",): affected = ["schedules"]
+    else: affected = ["rules"]
+    rec = {
+        "facility_id": facility_id, "trigger_type": trigger_type,
+        "trigger_detail": trigger_detail or {}, "affected_modules": affected, "status": "PENDING",
+    }
+    r = sb.table("runtime_re_evaluation_queue").insert(rec).execute()
+    row = r.data[0] if r.data else rec
+    _p_audit(sb, facility_id, row.get("id"), "RE_EVAL_QUEUED", {"trigger": trigger_type, "modules": affected})
+    return row
+
+
+def list_re_evaluation_queue(facility_id=None, status=None, page=1, page_size=20):
+    sb = get_supabase()
+    q = sb.table("runtime_re_evaluation_queue").select("*", count="exact")
+    if facility_id: q = q.eq("facility_id", facility_id)
+    if status: q = q.eq("status", status)
+    o = (page-1)*page_size
+    q = q.order("created_at", desc=True).range(o, o+page_size-1)
+    r = q.execute()
+    return {"items": r.data or [], "total": r.count or 0}
+
+
+# ═══ 5. Schedule Persistence (중복 생성 금지) ═══
+
+def create_schedule_instance(facility_id, schedule_type, schedule_key, next_due_date=None, schedule_activation_id=None):
+    """schedule instance 생성. 동일 facility+key 중복 차단."""
+    sb = get_supabase()
+    existing = sb.table("runtime_schedule_instance").select("id").eq("facility_id", facility_id).eq("schedule_key", schedule_key).eq("status", "ACTIVE").execute()
+    if existing.data:
+        _p_audit(sb, facility_id, None, "SCHEDULE_DUPLICATE_BLOCKED", {"key": schedule_key})
+        raise ValueError(f"duplicate schedule: {schedule_key} already ACTIVE for facility")
+    rec = {
+        "facility_id": facility_id, "schedule_activation_id": schedule_activation_id,
+        "schedule_type": schedule_type, "schedule_key": schedule_key,
+        "next_due_date": next_due_date, "status": "ACTIVE",
+    }
+    r = sb.table("runtime_schedule_instance").insert(rec).execute()
+    inst = r.data[0] if r.data else rec
+    if inst.get("id"):
+        sb.table("runtime_schedule_history").insert({"schedule_instance_id": inst["id"], "action": "CREATED", "detail": {"key": schedule_key}}).execute()
+        _p_audit(sb, facility_id, None, "SCHEDULE_CREATED", {"key": schedule_key, "type": schedule_type})
+    return inst
+
+
+# ═══ 6. Drift Detector ═══
+
+def check_drift(facility_id):
+    """동일 입력 반복 평가 시 drift 검출. 동일이면 동일 결과."""
+    sb = get_supabase()
+    snaps = sb.table("runtime_activation_snapshot").select("id,result_hash,runtime_version").eq("facility_id", facility_id).order("runtime_version", desc=True).limit(2).execute()
+    if not snaps.data or len(snaps.data) < 2:
+        return {"facility_id": facility_id, "drift_detected": False, "reason": "insufficient snapshots"}
+    cur = snaps.data[0]
+    prev = snaps.data[1]
+    drift = cur["result_hash"] != prev["result_hash"]
+    rec = {
+        "facility_id": facility_id,
+        "previous_result_hash": prev["result_hash"],
+        "current_result_hash": cur["result_hash"],
+        "drift_detected": drift,
+        "drift_detail": {"prev_version": prev["runtime_version"], "cur_version": cur["runtime_version"]},
+    }
+    sb.table("runtime_drift_detection_log").insert(rec).execute()
+    action = "DRIFT_DETECTED" if drift else "DRIFT_CLEAR"
+    _p_audit(sb, facility_id, None, action, {"prev_hash": prev["result_hash"], "cur_hash": cur["result_hash"]})
+    return {"facility_id": facility_id, "drift_detected": drift, "prev_hash": prev["result_hash"], "cur_hash": cur["result_hash"]}
+
+
+# ═══ 7. Long-Term Audit ═══
+
+def get_facility_history(facility_id):
+    sb = get_supabase()
+    snaps = sb.table("runtime_activation_snapshot").select("id,runtime_version,result_hash,rules_active,tasks_active,created_at").eq("facility_id", facility_id).order("runtime_version").execute()
+    diffs = sb.table("runtime_activation_diff").select("*").eq("facility_id", facility_id).order("created_at").execute()
+    drift_logs = sb.table("runtime_drift_detection_log").select("*").eq("facility_id", facility_id).order("created_at").execute()
+    schedules = sb.table("runtime_schedule_instance").select("*").eq("facility_id", facility_id).execute()
+    versions = sb.table("runtime_runtime_version").select("*").eq("facility_id", facility_id).order("version_number").execute()
+    audit = sb.table("runtime_re_evaluation_audit_log").select("*").eq("facility_id", facility_id).order("created_at", desc=True).limit(50).execute()
+    return {
+        "snapshots": snaps.data or [], "diffs": diffs.data or [],
+        "drift_logs": drift_logs.data or [], "schedules": schedules.data or [],
+        "versions": versions.data or [], "audit_log": audit.data or [],
+    }
+
+
+def _p_audit(sb, facility_id, re_eval_id, action, detail):
+    try: sb.table("runtime_re_evaluation_audit_log").insert({"facility_id": facility_id, "re_evaluation_id": re_eval_id, "action": action, "detail": detail}).execute()
+    except: pass

--- a/services/runtime_binding_resolver.py
+++ b/services/runtime_binding_resolver.py
@@ -1,0 +1,123 @@
+"""runtime_binding_resolver.py — Runtime Data Binding Engine (PHASE B)
+
+schema field에 runtime data binding 수행.
+document_schema_registry.source_mapping → 실제 DB 데이터 조회.
+
+절대 금지: AI 기반 field mapping, semantic inference, guessed binding
+"""
+from typing import Optional
+from db.supabase_client import get_supabase
+
+# Source → (table, column) deterministic 매핑
+SOURCE_TABLE_MAP = {
+    # runtime_facility_profile
+    "facility.facility_name": ("runtime_facility_profile", "facility_name"),
+    "facility.industry_code": ("runtime_facility_profile", "industry_code"),
+    "facility.industry_name": ("runtime_facility_profile", "industry_name"),
+    "facility.worker_count": ("runtime_facility_profile", "worker_count"),
+    "facility.address": ("runtime_facility_profile", "address"),
+    "facility.contractor_exists": ("runtime_facility_profile", "contractor_exists"),
+    "facility.facility_types": ("runtime_facility_profile", "facility_types"),
+    # facility_condition (key-value)
+    "condition.electrical_capacity": ("facility_condition", "electrical_capacity"),
+    "condition.hazardous_quantity": ("facility_condition", "hazardous_quantity"),
+    "condition.building_area": ("facility_condition", "building_area"),
+    # sites
+    "site.site_name": ("sites", "site_name"),
+    "site.site_code": ("sites", "site_code"),
+}
+
+
+def resolve_source_value(source_mapping: str, tenant_context: dict) -> dict:
+    """source_mapping 문자열을 실제 값으로 resolve. deterministic only."""
+    if not source_mapping:
+        return {"value": None, "resolved": False, "reason": "no_source_mapping"}
+
+    facility_id = tenant_context.get("facility_id")
+    if not facility_id:
+        return {"value": None, "resolved": False, "reason": "no_facility_id"}
+
+    sb = get_supabase()
+
+    # facility_condition은 key-value 구조
+    if source_mapping.startswith("condition."):
+        field_name = source_mapping.split(".", 1)[1]
+        result = sb.table("facility_condition").select("condition_value").eq(
+            "factory_id", facility_id
+        ).eq("condition_field", field_name).limit(1).execute()
+        if result.data:
+            return {"value": result.data[0]["condition_value"], "resolved": True, "source": source_mapping}
+        return {"value": None, "resolved": False, "reason": f"condition '{field_name}' not found"}
+
+    # 일반 테이블 매핑
+    mapping = SOURCE_TABLE_MAP.get(source_mapping)
+    if not mapping:
+        return {"value": None, "resolved": False, "reason": f"unknown_source: {source_mapping}"}
+
+    table, column = mapping
+    try:
+        result = sb.table(table).select(column).eq("id", facility_id).limit(1).execute()
+        if result.data:
+            return {"value": result.data[0].get(column), "resolved": True, "source": source_mapping}
+        return {"value": None, "resolved": False, "reason": f"no data in {table}"}
+    except Exception as e:
+        return {"value": None, "resolved": False, "reason": str(e)}
+
+
+def resolve_document_runtime(document_type: str, tenant_context: dict) -> dict:
+    """document_type의 전체 필드를 runtime data로 binding"""
+    sb = get_supabase()
+
+    # 섹션 조회
+    sections = sb.table("document_schema_section").select("*").eq(
+        "document_type", document_type
+    ).eq("enabled", True).order("section_order").execute()
+
+    # 필드 조회
+    fields = sb.table("document_schema_registry").select("*").eq(
+        "document_type", document_type
+    ).eq("enabled", True).order("field_order").execute()
+
+    if not fields.data:
+        return {"error": f"No schema for {document_type}"}
+
+    # 섹션별 그룹
+    section_fields = {}
+    for f in fields.data:
+        sc = f.get("section_code", "GENERAL")
+        if sc not in section_fields:
+            section_fields[sc] = []
+
+        # runtime binding
+        binding = resolve_source_value(f.get("source_mapping"), tenant_context)
+
+        section_fields[sc].append({
+            "field_code": f["field_code"],
+            "field_label": f["field_label"],
+            "field_type": f["field_type"],
+            "required_level": f["required_level"],
+            "value": binding["value"],
+            "source": f.get("source_mapping"),
+            "resolved": binding["resolved"],
+            "resolve_reason": binding.get("reason"),
+            "render_component": f.get("render_component"),
+            "source_trace": f.get("source_trace"),
+            "source_reason": f.get("source_reason"),
+        })
+
+    # 조립
+    result_sections = []
+    for s in (sections.data or []):
+        sc = s["section_code"]
+        result_sections.append({
+            "section_code": sc,
+            "section_title": s["section_title"],
+            "section_order": s["section_order"],
+            "fields": section_fields.get(sc, []),
+        })
+
+    return {
+        "document_type": document_type,
+        "tenant_context": {k: str(v)[:50] for k, v in tenant_context.items()},
+        "sections": result_sections,
+    }

--- a/services/runtime_evaluator_svc.py
+++ b/services/runtime_evaluator_svc.py
@@ -1,0 +1,433 @@
+"""TAI Runtime Evaluator Engine v1.0.0
+
+Deterministic Condition-Based Rule Activation Engine.
+절대 금지: semantic inference, best_match, fallback, guessed, probable,
+           AI recommendation, similar industry, hidden normalization,
+           auto condition repair, implied obligation activation
+
+허용: EXPLICIT_MATCH, THRESHOLD_MATCH, EVENT_MATCH, SCHEDULE_MATCH
+"""
+from datetime import datetime, timezone
+from db.supabase_client import get_supabase
+
+
+# ═══ 1. Evaluation Context ═══
+
+def create_context(data: dict) -> dict:
+    sb = get_supabase()
+    now = datetime.now(timezone.utc).isoformat()
+    rec = {
+        "industry_code": data.get("industry_code"),
+        "worker_count": data.get("worker_count"),
+        "hazardous_materials": data.get("hazardous_materials", []),
+        "equipment": data.get("equipment", []),
+        "pressure_vessels": data.get("pressure_vessels", []),
+        "fire_facilities": data.get("fire_facilities", []),
+        "contractors": data.get("contractors", []),
+        "process_types": data.get("process_types", []),
+        "accident_occurred": data.get("accident_occurred", False),
+        "construction_started": data.get("construction_started", False),
+        "shutdown": data.get("shutdown", False),
+        "additional_inputs": data.get("additional_inputs", {}),
+        "evaluation_status": "PENDING",
+        "created_by": data.get("created_by"),
+        "created_at": now,
+        "updated_at": now,
+    }
+    if data.get("company_id"): rec["company_id"] = data["company_id"]
+    if data.get("facility_id"): rec["facility_id"] = data["facility_id"]
+    r = sb.table("runtime_evaluation_context").insert(rec).execute()
+    ctx = r.data[0] if r.data else {}
+    if ctx:
+        _audit(sb, ctx["id"], "CONTEXT_CREATED", None, None, None, "context created", data.get("created_by"))
+    return ctx
+
+
+def get_context(ctx_id: str) -> dict:
+    sb = get_supabase()
+    r = sb.table("runtime_evaluation_context").select("*").eq("id", ctx_id).single().execute()
+    return r.data
+
+
+def list_contexts(company_id: str = None, page: int = 1, page_size: int = 20) -> dict:
+    sb = get_supabase()
+    q = sb.table("runtime_evaluation_context").select("*", count="exact")
+    if company_id: q = q.eq("company_id", company_id)
+    o = (page - 1) * page_size
+    q = q.order("created_at", desc=True).range(o, o + page_size - 1)
+    r = q.execute()
+    return {"items": r.data or [], "total": r.count or 0, "page": page, "page_size": page_size}
+
+
+# ═══ 2. Core Evaluator ═══
+
+def evaluate(ctx_id: str) -> dict:
+    """Deterministic evaluation. semantic/fallback/guess 절대 금지."""
+    sb = get_supabase()
+    ctx = sb.table("runtime_evaluation_context").select("*").eq("id", ctx_id).single().execute()
+    if not ctx.data: raise ValueError("context not found")
+    c = ctx.data
+    sb.table("runtime_evaluation_context").update({"evaluation_status": "EVALUATING", "updated_at": datetime.now(timezone.utc).isoformat()}).eq("id", ctx_id).execute()
+
+    results = {"rules": [], "tasks": [], "documents": [], "schedules": [], "penalties": [], "conflicts": [], "unknown": [], "ambiguous": []}
+    try:
+        # [3단계] Condition Evaluator + [4단계] Rule Activation
+        rules = _evaluate_rules(sb, ctx_id, c)
+        results["rules"] = rules
+
+        # [9단계] Event Trigger
+        events = _evaluate_events(sb, ctx_id, c)
+        results["rules"].extend(events)
+
+        # [5단계] Task Activation (활성 rule 기반만)
+        active_rules = [r for r in results["rules"] if r.get("status") == "ACTIVE"]
+        for ar in active_rules:
+            tasks = _activate_tasks(sb, ctx_id, ar)
+            results["tasks"].extend(tasks)
+
+        # [6단계] Document Activation (활성 task 기반만)
+        active_tasks = [t for t in results["tasks"] if t.get("status") == "ACTIVE"]
+        for at in active_tasks:
+            docs = _activate_documents(sb, ctx_id, at)
+            results["documents"].extend(docs)
+
+        # [7단계] Schedule Activation
+        for ar in active_rules:
+            scheds = _activate_schedules(sb, ctx_id, ar)
+            results["schedules"].extend(scheds)
+
+        # [8단계] Penalty Activation
+        for ar in active_rules:
+            pens = _activate_penalties(sb, ctx_id, ar)
+            results["penalties"].extend(pens)
+
+        # [10단계] Conflict Detection
+        conflicts = _detect_conflicts(sb, ctx_id, results)
+        results["conflicts"] = conflicts
+
+        # [11단계] UNKNOWN/AMBIGUOUS 수집
+        results["unknown"] = [r for r in results["rules"] if r.get("status") == "UNKNOWN"]
+        results["ambiguous"] = [r for r in results["rules"] if r.get("status") == "AMBIGUOUS"]
+
+        sb.table("runtime_evaluation_context").update({"evaluation_status": "COMPLETED", "updated_at": datetime.now(timezone.utc).isoformat()}).eq("id", ctx_id).execute()
+        _audit(sb, ctx_id, "EVALUATION_COMPLETED", None, None, None, f"rules={len(results['rules'])} tasks={len(results['tasks'])} docs={len(results['documents'])}", "system")
+
+    except Exception as e:
+        sb.table("runtime_evaluation_context").update({"evaluation_status": "FAILED", "updated_at": datetime.now(timezone.utc).isoformat()}).eq("id", ctx_id).execute()
+        _audit(sb, ctx_id, "EVALUATION_FAILED", None, None, None, str(e), "system")
+        raise
+
+    return {
+        "context_id": ctx_id,
+        "status": "COMPLETED",
+        "summary": {
+            "rules_active": len([r for r in results["rules"] if r.get("status") == "ACTIVE"]),
+            "rules_not_activated": len([r for r in results["rules"] if r.get("status") == "NOT_ACTIVATED"]),
+            "rules_unknown": len(results["unknown"]),
+            "rules_ambiguous": len(results["ambiguous"]),
+            "tasks_active": len(results["tasks"]),
+            "documents_active": len(results["documents"]),
+            "schedules_active": len(results["schedules"]),
+            "penalties_potential": len(results["penalties"]),
+            "conflicts": len(results["conflicts"]),
+        },
+        "activations": results,
+    }
+
+
+# ═══ 3. Rule Activation (EXPLICIT/THRESHOLD only) ═══
+
+def _evaluate_rules(sb, ctx_id, ctx):
+    """rule_candidate + executable_draft 조건 평가. semantic 금지."""
+    activated = []
+    # executable_draft의 조건 평가
+    drafts = sb.table("executable_draft").select("id,rule_candidate_id,condition_json,status").eq("status", "CANDIDATE").limit(500).execute()
+    for d in (drafts.data or []):
+        cond = d.get("condition_json") or {}
+        match_result = _match_condition(ctx, cond)
+        act_type = match_result["type"]
+        act_status = match_result["status"]
+        reason = match_result["reason"]
+
+        rec = {
+            "evaluation_context_id": ctx_id,
+            "rule_candidate_id": d.get("rule_candidate_id"),
+            "activation_type": act_type if act_status == "ACTIVE" else "EXPLICIT_MATCH",
+            "activation_reason": reason,
+            "matched_condition": cond,
+            "status": act_status,
+            "source_trace": {"draft_id": str(d["id"])},
+        }
+        r = sb.table("runtime_rule_activation").insert(rec).execute()
+        row = r.data[0] if r.data else rec
+        activated.append(row)
+
+        log_action = "RULE_ACTIVATED" if act_status == "ACTIVE" else ("RULE_UNKNOWN" if act_status == "UNKNOWN" else "RULE_NOT_ACTIVATED")
+        _audit(sb, ctx_id, log_action, "rule", d.get("rule_candidate_id"), cond, reason, "system")
+    return activated
+
+
+def _match_condition(ctx, cond):
+    """명시 조건 매칭. semantic/fallback/guess 절대 금지."""
+    if not cond:
+        return {"type": "EXPLICIT_MATCH", "status": "UNKNOWN", "reason": "no condition defined"}
+
+    # worker_count threshold
+    wc_min = cond.get("worker_count_min")
+    wc = ctx.get("worker_count")
+    if wc_min is not None:
+        if wc is None:
+            return {"type": "THRESHOLD_MATCH", "status": "UNKNOWN", "reason": f"worker_count not provided, threshold={wc_min}"}
+        if wc < wc_min:
+            return {"type": "THRESHOLD_MATCH", "status": "NOT_ACTIVATED", "reason": f"worker_count {wc} < {wc_min}"}
+
+    # industry_code exact match
+    ind_codes = cond.get("industry_codes", [])
+    if ind_codes:
+        ic = ctx.get("industry_code")
+        if not ic:
+            return {"type": "EXPLICIT_MATCH", "status": "UNKNOWN", "reason": "industry_code not provided"}
+        if ic not in ind_codes:
+            return {"type": "EXPLICIT_MATCH", "status": "NOT_ACTIVATED", "reason": f"industry_code {ic} not in {ind_codes}"}
+
+    # equipment exists
+    req_equip = cond.get("requires_equipment", [])
+    if req_equip:
+        user_equip = ctx.get("equipment") or []
+        if not user_equip:
+            return {"type": "EXPLICIT_MATCH", "status": "UNKNOWN", "reason": "equipment not provided"}
+        if not any(e in user_equip for e in req_equip):
+            return {"type": "EXPLICIT_MATCH", "status": "NOT_ACTIVATED", "reason": f"required equipment {req_equip} not found"}
+
+    # pressure_vessel
+    if cond.get("requires_pressure_vessel"):
+        pv = ctx.get("pressure_vessels") or []
+        if not pv:
+            return {"type": "EXPLICIT_MATCH", "status": "NOT_ACTIVATED", "reason": "no pressure vessels"}
+
+    # hazardous_material
+    if cond.get("requires_hazardous_material"):
+        hm = ctx.get("hazardous_materials") or []
+        if not hm:
+            return {"type": "EXPLICIT_MATCH", "status": "NOT_ACTIVATED", "reason": "no hazardous materials"}
+
+    # fire_facility
+    if cond.get("requires_fire_facility"):
+        ff = ctx.get("fire_facilities") or []
+        if not ff:
+            return {"type": "EXPLICIT_MATCH", "status": "NOT_ACTIVATED", "reason": "no fire facilities"}
+
+    # 모든 조건 통과
+    return {"type": "EXPLICIT_MATCH", "status": "ACTIVE", "reason": "all conditions met"}
+
+
+# ═══ 9. Event Trigger ═══
+
+def _evaluate_events(sb, ctx_id, ctx):
+    """EVENT_MATCH: 명시 입력 이벤트 기반만. inferred event 금지."""
+    events = []
+    event_flags = [
+        ("accident_occurred", "사고 발생"),
+        ("construction_started", "건설공사 개시"),
+        ("shutdown", "사업장 폐쇄/중지"),
+    ]
+    for flag, label in event_flags:
+        if ctx.get(flag) is True:
+            rec = {
+                "evaluation_context_id": ctx_id,
+                "activation_type": "EVENT_MATCH",
+                "activation_reason": f"event: {label}",
+                "matched_condition": {flag: True},
+                "status": "ACTIVE",
+                "source_trace": {"event_flag": flag},
+            }
+            r = sb.table("runtime_rule_activation").insert(rec).execute()
+            row = r.data[0] if r.data else rec
+            events.append(row)
+            _audit(sb, ctx_id, "EVENT_TRIGGERED", "event", None, {flag: True}, label, "system")
+    return events
+
+
+# ═══ 5. Task Activation (rule 활성 시만) ═══
+
+def _activate_tasks(sb, ctx_id, rule_act):
+    """task_candidate 활성. standalone task inference 금지."""
+    rid = rule_act.get("rule_candidate_id")
+    if not rid: return []
+    tasks_r = sb.table("task_candidate").select("id,task_type,source_action_family,obligation_family,status").limit(50).execute()
+    activated = []
+    for t in (tasks_r.data or []):
+        rec = {
+            "evaluation_context_id": ctx_id,
+            "rule_activation_id": rule_act["id"],
+            "task_candidate_id": t["id"],
+            "task_type": t.get("task_type"),
+            "task_title": t.get("source_action_family", ""),
+            "activation_reason": f"rule {rid} activated",
+            "status": "ACTIVE" if t.get("status") != "NEEDS_HUMAN_REVIEW" else "UNKNOWN",
+            "source_trace": {"rule_candidate_id": str(rid), "task_candidate_id": str(t["id"])},
+        }
+        r = sb.table("runtime_task_activation").insert(rec).execute()
+        row = r.data[0] if r.data else rec
+        activated.append(row)
+        _audit(sb, ctx_id, "TASK_ACTIVATED", "task", t["id"], None, rec["activation_reason"], "system")
+    return activated
+
+
+# ═══ 6. Document Activation (binding 기반만) ═══
+
+def _activate_documents(sb, ctx_id, task_act):
+    """document_requirement_candidate binding 기반. semantic document recommendation 금지."""
+    tid = task_act.get("task_candidate_id")
+    if not tid: return []
+    # requirement 연결 조회 (requirement_family 기반)
+    reqs = sb.table("document_requirement_candidate").select("id,requirement_family,document_name,form_type").limit(20).execute()
+    activated = []
+    for req in (reqs.data or []):
+        rec = {
+            "evaluation_context_id": ctx_id,
+            "task_activation_id": task_act["id"],
+            "document_requirement_id": req["id"],
+            "activation_reason": f"task {tid} requires document {req.get('document_name','')}",
+            "status": "ACTIVE",
+            "source_trace": {"task_candidate_id": str(tid), "requirement_id": str(req["id"])},
+        }
+        r = sb.table("runtime_document_activation").insert(rec).execute()
+        row = r.data[0] if r.data else rec
+        activated.append(row)
+        _audit(sb, ctx_id, "DOCUMENT_ACTIVATED", "document", req["id"], None, rec["activation_reason"], "system")
+    return activated
+
+
+# ═══ 7. Schedule Activation (explicit rule 기반만) ═══
+
+def _activate_schedules(sb, ctx_id, rule_act):
+    """schedule_candidate 활성. inferred deadline / guessed recurrence 금지."""
+    rid = rule_act.get("rule_candidate_id")
+    if not rid: return []
+    scheds = sb.table("schedule_candidate").select("id,schedule_type,source_family,status").limit(20).execute()
+    activated = []
+    TYPE_MAP = {"DAILY": "DAILY", "WEEKLY": "WEEKLY", "MONTHLY": "MONTHLY", "QUARTERLY": "QUARTERLY",
+                "YEARLY": "ANNUAL", "ANNUAL": "ANNUAL", "PERIODIC": "MONTHLY", "EVENT": "EVENT_TRIGGERED"}
+    for s in (scheds.data or []):
+        st = s.get("schedule_type", "UNKNOWN")
+        mapped = TYPE_MAP.get(st, "UNKNOWN")
+        rec = {
+            "evaluation_context_id": ctx_id,
+            "rule_activation_id": rule_act["id"],
+            "schedule_candidate_id": s["id"],
+            "schedule_type": mapped,
+            "activation_reason": f"rule {rid} schedule: {st}",
+            "status": "ACTIVE" if mapped != "UNKNOWN" else "UNKNOWN",
+            "source_trace": {"rule_candidate_id": str(rid), "schedule_candidate_id": str(s["id"])},
+        }
+        r = sb.table("runtime_schedule_activation").insert(rec).execute()
+        row = r.data[0] if r.data else rec
+        activated.append(row)
+        _audit(sb, ctx_id, "SCHEDULE_ACTIVATED", "schedule", s["id"], None, rec["activation_reason"], "system")
+    return activated
+
+
+# ═══ 8. Penalty Activation (가능성만, 자동 처벌 금지) ═══
+
+def _activate_penalties(sb, ctx_id, rule_act):
+    """penalty_candidate 연결. auto violation / auto punishment 금지."""
+    rid = rule_act.get("rule_candidate_id")
+    if not rid: return []
+    pens = sb.table("penalty_obligation_relation").select("id,penalty_candidate_id,obligation_family,status").limit(20).execute()
+    activated = []
+    for p in (pens.data or []):
+        rec = {
+            "evaluation_context_id": ctx_id,
+            "rule_activation_id": rule_act["id"],
+            "penalty_candidate_id": p.get("penalty_candidate_id"),
+            "penalty_type": p.get("obligation_family"),
+            "activation_reason": f"rule {rid} penalty potential",
+            "status": "POTENTIAL",
+            "source_trace": {"rule_candidate_id": str(rid), "penalty_relation_id": str(p["id"])},
+        }
+        r = sb.table("runtime_penalty_activation").insert(rec).execute()
+        row = r.data[0] if r.data else rec
+        activated.append(row)
+        _audit(sb, ctx_id, "PENALTY_ACTIVATED", "penalty", p.get("penalty_candidate_id"), None, rec["activation_reason"], "system")
+    return activated
+
+
+# ═══ 10. Conflict Detection (자동 resolve 금지) ═══
+
+def _detect_conflicts(sb, ctx_id, results):
+    """conflict 검출. 자동 resolve 절대 금지. NEEDS_HUMAN_REVIEW 유지."""
+    conflicts = []
+    # duplicate task 검출
+    task_types = {}
+    for t in results.get("tasks", []):
+        tt = t.get("task_type", "")
+        if tt in task_types:
+            rec = {
+                "evaluation_context_id": ctx_id,
+                "conflict_type": "DUPLICATE_TASK",
+                "item_a_id": task_types[tt].get("id"),
+                "item_a_type": "task",
+                "item_b_id": t.get("id"),
+                "item_b_type": "task",
+                "detail": {"task_type": tt},
+                "status": "NEEDS_HUMAN_REVIEW",
+            }
+            r = sb.table("runtime_conflict_queue").insert(rec).execute()
+            row = r.data[0] if r.data else rec
+            conflicts.append(row)
+            _audit(sb, ctx_id, "CONFLICT_DETECTED", "conflict", None, None, f"duplicate task: {tt}", "system")
+        else:
+            task_types[tt] = t
+    return conflicts
+
+
+# ═══ Result Queries ═══
+
+def get_result(ctx_id: str) -> dict:
+    sb = get_supabase()
+    ctx = sb.table("runtime_evaluation_context").select("*").eq("id", ctx_id).single().execute()
+    if not ctx.data: return None
+    rules = sb.table("runtime_rule_activation").select("*").eq("evaluation_context_id", ctx_id).execute()
+    tasks = sb.table("runtime_task_activation").select("*").eq("evaluation_context_id", ctx_id).execute()
+    docs = sb.table("runtime_document_activation").select("*").eq("evaluation_context_id", ctx_id).execute()
+    scheds = sb.table("runtime_schedule_activation").select("*").eq("evaluation_context_id", ctx_id).execute()
+    pens = sb.table("runtime_penalty_activation").select("*").eq("evaluation_context_id", ctx_id).execute()
+    conflicts = sb.table("runtime_conflict_queue").select("*").eq("evaluation_context_id", ctx_id).execute()
+    audit = sb.table("runtime_evaluator_audit_log").select("*").eq("evaluation_context_id", ctx_id).order("created_at", desc=True).execute()
+    return {
+        "context": ctx.data,
+        "rules": rules.data or [],
+        "tasks": tasks.data or [],
+        "documents": docs.data or [],
+        "schedules": scheds.data or [],
+        "penalties": pens.data or [],
+        "conflicts": conflicts.data or [],
+        "audit_log": audit.data or [],
+    }
+
+def get_conflicts(ctx_id: str) -> list:
+    sb = get_supabase()
+    r = sb.table("runtime_conflict_queue").select("*").eq("evaluation_context_id", ctx_id).execute()
+    return r.data or []
+
+def get_audit(ctx_id: str) -> list:
+    sb = get_supabase()
+    r = sb.table("runtime_evaluator_audit_log").select("*").eq("evaluation_context_id", ctx_id).order("created_at", desc=True).execute()
+    return r.data or []
+
+
+# ═══ 12. Audit ═══
+
+def _audit(sb, ctx_id, action, target_type, target_id, matched_cond, reason, actor):
+    try:
+        sb.table("runtime_evaluator_audit_log").insert({
+            "evaluation_context_id": ctx_id,
+            "action": action,
+            "target_type": target_type,
+            "target_id": target_id,
+            "matched_condition": matched_cond,
+            "activation_reason": reason,
+            "actor_id": actor,
+        }).execute()
+    except: pass

--- a/services/saas_setup_service.py
+++ b/services/saas_setup_service.py
@@ -1,0 +1,167 @@
+"""SaaS 반복설정 서비스.
+
+SaaS는 자동 의무등록기가 아니다.
+진단 결과 중 반복관리 후보를 승인받아 운영설정까지 한다.
+"""
+import os, json
+from datetime import datetime, timezone
+
+
+def _get_sb():
+    from supabase import create_client
+    return create_client(os.environ.get('SUPABASE_URL',''),
+                         os.environ.get('SUPABASE_SERVICE_ROLE_KEY',''))
+
+
+class SaaSSetupService:
+    """SaaS 반복설정 후보 추출 + 승인 + 등록."""
+
+    # ── [4] 반복설정 후보 추출 조건 ──
+    RECURRING_TYPES = {'INSPECTION','EDUCATION','REPORT','MEASUREMENT',
+                       'PRESERVATION','PERMIT_RENEWAL','PRE_WORK_CHECK'}
+    HOLD_STATUSES = {'UNKNOWN','UNRESOLVED','AMBIGUOUS','NEEDS_HUMAN_REVIEW'}
+
+    @staticmethod
+    def extract_setup_candidates(sb, session_id: str) -> dict:
+        """진단 결과에서 반복관리 후보 추출. 자동 등록 금지."""
+        # 진단 세션 확인
+        session = sb.table('diagnosis_session').select('*').eq('id', session_id).execute()
+        if not session.data:
+            raise ValueError('Session not found')
+        s = session.data[0]
+        if s['diagnosis_status'] not in ('COMPLETED_WITH_CANDIDATES','NEEDS_HUMAN_REVIEW'):
+            return {'candidates': [], 'reason': f"Status {s['diagnosis_status']} — no candidates"}
+
+        # Obligation candidates 조회
+        candidates = sb.table('diagnosis_candidate').select('*').eq(
+            'session_id', session_id
+        ).eq('candidate_type', 'OBLIGATION').execute()
+
+        # Schedule hints 조회
+        hints = sb.table('diagnosis_schedule_hint').select('*').eq(
+            'session_id', session_id).execute()
+        hint_map = {h.get('related_candidate_id'): h for h in (hints.data or [])}
+
+        setup_candidates = []
+        for c in (candidates.data or []):
+            sub = c.get('sub_type', '')
+
+            # [4] 반복관리 대상 확인
+            if sub not in SaaSSetupService.RECURRING_TYPES:
+                continue
+
+            # [4] 보류 조건 확인
+            if c.get('status') in SaaSSetupService.HOLD_STATUSES:
+                continue
+
+            # Setup type 결정
+            hint = hint_map.get(c['id'], {})
+            freq = hint.get('frequency_family', 'UNKNOWN')
+            trigger = hint.get('trigger_family', 'UNKNOWN')
+
+            if freq in ('YEARLY','MONTHLY','WEEKLY','DAILY','PERIODIC'):
+                setup_type = 'RECURRING_TASK'
+            elif trigger not in ('UNKNOWN',''):
+                setup_type = 'EVENT_BASED_TASK'
+            elif sub == 'PRESERVATION':
+                setup_type = 'RECORD_RETENTION'
+            else:
+                setup_type = 'DEADLINE_TRACKING'
+
+            ssc = sb.table('saas_setup_candidate').insert({
+                'session_id': session_id,
+                'related_candidate_id': c['id'],
+                'setup_type': setup_type,
+                'task_title_candidate': c.get('title_candidate', ''),
+                'frequency_candidate': json.dumps({
+                    'family': freq,
+                    'raw_text': hint.get('raw_text'),
+                    'status': 'CANDIDATE'
+                }),
+                'trigger_candidate': json.dumps({
+                    'family': trigger,
+                    'status': 'CANDIDATE'
+                }),
+                'deadline_candidate': json.dumps({
+                    'family': hint.get('deadline_family', 'UNKNOWN'),
+                    'status': 'CANDIDATE'
+                }),
+                'source_trace': json.dumps({
+                    'law_name': c.get('source_law', ''),
+                    'article': c.get('source_article', ''),
+                    'source_text': c.get('source_text', ''),
+                }),
+                'approval_status': 'PENDING_USER_APPROVAL',
+            }).execute()
+            setup_candidates.append(ssc.data[0] if ssc.data else {})
+
+        return {
+            'session_id': session_id,
+            'total_extracted': len(setup_candidates),
+            'candidates': setup_candidates,
+        }
+
+    @staticmethod
+    def approve(sb, setup_id: str, user_id: str = None) -> dict:
+        """[7] 사용자 승인. 승인 후에만 SaaS 등록 가능."""
+        before = sb.table('saas_setup_candidate').select('approval_status').eq('id', setup_id).execute()
+        if not before.data:
+            raise ValueError('Setup candidate not found')
+        if before.data[0]['approval_status'] != 'PENDING_USER_APPROVAL':
+            raise ValueError(f"Cannot approve: current status {before.data[0]['approval_status']}")
+
+        sb.table('saas_setup_candidate').update({
+            'approval_status': 'APPROVED_FOR_SAAS_SETUP',
+            'approved_at': datetime.now(timezone.utc).isoformat(),
+            'approved_by': user_id,
+        }).eq('id', setup_id).execute()
+        return {'setup_id': setup_id, 'status': 'APPROVED_FOR_SAAS_SETUP'}
+
+    @staticmethod
+    def reject(sb, setup_id: str, reason: str = None) -> dict:
+        sb.table('saas_setup_candidate').update({
+            'approval_status': 'REJECTED_BY_USER',
+        }).eq('id', setup_id).execute()
+        return {'setup_id': setup_id, 'status': 'REJECTED_BY_USER'}
+
+    @staticmethod
+    def request_more_data(sb, setup_id: str) -> dict:
+        sb.table('saas_setup_candidate').update({
+            'approval_status': 'NEEDS_MORE_DATA',
+        }).eq('id', setup_id).execute()
+        return {'setup_id': setup_id, 'status': 'NEEDS_MORE_DATA'}
+
+    @staticmethod
+    def register_to_runtime(sb, setup_id: str, user_id: str = None) -> dict:
+        """[8] 승인된 항목만 Runtime에 등록. rollback 가능."""
+        ssc = sb.table('saas_setup_candidate').select('*').eq('id', setup_id).execute()
+        if not ssc.data:
+            raise ValueError('Not found')
+        c = ssc.data[0]
+        if c['approval_status'] != 'APPROVED_FOR_SAAS_SETUP':
+            raise ValueError(f"Not approved: {c['approval_status']}")
+
+        # Registration log (실제 Runtime 등록은 기존 시스템이 처리)
+        log = sb.table('saas_registration_log').insert({
+            'setup_candidate_id': setup_id,
+            'registered_entity_type': c['setup_type'],
+            'source_trace': c.get('source_trace'),
+            'rollback_available': True,
+            'registered_by': user_id,
+        }).execute()
+
+        return {
+            'setup_id': setup_id,
+            'registration_id': log.data[0]['id'] if log.data else None,
+            'status': 'REGISTERED',
+            'rollback_available': True,
+        }
+
+    @staticmethod
+    def list_candidates(sb, session_id: str = None, status: str = None, limit: int = 50) -> dict:
+        q = sb.table('saas_setup_candidate').select('*', count='exact')
+        if session_id: q = q.eq('session_id', session_id)
+        if status: q = q.eq('approval_status', status)
+        q = q.order('created_at', desc=True).limit(limit)
+        r = q.execute()
+        return {'data': r.data or [], 'count': r.count}

--- a/services/simulation_svc.py
+++ b/services/simulation_svc.py
@@ -1,0 +1,230 @@
+"""TAI Operational Scenario Simulation Engine v1.0.0
+Deterministic Runtime Verification. AI 예측 금지.
+절대 금지: semantic/fallback/guessed/probable/AI/inferred
+"""
+import hashlib, json, time
+from datetime import datetime, timezone
+from db.supabase_client import get_supabase
+from services import runtime_evaluator_svc as evaluator
+
+
+def create_scenario(data: dict) -> dict:
+    sb = get_supabase()
+    rec = {
+        "scenario_name": data["scenario_name"],
+        "industry_code": data.get("industry_code"),
+        "worker_count": data.get("worker_count"),
+        "hazardous_materials": data.get("hazardous_materials", []),
+        "pressure_vessels": data.get("pressure_vessels", []),
+        "fire_facilities": data.get("fire_facilities", []),
+        "contractor_exists": data.get("contractor_exists", False),
+        "construction_started": data.get("construction_started", False),
+        "accident_occurred": data.get("accident_occurred", False),
+        "shutdown": data.get("shutdown", False),
+        "facility_types": data.get("facility_types", []),
+        "equipment": data.get("equipment", []),
+        "additional_inputs": data.get("additional_inputs", {}),
+        "status": "PENDING",
+        "created_by": data.get("created_by"),
+    }
+    r = sb.table("runtime_simulation_scenario").insert(rec).execute()
+    sc = r.data[0] if r.data else {}
+    if sc:
+        _sim_audit(sb, sc["id"], "SCENARIO_CREATED", {"name": data["scenario_name"]})
+    return sc
+
+
+def run_simulation(scenario_id: str) -> dict:
+    """Deterministic simulation. semantic/fallback/guess 절대 금지."""
+    sb = get_supabase()
+    sc = sb.table("runtime_simulation_scenario").select("*").eq("id", scenario_id).single().execute()
+    if not sc.data: raise ValueError("scenario not found")
+    s = sc.data
+    if s["status"] not in ("PENDING", "COMPLETED"): raise ValueError(f"invalid status: {s['status']}")
+
+    sb.table("runtime_simulation_scenario").update({"status": "RUNNING"}).eq("id", scenario_id).execute()
+    _sim_audit(sb, scenario_id, "SIMULATION_STARTED", {})
+    t0 = time.time()
+
+    try:
+        # 1. evaluation context 생성
+        ctx_data = {
+            "industry_code": s.get("industry_code"),
+            "worker_count": s.get("worker_count"),
+            "hazardous_materials": s.get("hazardous_materials", []),
+            "equipment": s.get("equipment", []),
+            "pressure_vessels": s.get("pressure_vessels", []),
+            "fire_facilities": s.get("fire_facilities", []),
+            "contractors": ["contractor"] if s.get("contractor_exists") else [],
+            "process_types": s.get("facility_types", []),
+            "accident_occurred": s.get("accident_occurred", False),
+            "construction_started": s.get("construction_started", False),
+            "shutdown": s.get("shutdown", False),
+            "additional_inputs": s.get("additional_inputs", {}),
+            "created_by": "simulation",
+        }
+        ctx = evaluator.create_context(ctx_data)
+        ctx_id = ctx["id"]
+        _sim_audit(sb, scenario_id, "CONTEXT_CREATED", {"context_id": ctx_id})
+
+        # 2. evaluate
+        result = evaluator.evaluate(ctx_id)
+        _sim_audit(sb, scenario_id, "EVALUATION_EXECUTED", {"context_id": ctx_id})
+
+        # 3. activation snapshot 저장
+        activations = result.get("activations", {})
+        for r_item in activations.get("rules", []):
+            sb.table("runtime_simulation_activation_snapshot").insert({
+                "scenario_id": scenario_id,
+                "activation_type": "RULE",
+                "target_id": r_item.get("rule_candidate_id"),
+                "activation_status": r_item.get("status", "UNKNOWN"),
+                "activation_reason": r_item.get("activation_reason", ""),
+                "matched_condition": r_item.get("matched_condition", {}),
+                "source_trace": r_item.get("source_trace", {}),
+            }).execute()
+        for t_item in activations.get("tasks", []):
+            sb.table("runtime_simulation_activation_snapshot").insert({
+                "scenario_id": scenario_id,
+                "activation_type": "TASK",
+                "target_id": t_item.get("task_candidate_id"),
+                "activation_status": t_item.get("status", "UNKNOWN"),
+                "activation_reason": t_item.get("activation_reason", ""),
+            }).execute()
+        for d_item in activations.get("documents", []):
+            sb.table("runtime_simulation_activation_snapshot").insert({
+                "scenario_id": scenario_id,
+                "activation_type": "DOCUMENT",
+                "target_id": d_item.get("document_requirement_id"),
+                "activation_status": d_item.get("status", "UNKNOWN"),
+                "activation_reason": d_item.get("activation_reason", ""),
+            }).execute()
+        for s_item in activations.get("schedules", []):
+            sb.table("runtime_simulation_activation_snapshot").insert({
+                "scenario_id": scenario_id,
+                "activation_type": "SCHEDULE",
+                "target_id": s_item.get("schedule_candidate_id"),
+                "activation_status": s_item.get("status", "UNKNOWN"),
+                "activation_reason": s_item.get("activation_reason", ""),
+            }).execute()
+        for p_item in activations.get("penalties", []):
+            sb.table("runtime_simulation_activation_snapshot").insert({
+                "scenario_id": scenario_id,
+                "activation_type": "PENALTY",
+                "target_id": p_item.get("penalty_candidate_id"),
+                "activation_status": p_item.get("status", "UNKNOWN"),
+                "activation_reason": p_item.get("activation_reason", ""),
+            }).execute()
+        _sim_audit(sb, scenario_id, "SNAPSHOT_SAVED", {})
+
+        # 4. conflict snapshot
+        for c_item in activations.get("conflicts", []):
+            sb.table("runtime_simulation_conflict_snapshot").insert({
+                "scenario_id": scenario_id,
+                "conflict_type": c_item.get("conflict_type", "UNKNOWN"),
+                "item_a": {"id": str(c_item.get("item_a_id", "")), "type": c_item.get("item_a_type", "")},
+                "item_b": {"id": str(c_item.get("item_b_id", "")), "type": c_item.get("item_b_type", "")},
+                "detail": c_item.get("detail", {}),
+                "status": "NEEDS_HUMAN_REVIEW",
+            }).execute()
+            _sim_audit(sb, scenario_id, "CONFLICT_DETECTED", c_item.get("detail", {}))
+
+        # 5. deterministic hash
+        summary = result.get("summary", {})
+        hash_input = json.dumps(summary, sort_keys=True)
+        det_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:16]
+
+        elapsed = int((time.time() - t0) * 1000)
+
+        # 6. result 저장
+        res_rec = {
+            "scenario_id": scenario_id,
+            "evaluation_context_id": ctx_id,
+            "activated_rules_count": summary.get("rules_active", 0),
+            "activated_tasks_count": summary.get("tasks_active", 0),
+            "activated_documents_count": summary.get("documents_active", 0),
+            "activated_schedules_count": summary.get("schedules_active", 0),
+            "activated_penalties_count": summary.get("penalties_potential", 0),
+            "conflicts_count": summary.get("conflicts", 0),
+            "unknowns_count": summary.get("rules_unknown", 0),
+            "ambiguities_count": summary.get("rules_ambiguous", 0),
+            "result_snapshot": summary,
+            "deterministic_hash": det_hash,
+            "execution_ms": elapsed,
+        }
+        sb.table("runtime_simulation_result").insert(res_rec).execute()
+
+        sb.table("runtime_simulation_scenario").update({
+            "status": "COMPLETED", "evaluation_context_id": ctx_id
+        }).eq("id", scenario_id).execute()
+        _sim_audit(sb, scenario_id, "SIMULATION_COMPLETED", {"hash": det_hash, "ms": elapsed})
+
+        return {
+            "scenario_id": scenario_id,
+            "context_id": ctx_id,
+            "status": "COMPLETED",
+            "deterministic_hash": det_hash,
+            "execution_ms": elapsed,
+            "summary": summary,
+        }
+
+    except Exception as e:
+        sb.table("runtime_simulation_scenario").update({"status": "FAILED"}).eq("id", scenario_id).execute()
+        _sim_audit(sb, scenario_id, "SIMULATION_FAILED", {"error": str(e)})
+        raise
+
+
+def verify_deterministic(scenario_id: str) -> dict:
+    """동일 시나리오 2회 실행 → 동일 hash 확인."""
+    r1 = run_simulation(scenario_id)
+    # scenario 상태 초기화 (재실행 가능하도록)
+    sb = get_supabase()
+    sb.table("runtime_simulation_scenario").update({"status": "PENDING"}).eq("id", scenario_id).execute()
+    r2 = run_simulation(scenario_id)
+
+    match = r1["deterministic_hash"] == r2["deterministic_hash"]
+    action = "DETERMINISTIC_CHECK_PASS" if match else "DETERMINISTIC_CHECK_FAIL"
+    _sim_audit(sb, scenario_id, action, {"hash_1": r1["deterministic_hash"], "hash_2": r2["deterministic_hash"]})
+
+    return {
+        "scenario_id": scenario_id,
+        "deterministic": match,
+        "hash_run_1": r1["deterministic_hash"],
+        "hash_run_2": r2["deterministic_hash"],
+        "run_1_ms": r1["execution_ms"],
+        "run_2_ms": r2["execution_ms"],
+    }
+
+
+def get_scenario(scenario_id: str) -> dict:
+    sb = get_supabase()
+    sc = sb.table("runtime_simulation_scenario").select("*").eq("id", scenario_id).single().execute()
+    return sc.data
+
+def list_scenarios(page=1, page_size=20) -> dict:
+    sb = get_supabase()
+    q = sb.table("runtime_simulation_scenario").select("*", count="exact")
+    o = (page-1)*page_size
+    q = q.order("created_at", desc=True).range(o, o+page_size-1)
+    r = q.execute()
+    return {"items": r.data or [], "total": r.count or 0, "page": page, "page_size": page_size}
+
+def get_result(scenario_id: str) -> dict:
+    sb = get_supabase()
+    res = sb.table("runtime_simulation_result").select("*").eq("scenario_id", scenario_id).order("created_at", desc=True).execute()
+    snaps = sb.table("runtime_simulation_activation_snapshot").select("*").eq("scenario_id", scenario_id).execute()
+    conflicts = sb.table("runtime_simulation_conflict_snapshot").select("*").eq("scenario_id", scenario_id).execute()
+    audit = sb.table("runtime_simulation_audit_log").select("*").eq("scenario_id", scenario_id).order("created_at").execute()
+    return {
+        "results": res.data or [],
+        "activation_snapshots": snaps.data or [],
+        "conflict_snapshots": conflicts.data or [],
+        "audit_log": audit.data or [],
+    }
+
+def _sim_audit(sb, scenario_id, action, detail):
+    try:
+        sb.table("runtime_simulation_audit_log").insert({
+            "scenario_id": scenario_id, "action": action, "detail": detail,
+        }).execute()
+    except: pass


### PR DESCRIPTION
## Notification Engine Phase 1 전체 배포

### 신규 서비스 (services/notification_engine/)
- `event_wiring.py` — Event→Policy→Audience→Runtime emit 중앙화
- `audience_resolver.py` — audience_key→actor list resolve (9 types, tenant DB)
- `digest_runtime.py` — Digest shadow mode (queue append only)
- `adapters/push.py` v2.0 — Mock→Compat (fcm_utils.send_push 실연결)

### 신규 라우터 (routers/)
- `notification_wiring_api.py` — GET wirings + GET policies + POST test
- `notification_digest_api.py` — GET digest-policies + GET candidates + POST test

### Runtime Injection (기존 코드 수정)
- `payment_billing.py` — subscription_activated + payment_failed wire_and_emit (034)
- `overdue_checker.py` — schedule_overdue wire_and_emit (033)
- `weather.py` — weather_work_stop wire_and_emit (033)

### 규칙
- Legacy SMS/push 유지 (제거 없음, compat 공존)
- try/except on all wiring paths
- wire_and_emit import inside helpers (순환 방지)

### DB (이미 적용됨)
- notification_policy_registry (8 rows)
- notification_event_wiring_registry (22 rows)
- notification_digest_policy_registry (5 rows)
- runtime_notification_digest_queue
- PUSH channel enabled=true