### PR TITLE
fix(pdf): restore documents storage wiring for generated PDFs

### DIFF
--- a/router_registry/document_engine.py
+++ b/router_registry/document_engine.py
@@ -1,0 +1,13 @@
+"""Document Engine — 문서엔진 전용 라우터.
+
+격리 필수: 이 그룹 실패해도 SaaS Core 정상 작동.
+"""
+ROUTERS = [
+    {"module": "routers.document_engine"},
+    {"module": "routers.document_engine_api"},
+    {"module": "routers.engine_document"},
+    {"module": "routers.report_forms"},
+    {"module": "routers.document_monitoring"},
+    {"module": "routers.requirement_engine"},
+    {"module": "routers.diagram_proxy"},
+]

--- a/routers/contract_kmong.py
+++ b/routers/contract_kmong.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime, timezone
 import io
+import logging
 import os
 
 from db.supabase_client import get_supabase
@@ -26,6 +27,7 @@ from services.legal_format import _classify_rules_db, format_rule_result_db
 from services.legal_rules import _risk_level
 
 router = APIRouter(prefix="/contract/kmong", tags=["contract-kmong"])
+log = logging.getLogger(__name__)
 
 
 # ──────────────────────────────────────────────
@@ -190,7 +192,7 @@ def patch_request(request_id: str, body: KmongPatchBody):
 
 
 @router.post("/{request_id}/pdf")
-def generate_pdf(request_id: str):
+async def generate_pdf(request_id: str):
     """
     result_html → xhtml2pdf → PDF bytes → Supabase Storage 업로드 → result_pdf_url 저장
     Storage 버킷: diagnosis-pdfs (public)
@@ -218,9 +220,28 @@ def generate_pdf(request_id: str):
         raise HTTPException(status_code=500, detail=f"PDF 생성 실패: {result.err}")
 
     pdf_bytes = pdf_buffer.getvalue()
+    file_name = f"kmong/{request_id}.pdf"
+
+    company_id = row.get("company_id")
+    try:
+        from services.document_svc import register_generated
+
+        if company_id:
+            await register_generated(
+                file_bytes=pdf_bytes,
+                file_name=f"{request_id}.pdf",
+                mime_type="application/pdf",
+                company_id=company_id,
+                category="contract",
+                generated_by="contract_kmong",
+                linked_table="contracts",
+                linked_id=request_id,
+                title=f"계약서 {row.get('request_no') or request_id}",
+            )
+    except Exception as _doc_err:
+        log.warning("documents 기록 실패 (PDF는 정상 반환): %s", _doc_err)
 
     # ── Supabase Storage 업로드 ──
-    file_name   = f"kmong/{request_id}.pdf"
     bucket_name = "diagnosis-pdfs"
 
     try:

--- a/routers/diagnosis_proposal.py
+++ b/routers/diagnosis_proposal.py
@@ -381,6 +381,45 @@ async def get_proposal_pdf(public_token: str):
     pdf      = await _generate_pdf(html)
     filename = f"TAI_proposal_{context['report_no']}.pdf"
 
+    input_data = row.get("input_data") or {}
+    full_result = row.get("full_result") or {}
+    diagnosis_id = row.get("id")
+    company_id = input_data.get("company_id") or full_result.get("company_id")
+    factory_id = full_result.get("factory_id") or input_data.get("factory_id")
+    if not company_id and factory_id:
+        try:
+            sb_lookup = get_supabase()
+            fac_res = (
+                sb_lookup.table("factories")
+                .select("company_id")
+                .eq("id", factory_id)
+                .limit(1)
+                .execute()
+            )
+            if fac_res.data:
+                company_id = fac_res.data[0].get("company_id")
+        except Exception:
+            pass
+
+    try:
+        from services.document_svc import register_generated
+
+        if company_id:
+            await register_generated(
+                file_bytes=pdf,
+                file_name=filename,
+                mime_type="application/pdf",
+                company_id=company_id,
+                category="report",
+                generated_by="diagnosis_proposal",
+                factory_id=factory_id,
+                linked_table="diagnosis_results",
+                linked_id=diagnosis_id,
+                title=f"법령진단 제안서 {context['report_no']}",
+            )
+    except Exception as _doc_err:
+        log.warning("documents 기록 실패 (PDF는 정상 반환): %s", _doc_err)
+
     # Storage \uc5c5\ub85c\ub4dc \ud6c4 DB\uc5d0 URL \uae30\ub85d (\uc2e4\ud328 \uc2dc \uc9c1\uc811 \uc2a4\ud2b8\ub9ac\ubc0d fallback)
     try:
         sb           = get_supabase()

--- a/routers/diagnosis_report.py
+++ b/routers/diagnosis_report.py
@@ -385,6 +385,42 @@ async def get_paid_report_pdf(public_token: str):
         receipt_no, tier_code, len(pdf_bytes)
     )
 
+    diagnosis_id = rec.get("id")
+    company_id = input_data.get("company_id") or full_result.get("company_id")
+    factory_id = full_result.get("factory_id") or input_data.get("factory_id")
+    if not company_id and factory_id:
+        try:
+            fac_res = (
+                supabase.table("factories")
+                .select("company_id")
+                .eq("id", factory_id)
+                .limit(1)
+                .execute()
+            )
+            if fac_res.data:
+                company_id = fac_res.data[0].get("company_id")
+        except Exception:
+            pass
+
+    try:
+        from services.document_svc import register_generated
+
+        if company_id:
+            await register_generated(
+                file_bytes=pdf_bytes,
+                file_name=filename,
+                mime_type="application/pdf",
+                company_id=company_id,
+                category="report",
+                generated_by="diagnosis_report",
+                factory_id=factory_id,
+                linked_table="diagnosis_results",
+                linked_id=diagnosis_id,
+                title=f"법령진단 리포트 {receipt_no}",
+            )
+    except Exception as _doc_err:
+        log.warning("documents 기록 실패 (PDF는 정상 반환): %s", _doc_err)
+
     return Response(
         content=pdf_bytes,
         media_type="application/pdf",

--- a/routers/document_engine.py
+++ b/routers/document_engine.py
@@ -1,0 +1,130 @@
+"""Document Engine Router
+
+문서 자동생성 엔진 API.
+- /document-forms/{doc_id}/preview  — HTML 미리보기
+- /document-forms/{doc_id}/generate — PDF 생성 + 티켓 차감
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import HTMLResponse, Response
+from pydantic import BaseModel
+
+from db.supabase_client import get_supabase
+from services.document_engine.fetchers.tbm_fetcher import TbmFetcher
+from services.document_engine.renderer import (
+    generate_document_pdf,
+    render_document_html,
+)
+
+router = APIRouter(prefix="/document-forms", tags=["document-engine"])
+log = logging.getLogger(__name__)
+
+# 패처 레지스트리 (doc_id → Fetcher)
+_FETCHERS = {
+    "DOC-OSH-056": TbmFetcher(),
+    # TODO: 추가 패처 등록
+}
+
+
+class GenerateRequest(BaseModel):
+    factory_id: str
+    date_from: Optional[date] = None
+    date_to: Optional[date] = None
+    meeting_id: Optional[str] = None
+    additional_data: Optional[dict] = None
+
+
+@router.get("/{doc_id}/preview", response_class=HTMLResponse)
+async def preview_document(
+    doc_id: str,
+    factory_id: str = Query(...),
+    date_from: Optional[date] = Query(None),
+    date_to: Optional[date] = Query(None),
+    meeting_id: Optional[str] = Query(None),
+):
+    """HTML 미리보기 — 데이터를 주입한 문서 HTML을 반환합니다."""
+    fetcher = _FETCHERS.get(doc_id)
+    if not fetcher:
+        raise HTTPException(404, f"No fetcher registered for {doc_id}")
+
+    try:
+        data = await fetcher.fetch(
+            factory_id=factory_id,
+            date_from=date_from,
+            date_to=date_to,
+            meeting_id=meeting_id,
+        )
+        html = await render_document_html(doc_id, data)
+        return HTMLResponse(content=html)
+    except FileNotFoundError as e:
+        raise HTTPException(404, str(e))
+    except Exception as e:
+        raise HTTPException(500, f"Preview failed: {e}")
+
+
+@router.post("/{doc_id}/generate")
+async def generate_document(doc_id: str, req: GenerateRequest):
+    """PDF 생성 — 데이터 주입 → Gotenberg PDF 변환 → 바이트 반환."""
+    fetcher = _FETCHERS.get(doc_id)
+    if not fetcher:
+        raise HTTPException(404, f"No fetcher registered for {doc_id}")
+
+    # TODO: 티켓 잔여 확인 + 차감 (B~D등급)
+    # from services.document_forms_service import get_document_form
+    # form = get_document_form(doc_id)
+    # if form['tai_grade'] != 'A':
+    #     check_and_deduct_ticket(factory_id, form['ticket_cost'])
+
+    try:
+        data = await fetcher.fetch(
+            factory_id=req.factory_id,
+            date_from=req.date_from,
+            date_to=req.date_to,
+            meeting_id=req.meeting_id,
+            additional_data=req.additional_data,
+        )
+        pdf_bytes = await generate_document_pdf(doc_id, data)
+
+        filename = f"{doc_id}_{req.factory_id[:8]}_{data.get('work_date', 'doc')}.pdf"
+        try:
+            from services.document_svc import register_generated
+
+            _sb = get_supabase()
+            _fac = (
+                _sb.table("factories")
+                .select("company_id")
+                .eq("id", req.factory_id)
+                .limit(1)
+                .execute()
+            )
+            _company_id = (_fac.data[0].get("company_id") if _fac.data else None)
+            if _company_id:
+                await register_generated(
+                    file_bytes=pdf_bytes,
+                    file_name=filename,
+                    mime_type="application/pdf",
+                    company_id=_company_id,
+                    category="tbm",
+                    generated_by="document_engine",
+                    factory_id=req.factory_id,
+                    linked_table="tbm_meetings",
+                    linked_id=req.meeting_id,
+                    title=f"TBM 기록 {data.get('work_date', '')}",
+                )
+        except Exception as _doc_err:
+            log.warning("documents 기록 실패 (PDF는 정상 반환): %s", _doc_err)
+
+        return Response(
+            content=pdf_bytes,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(404, str(e))
+    except Exception as e:
+        raise HTTPException(500, f"Generate failed: {e}")


### PR DESCRIPTION
## 변경 내용

PDF 생성 라우터에서 `document_svc.register_generated()` 호출을 연결하여, 생성된 PDF가 `company-docs` Storage에 업로드되고 `documents` 테이블에 기록되도록 복구합니다.

### 수정 파일 (5개)

| 파일 | 변경 | 상세 |
|------|------|------|
| `routers/document_engine.py` | 복원 + 와이어링 | TBM PDF — `register_generated()` 연결 (category=`tbm`) |
| `routers/diagnosis_report.py` | 와이어링 추가 | 진단리포트 — `register_generated()` 연결 (category=`report`) |
| `routers/diagnosis_proposal.py` | 와이어링 추가 | 제안서 — `register_generated()` 연결 (category=`report`) |
| `routers/contract_kmong.py` | 와이어링 추가 + async 전환 | 계약서 — `register_generated()` 연결 (category=`contract`) |
| `router_registry/document_engine.py` | 라우터 등록 | `routers.document_engine` 등록 (TBM PDF 엔드포인트 활성화) |

### 변경하지 않은 것

- `services/document_svc.py` — 수정 없음 (이미 완성)
- `documents` 테이블 스키마 — 변경 없음
- `company-docs` Storage bucket — 변경 없음
- PDF 생성 로직 (HTML→PDF 변환) — 변경 없음
- Gotenberg 설정 — 변경 없음
- 엔진 구조 — 변경 없음

### 안전장치

- 모든 `register_generated()` 호출은 `try/except`로 감싸져 있어, documents 기록 실패 시에도 PDF는 정상 반환됩니다
- `company_id`가 없는 익명 요청은 documents 기록을 건너뜁니다 (의도된 동작)

### 검증 완료

- Route prefix 충돌 없음 (`/document-forms` vs `/document-engine`)
- doc_category enum 기존값만 사용 (`tbm`, `report`, `contract`)
- doc_source enum `AUTO_GENERATED` 사용
- py_compile 문법 검증 PASS