### PR TITLE
Phase 10 — Quality Runtime Activation (의무 전체 품질 평가 + Coverage + Gate 시연)

### DIFF
--- a/docs/PHASE10_QUALITY_RUNTIME_ACTIVATION.md
+++ b/docs/PHASE10_QUALITY_RUNTIME_ACTIVATION.md
@@ -1,0 +1,66 @@
+# Phase 10 — Quality Runtime Activation
+
+> 검증된 Quality Evaluator(Phase 9)를 실제 운영 의무에 적용. **새 엔진 없음.** Evaluator 무수정 사용.
+
+## 중요 사실 (조사 결과, 추측 아님)
+
+tai-api에는 **운영 의무별 Check EvidenceReport가 아직 없다.** (`HANDOFF_EVIDENCE_ENGINE.md`의 Evidence Engine은 법령 원문 파싱 파이프라인이며 Check 리포트와 무관.)
+
+그래서 이번 배치의 의미는:
+- Check 리포트 없는 의무 = 근거 미관측 = **TRACE_REQUIRED** (정상 의미, 조작 아님). 빈 well-formed Check 리포트를 넓어 evaluator가 정직하게 TRACE로 매핑.
+- 법령 연결 누락 / 법령 충돌 의무 = **CORRECTION_REQUIRED**.
+- **READY = 0건** (아직 어떤 의무도 Check 검증되지 않음).
+
+## ⚠ Schedule Gate 전역 활성화 경고 (작업 4)
+
+READY가 0건인 현 상태에서 `enforce_quality`를 전역 기본 True로 켜면 **모든 스케줄 생성이 차단**된다(운영 중단). 따라서:
+- 전역 default는 **False 유지** (변경 안 함).
+- 게이트는 **per-call** `?enforce_quality=true` 로 시연/검증만.
+- Check 리포트 연결 → READY 발생 후 전역 활성화 권장.
+(전역 강제를 원하시면 명시 지시 — 현재는 스케줄 0건이 됩니다.)
+
+## 산출물
+
+1. **Batch 평가 러너** — `scripts/run_quality_batch.py` (`--dry-run` / `--commit`)
+2. **인구 평가 로직** — `services/obligation_quality_batch.py` (`collect_obligations_from_diagnosis`, `evaluate_population`, `empty_check_report`)
+3. **Coverage** — `services/obligation_quality_coverage.py` (`compute_coverage`) + `GET /admin/obligations/coverage`
+4. **Admin Queue 적재** — `--commit` 시 CORRECTION_REQUIRED → `record_evaluation` → admin_obligation_queue 자동 등록 (Phase 9 store)
+5. **테스트** — `tests/test_obligation_quality_coverage.py` (순수, DB 불필요)
+6. **리포트 템플릿** — `reports/PHASE10_COVERAGE_REPORT.md` (실행 후 실제 숫자로 채움)
+
+## 의무 모집 정의
+
+"기존 의무 전체" = 최신 진단결과(`factory_diagnosis_results.is_latest`)의 `result_data.inspection_required[]` 룰을 obligation_id(rule_id/rule_code) 기준으로 distinct 수집. 이는 Schedule Gate가 조회하는 동일 출처라 게이트 커버리지가 일치한다. (별도 master 의무 테이블이 있으면 알려주십시오.)
+
+## 실행 절차 (사람)
+
+```bash
+# 0) 순수 테스트 (DB 불필요)
+python -m pytest tests/test_obligation_quality_coverage.py -q
+
+# 1) 마이그레이션 적용: sql/20260603_obligation_quality_layer.sql → Supabase taieng
+
+# 2) 미리보기 (DB 쓰기 없음)
+PYTHONPATH=. python scripts/run_quality_batch.py --dry-run
+
+# 3) 적재 (obligation_quality + CORRECTION 시 admin 큐)
+PYTHONPATH=. python scripts/run_quality_batch.py --commit
+
+# 4) Coverage 확인
+curl -s https://api.taieng.co.kr/admin/obligations/coverage | jq
+
+# 5) Gate 시연 (전역 활성화 아님, per-call)
+curl -s -X POST "https://api.taieng.co.kr/legal-engine/generate-schedules/<FACTORY_ID>?enforce_quality=true" | jq
+```
+
+## 성공 기준
+
+기존 의무 전체가 READY / TRACE_REQUIRED / CORRECTION_REQUIRED 중 하나를 가진다 → `compute_coverage.fully_classified == true` 로 확인. (실행 후 리포트에 실제 숫자 기록.)
+
+## 검증 상태: UNVERIFIED (이번 세션 실행 불가)
+
+순수 테스트는 작성 완료(사용자 실행 필요). 배치/Coverage/Gate의 실데이터 숫자는 사람이 위 명령 실행 후 확정. 추측 숫자 기재 금지.
+
+## 금지사항 준수
+
+Check/LEG 수정 / 새 엔진 / 법령 재판단: 없음. Evaluator 무수정. Check 결과 소비만.

--- a/reports/PHASE10_COVERAGE_REPORT.md
+++ b/reports/PHASE10_COVERAGE_REPORT.md
@@ -2,13 +2,18 @@
 
 > 상태: **PENDING** — 아래 숫자는 `scripts/run_quality_batch.py` 실제 실행 후 채운다. 추측 금지.
 
-## 의무 출처 (실데이터 확정)
+## 의무 출처 (실데이터로 확정)
 
-진단 기반 수집은 이 환경에서 0건(최신 진단의 result_data에 `inspection_required` 없음, `rules`/`key_obligations` 사용). 실제 운영 의무 원장 = **`work_schedules` (LEGAL, 60건 관측)**, distinct `rule_code`. 따라서 기본 출처를 work_schedules로 설정.
+라이브 DB 프로브 결과:
+- `work_schedules` 60건 = MANUAL 58 / LEGAL 2, **rule_code 0건 / law 연결 없음** → 의무 원장 아님.
+- `master_rules` / `obligation*` 테이블 없음, `legal_obligations` 0건.
+- **최신 진단 `factory_diagnosis_results(is_latest).result_data.rules` = 1,000 룰** → 각 룰에 rule_code / law_name / law_article / obligation 보유. **이것이 의무 전체.**
+
+→ 배치 기본 출처 = **diagnosis** (result_data.rules), obligation_id = rule_code.
 
 ## 1. 실행 명령
 ```bash
-PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기 (work_schedules)
+PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기 (diagnosis)
 PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 ```
 
@@ -16,7 +21,7 @@ PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 
 | 항목 | 값 |
 |------|-----|
-| source_rows (work_schedules LEGAL) | _PENDING_ |
+| source_rows (is_latest 진단) | _PENDING_ |
 | obligation_count (distinct rule_code) | _PENDING_ |
 | READY | _PENDING_ |
 | TRACE_REQUIRED | _PENDING_ |
@@ -35,7 +40,7 @@ PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 
 ## 5. Schedule Gate 결과 (per-call 시연, 실행 후 기록)
 
-`POST /legal-engine/generate-schedules/<FACTORY_ID>?enforce_quality=true`
+> 참고: 현 generate-schedules 엔드포인트는 result_data.inspection_required를 읽는데 실제 진단은 result_data.rules를 쓴다(키 불일치, Phase 10 범위 밖 관찰). 게이트 자체 동작은 obligation_quality 기반이므로 rule_code 공간은 일치.
 
 | field | value |
 |-------|-------|
@@ -45,4 +50,4 @@ PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 
 ## 예상 (현 시점, Check 리포트 부재)
 
-READY 0 / 대부분 TRACE_REQUIRED(EVIDENCE_INSUFFICIENT) / 일부 CORRECTION(LAW_LINK_ERROR·DUPLICATE). 실제 수치와 일치 여부를 실행으로 확인.
+READY 0 / 대부분 TRACE_REQUIRED(EVIDENCE_INSUFFICIENT) / law_name·law_article 누락 룰은 CORRECTION(LAW_LINK_ERROR). 실제 수치와 일치 여부 확인.

--- a/reports/PHASE10_COVERAGE_REPORT.md
+++ b/reports/PHASE10_COVERAGE_REPORT.md
@@ -2,17 +2,22 @@
 
 > 상태: **PENDING** — 아래 숫자는 `scripts/run_quality_batch.py` 실제 실행 후 채운다. 추측 금지.
 
+## 의무 출처 (실데이터 확정)
+
+진단 기반 수집은 이 환경에서 0건(최신 진단의 result_data에 `inspection_required` 없음, `rules`/`key_obligations` 사용). 실제 운영 의무 원장 = **`work_schedules` (LEGAL, 60건 관측)**, distinct `rule_code`. 따라서 기본 출처를 work_schedules로 설정.
+
 ## 1. 실행 명령
 ```bash
-PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기
+PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기 (work_schedules)
 PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 ```
 
 ## 2. Quality Distribution (실행 후 기록)
 
-| status | count |
-|--------|-------|
-| 전체 의무 | _PENDING_ |
+| 항목 | 값 |
+|------|-----|
+| source_rows (work_schedules LEGAL) | _PENDING_ |
+| obligation_count (distinct rule_code) | _PENDING_ |
 | READY | _PENDING_ |
 | TRACE_REQUIRED | _PENDING_ |
 | CORRECTION_REQUIRED | _PENDING_ |
@@ -40,4 +45,4 @@ PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 
 ## 예상 (현 시점, Check 리포트 부재)
 
-READY 0 / 대부분 TRACE_REQUIRED(EVIDENCE_INSUFFICIENT) / 일부 CORRECTION(LAW_LINK_ERROR·DUPLICATE). 이 예상과 실제 수치가 일치하는지 실행으로 확인.
+READY 0 / 대부분 TRACE_REQUIRED(EVIDENCE_INSUFFICIENT) / 일부 CORRECTION(LAW_LINK_ERROR·DUPLICATE). 실제 수치와 일치 여부를 실행으로 확인.

--- a/reports/PHASE10_COVERAGE_REPORT.md
+++ b/reports/PHASE10_COVERAGE_REPORT.md
@@ -18,14 +18,11 @@ railway run sh -c 'PYTHONPATH=. python scripts/quality_coverage_report.py'      
 
 ## 2. Quality Distribution — **VERIFIED (commit, 2026-06-03)**
 
-`railway run ... --commit` 실제 출력 (추측 아님):
+`railway run ... --commit` 실제 출력:
 ```json
-{"source":"diagnosis","mode":"commit","source_rows":1,"obligation_count":1000,
- "conflicts":0,
- "coverage":{"total":1000,
-   "distribution":{"READY":0,"TRACE_REQUIRED":1000,"CORRECTION_REQUIRED":0},
-   "top_reasons":[{"reason":"EVIDENCE_INSUFFICIENT","count":1000}],
-   "unclassified":0,"fully_classified":true},
+{"source":"diagnosis","mode":"commit","source_rows":1,"obligation_count":1000,"conflicts":0,
+ "coverage":{"total":1000,"distribution":{"READY":0,"TRACE_REQUIRED":1000,"CORRECTION_REQUIRED":0},
+   "top_reasons":[{"reason":"EVIDENCE_INSUFFICIENT","count":1000}],"unclassified":0,"fully_classified":true},
  "persisted":1000}
 ```
 
@@ -45,18 +42,25 @@ railway run sh -c 'PYTHONPATH=. python scripts/quality_coverage_report.py'      
 |---|--------|-------|
 | 1 | EVIDENCE_INSUFFICIENT | 1000 |
 
-## 4. Admin Queue 현황
+## 4. Admin Queue 현황 — **VERIFIED (table read, 2026-06-03)**
 
-CORRECTION_REQUIRED = 0 → 자동 등록 없음. 예상 OPEN 건수 **0**. (테이블 확인: `scripts/quality_coverage_report.py` → _PENDING_)
+`scripts/quality_coverage_report.py` 실제 출력:
+```json
+{"obligation_quality_rows":1000,
+ "coverage":{"total":1000,"distribution":{"READY":0,"TRACE_REQUIRED":1000,"CORRECTION_REQUIRED":0},
+   "top_reasons":[{"reason":"EVIDENCE_INSUFFICIENT","count":1000}],"unclassified":0,"fully_classified":true},
+ "admin_obligation_queue_total":0,"admin_obligation_queue_by_status":{}}
+```
+obligation_quality 테이블에 1000행 적재 확인. CORRECTION 0 → admin 큐 **0건** 확정.
 
 ## 5. Schedule Gate — 배포 후
 
-`enforce_quality` 파라미터는 피처 브랜치에만 있어 현 운영(main)에 미배포. READY=0이므로 활성화 시 전량 skipped_not_ready(스케줄 0). 로직은 순수 테스트로 검증됨(`is_schedulable`). 전역 활성화는 Check 연결 후.
+`enforce_quality` 파라미터는 피처 브랜치에만 있어 현 운영(main)에 미배포. READY=0이므로 활성화 시 전량 skipped_not_ready(스케줄 0). 로직은 순수 테스트로 검증됨(`is_schedulable`). 전역 활성화는 Check 연결로 READY 발생 후.
 
 ## 참고 — Coverage HTTP 엔드포인트 404
 
-`GET /admin/obligations/coverage` 가 prod에서 404인 것은 라우터(routers/admin_obligation_queue.py)가 아직 main에 미머지·미배포라서. PR #89/#90 머지 + 배포 후 동작. 그 전엔 위 스크립트로 테이블에서 직접 확인.
+`GET /admin/obligations/coverage` 가 prod에서 404인 것은 라우터가 아직 main에 미머지·미배포라서. PR #89/#90 머지 + 배포 후 동작. 그 전엔 위 스크립트로 테이블에서 직접 확인(상기 4번).
 
 ## 결론
 
-성공 기준 달성: 기존 의무 전체(1000)가 3상태 중 하나를 가진다 (fully_classified=true), 실 DB 적재 완료(persisted=1000). 현 품질은 "전체 추적 필요(Check 미수행)" — 정직한 산출. 다음 근본 과제 = 의무별 Check 리포트(LEG→Check) 연결 → READY 발생.
+성공 기준 달성: 기존 의무 전체(1000)가 3상태 중 하나(fully_classified=true), 실 DB 적재 완료(persisted=1000, 테이블 재확인 1000). 현 품질은 "전체 추적 필요(Check 미수행)" — 정직한 산출. 다음 근본 과제 = 의무별 Check 리포트(LEG→Check) 연결 → READY 발생.

--- a/reports/PHASE10_COVERAGE_REPORT.md
+++ b/reports/PHASE10_COVERAGE_REPORT.md
@@ -5,54 +5,58 @@
 라이브 DB 프로브 결과:
 - `work_schedules` 60건 = MANUAL 58 / LEGAL 2, **rule_code 0건 / law 연결 없음** → 의무 원장 아님.
 - `master_rules` / `obligation*` 테이블 없음, `legal_obligations` 0건.
-- **최신 진단 `factory_diagnosis_results(is_latest).result_data.rules` = 1,000 룰** → 각 룰에 rule_code / law_name / law_article / obligation 보유. **이것이 의무 전체.**
+- **최신 진단 `factory_diagnosis_results(is_latest).result_data.rules` = 1,000 룰** → rule_code / law_name / law_article / obligation 보유. **이것이 의무 전체.**
 
-→ 배치 기본 출처 = **diagnosis** (result_data.rules), obligation_id = rule_code.
+→ 배치 출처 = diagnosis (result_data.rules), obligation_id = rule_code.
 
 ## 1. 실행 명령
 ```bash
-PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기 (diagnosis)
-PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
+PYTHONPATH=. python scripts/run_quality_batch.py --dry-run                       # 미리보기(anon 가능)
+railway run sh -c 'PYTHONPATH=. python scripts/run_quality_batch.py --commit'    # 적재(service_role)
+railway run sh -c 'PYTHONPATH=. python scripts/quality_coverage_report.py'       # 테이블에서 Coverage 읽기
 ```
 
-## 2. Quality Distribution — **VERIFIED (dry-run, 2026-06-03)**
+## 2. Quality Distribution — **VERIFIED (commit, 2026-06-03)**
 
-실제 실행 출력 (추측 아님):
+`railway run ... --commit` 실제 출력 (추측 아님):
 ```json
-{"source":"diagnosis","mode":"dry-run","source_rows":1,"obligation_count":1000,
+{"source":"diagnosis","mode":"commit","source_rows":1,"obligation_count":1000,
  "conflicts":0,
  "coverage":{"total":1000,
    "distribution":{"READY":0,"TRACE_REQUIRED":1000,"CORRECTION_REQUIRED":0},
    "top_reasons":[{"reason":"EVIDENCE_INSUFFICIENT","count":1000}],
-   "unclassified":0,"fully_classified":true}}
+   "unclassified":0,"fully_classified":true},
+ "persisted":1000}
 ```
 
 | 항목 | 값 |
 |------|-----|
-| source_rows (is_latest 진단) | 1 |
 | obligation_count (distinct rule_code) | 1000 |
 | READY | 0 |
 | TRACE_REQUIRED | 1000 |
 | CORRECTION_REQUIRED | 0 |
 | conflicts | 0 |
+| **persisted (obligation_quality upsert)** | **1000** ✅ |
 | **fully_classified** | **true** ✅ |
 
-해석: 1,000개 의무 모두 법령 연결 OK + 중복 없음. 단 Check 리포트가 없어 전부 TRACE_REQUIRED(근거 미관측). Check 연결 후 재실행하면 일부가 READY/CORRECTION으로 이동.
-
-## 3. TOP 10 원인 — VERIFIED (dry-run)
+## 3. TOP 10 원인 — VERIFIED
 
 | # | reason | count |
 |---|--------|-------|
 | 1 | EVIDENCE_INSUFFICIENT | 1000 |
 
-## 4. Admin Queue 현황 (적재 후 기록)
+## 4. Admin Queue 현황
 
-CORRECTION_REQUIRED = 0 → 자동 등록 대상 없음. `--commit` 후 `GET /admin/obligations/queue?status=OPEN` → OPEN 건수 기대값 **0**. (실행 후 확인 기록: _PENDING_)
+CORRECTION_REQUIRED = 0 → 자동 등록 없음. 예상 OPEN 건수 **0**. (테이블 확인: `scripts/quality_coverage_report.py` → _PENDING_)
 
-## 5. Schedule Gate 결과 (per-call 시연, 실행 후 기록)
+## 5. Schedule Gate — 배포 후
 
-> READY=0 이므로 게이트 활성화 시 모든 의무가 skipped_not_ready로 제외된다(스케줄 0건). 전역 활성화 금지, Check 연결로 READY 발생 후 검토. (per-call 시연 결과: _PENDING_)
+`enforce_quality` 파라미터는 피처 브랜치에만 있어 현 운영(main)에 미배포. READY=0이므로 활성화 시 전량 skipped_not_ready(스케줄 0). 로직은 순수 테스트로 검증됨(`is_schedulable`). 전역 활성화는 Check 연결 후.
+
+## 참고 — Coverage HTTP 엔드포인트 404
+
+`GET /admin/obligations/coverage` 가 prod에서 404인 것은 라우터(routers/admin_obligation_queue.py)가 아직 main에 미머지·미배포라서. PR #89/#90 머지 + 배포 후 동작. 그 전엔 위 스크립트로 테이블에서 직접 확인.
 
 ## 결론
 
-성공 기준 달성: 기존 의무 전체(1000)가 READY/TRACE_REQUIRED/CORRECTION_REQUIRED 중 하나를 가진다 → fully_classified=true. 현 품질 상태는 "전체 추적 필요(Check 미수행)"로 정직하게 산출됨.
+성공 기준 달성: 기존 의무 전체(1000)가 3상태 중 하나를 가진다 (fully_classified=true), 실 DB 적재 완료(persisted=1000). 현 품질은 "전체 추적 필요(Check 미수행)" — 정직한 산출. 다음 근본 과제 = 의무별 Check 리포트(LEG→Check) 연결 → READY 발생.

--- a/reports/PHASE10_COVERAGE_REPORT.md
+++ b/reports/PHASE10_COVERAGE_REPORT.md
@@ -1,7 +1,5 @@
 # Phase 10 — Quality Coverage Report
 
-> 상태: **PENDING** — 아래 숫자는 `scripts/run_quality_batch.py` 실제 실행 후 채운다. 추측 금지.
-
 ## 의무 출처 (실데이터로 확정)
 
 라이브 DB 프로브 결과:
@@ -17,37 +15,44 @@ PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기 (dia
 PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
 ```
 
-## 2. Quality Distribution (실행 후 기록)
+## 2. Quality Distribution — **VERIFIED (dry-run, 2026-06-03)**
+
+실제 실행 출력 (추측 아님):
+```json
+{"source":"diagnosis","mode":"dry-run","source_rows":1,"obligation_count":1000,
+ "conflicts":0,
+ "coverage":{"total":1000,
+   "distribution":{"READY":0,"TRACE_REQUIRED":1000,"CORRECTION_REQUIRED":0},
+   "top_reasons":[{"reason":"EVIDENCE_INSUFFICIENT","count":1000}],
+   "unclassified":0,"fully_classified":true}}
+```
 
 | 항목 | 값 |
 |------|-----|
-| source_rows (is_latest 진단) | _PENDING_ |
-| obligation_count (distinct rule_code) | _PENDING_ |
-| READY | _PENDING_ |
-| TRACE_REQUIRED | _PENDING_ |
-| CORRECTION_REQUIRED | _PENDING_ |
-| fully_classified | _PENDING_ |
+| source_rows (is_latest 진단) | 1 |
+| obligation_count (distinct rule_code) | 1000 |
+| READY | 0 |
+| TRACE_REQUIRED | 1000 |
+| CORRECTION_REQUIRED | 0 |
+| conflicts | 0 |
+| **fully_classified** | **true** ✅ |
 
-## 3. TOP 10 원인 (quality_reason, 실행 후 기록)
+해석: 1,000개 의무 모두 법령 연결 OK + 중복 없음. 단 Check 리포트가 없어 전부 TRACE_REQUIRED(근거 미관측). Check 연결 후 재실행하면 일부가 READY/CORRECTION으로 이동.
+
+## 3. TOP 10 원인 — VERIFIED (dry-run)
 
 | # | reason | count |
 |---|--------|-------|
-| 1 | _PENDING_ | |
+| 1 | EVIDENCE_INSUFFICIENT | 1000 |
 
-## 4. Admin Queue 현황 (실행 후 기록)
+## 4. Admin Queue 현황 (적재 후 기록)
 
-`GET /admin/obligations/queue?status=OPEN` → OPEN 건수: _PENDING_
+CORRECTION_REQUIRED = 0 → 자동 등록 대상 없음. `--commit` 후 `GET /admin/obligations/queue?status=OPEN` → OPEN 건수 기대값 **0**. (실행 후 확인 기록: _PENDING_)
 
 ## 5. Schedule Gate 결과 (per-call 시연, 실행 후 기록)
 
-> 참고: 현 generate-schedules 엔드포인트는 result_data.inspection_required를 읽는데 실제 진단은 result_data.rules를 쓴다(키 불일치, Phase 10 범위 밖 관찰). 게이트 자체 동작은 obligation_quality 기반이므로 rule_code 공간은 일치.
+> READY=0 이므로 게이트 활성화 시 모든 의무가 skipped_not_ready로 제외된다(스케줄 0건). 전역 활성화 금지, Check 연결로 READY 발생 후 검토. (per-call 시연 결과: _PENDING_)
 
-| field | value |
-|-------|-------|
-| created | _PENDING_ |
-| skipped_not_ready | _PENDING_ |
-| skipped_unevaluated | _PENDING_ |
+## 결론
 
-## 예상 (현 시점, Check 리포트 부재)
-
-READY 0 / 대부분 TRACE_REQUIRED(EVIDENCE_INSUFFICIENT) / law_name·law_article 누락 룰은 CORRECTION(LAW_LINK_ERROR). 실제 수치와 일치 여부 확인.
+성공 기준 달성: 기존 의무 전체(1000)가 READY/TRACE_REQUIRED/CORRECTION_REQUIRED 중 하나를 가진다 → fully_classified=true. 현 품질 상태는 "전체 추적 필요(Check 미수행)"로 정직하게 산출됨.

--- a/reports/PHASE10_COVERAGE_REPORT.md
+++ b/reports/PHASE10_COVERAGE_REPORT.md
@@ -1,0 +1,43 @@
+# Phase 10 — Quality Coverage Report
+
+> 상태: **PENDING** — 아래 숫자는 `scripts/run_quality_batch.py` 실제 실행 후 채운다. 추측 금지.
+
+## 1. 실행 명령
+```bash
+PYTHONPATH=. python scripts/run_quality_batch.py --dry-run   # 미리보기
+PYTHONPATH=. python scripts/run_quality_batch.py --commit    # 적재
+```
+
+## 2. Quality Distribution (실행 후 기록)
+
+| status | count |
+|--------|-------|
+| 전체 의무 | _PENDING_ |
+| READY | _PENDING_ |
+| TRACE_REQUIRED | _PENDING_ |
+| CORRECTION_REQUIRED | _PENDING_ |
+| fully_classified | _PENDING_ |
+
+## 3. TOP 10 원인 (quality_reason, 실행 후 기록)
+
+| # | reason | count |
+|---|--------|-------|
+| 1 | _PENDING_ | |
+
+## 4. Admin Queue 현황 (실행 후 기록)
+
+`GET /admin/obligations/queue?status=OPEN` → OPEN 건수: _PENDING_
+
+## 5. Schedule Gate 결과 (per-call 시연, 실행 후 기록)
+
+`POST /legal-engine/generate-schedules/<FACTORY_ID>?enforce_quality=true`
+
+| field | value |
+|-------|-------|
+| created | _PENDING_ |
+| skipped_not_ready | _PENDING_ |
+| skipped_unevaluated | _PENDING_ |
+
+## 예상 (현 시점, Check 리포트 부재)
+
+READY 0 / 대부분 TRACE_REQUIRED(EVIDENCE_INSUFFICIENT) / 일부 CORRECTION(LAW_LINK_ERROR·DUPLICATE). 이 예상과 실제 수치가 일치하는지 실행으로 확인.

--- a/routers/admin_obligation_queue.py
+++ b/routers/admin_obligation_queue.py
@@ -1,9 +1,10 @@
-"""Phase 9 — Admin Obligation Queue API.
+"""Phase 9/10 — Admin Obligation Queue + Coverage API.
 
-CORRECTION_REQUIRED 의무의 보정 작업 큐 조회/배정/해소. 운영 어드민 전용.
+CORRECTION_REQUIRED 의무의 보정 작업 큐 + 품질 Coverage. 운영 어드민 전용.
 GET    /admin/obligations/queue          목록(상태 필터)
 GET    /admin/obligations/queue/{id}      상세
 PATCH  /admin/obligations/queue/{id}      상태/담당자 변경
+GET    /admin/obligations/coverage        품질 분포 + TOP10 원인 (Phase 10)
 """
 from datetime import datetime, timezone
 from typing import Optional
@@ -42,6 +43,16 @@ def list_queue(
     start = (page - 1) * page_size
     res = q.order("created_at", desc=True).range(start, start + page_size - 1).execute()
     return {"status": "success", "data": res.data or [], "page": page, "page_size": page_size}
+
+
+@router.get("/admin/obligations/coverage")
+def coverage():
+    """Phase 10: 전체 obligation_quality 분포 + TOP10 원인."""
+    from db.supabase_client import get_supabase
+    from services.obligation_quality_coverage import compute_coverage
+    sb = get_supabase()
+    res = sb.table("obligation_quality").select("obligation_id, quality_status, quality_reason").execute()
+    return {"status": "success", "data": compute_coverage(res.data or [])}
 
 
 @router.get("/admin/obligations/queue/{queue_id}")

--- a/scripts/inspect_obligation_sources.py
+++ b/scripts/inspect_obligation_sources.py
@@ -1,0 +1,72 @@
+"""Phase 10 — read-only diagnostic: locate the real obligation population.
+
+No writes. Probes candidate source tables + the latest diagnosis result_data
+shape so we can ground the batch on ACTUAL data (the diagnosis-based source
+returned 0 obligations in this environment).
+
+    PYTHONPATH=. python scripts/inspect_obligation_sources.py
+"""
+import json
+
+from db.supabase_client import get_supabase
+
+# Candidate tables that might hold the obligation catalogue.
+CANDIDATE_TABLES = [
+    "factory_diagnosis_results",
+    "master_rules",
+    "evidence_candidate",
+    "obligation_candidate",
+    "obligations",
+    "obligation",
+    "legal_obligations",
+    "refined_obligation",
+    "obligation_refined",
+    "work_schedules",
+]
+
+
+def probe_table(sb, table):
+    try:
+        res = sb.table(table).select("*", count="exact").limit(1).execute()
+        sample_keys = sorted(res.data[0].keys()) if res.data else []
+        return {"table": table, "exists": True, "count": res.count, "sample_keys": sample_keys}
+    except Exception as e:  # noqa: BLE001
+        return {"table": table, "exists": False, "error": str(e)[:160]}
+
+
+def inspect_diagnosis(sb):
+    try:
+        res = (
+            sb.table("factory_diagnosis_results")
+            .select("id, factory_id, is_latest, result_data")
+            .eq("is_latest", True)
+            .limit(5)
+            .execute()
+        )
+        out = []
+        for row in (res.data or []):
+            rd = row.get("result_data") or {}
+            insp = rd.get("inspection_required")
+            out.append({
+                "id": row.get("id"),
+                "factory_id": row.get("factory_id"),
+                "result_data_keys": sorted(rd.keys()) if isinstance(rd, dict) else str(type(rd)),
+                "inspection_required_len": len(insp) if isinstance(insp, list) else None,
+                "inspection_required_sample": (insp[0] if isinstance(insp, list) and insp else None),
+            })
+        return out
+    except Exception as e:  # noqa: BLE001
+        return {"error": str(e)[:200]}
+
+
+def main():
+    sb = get_supabase()
+    report = {
+        "candidate_tables": [probe_table(sb, t) for t in CANDIDATE_TABLES],
+        "latest_diagnosis": inspect_diagnosis(sb),
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inspect_obligation_sources.py
+++ b/scripts/inspect_obligation_sources.py
@@ -1,44 +1,54 @@
-"""Phase 10 — read-only diagnostic: locate the real obligation population.
+"""Phase 10 — read-only diagnostic v2: see the REAL obligation data.
 
-No writes. Probes candidate source tables + the latest diagnosis result_data
-shape so we can ground the batch on ACTUAL data (the diagnosis-based source
-returned 0 obligations in this environment).
+No writes. Shows:
+  - work_schedules breakdown: total, by source_type, how many have rule_code,
+    distinct rule_code count, samples.
+  - latest diagnosis result_data.rules / key_obligations shape + samples.
+Goal: stop guessing filters — ground the batch source on actual rows.
 
     PYTHONPATH=. python scripts/inspect_obligation_sources.py
 """
 import json
+from collections import Counter
 
 from db.supabase_client import get_supabase
 
-# Candidate tables that might hold the obligation catalogue.
-CANDIDATE_TABLES = [
-    "factory_diagnosis_results",
-    "master_rules",
-    "evidence_candidate",
-    "obligation_candidate",
-    "obligations",
-    "obligation",
-    "legal_obligations",
-    "refined_obligation",
-    "obligation_refined",
-    "work_schedules",
-]
 
-
-def probe_table(sb, table):
+def inspect_work_schedules(sb):
     try:
-        res = sb.table(table).select("*", count="exact").limit(1).execute()
-        sample_keys = sorted(res.data[0].keys()) if res.data else []
-        return {"table": table, "exists": True, "count": res.count, "sample_keys": sample_keys}
+        res = (
+            sb.table("work_schedules")
+            .select("rule_code, source_type, status_code, law_name, law_article")
+            .limit(2000)
+            .execute()
+        )
+        rows = res.data or []
+        by_source = Counter((r.get("source_type") or "<none>") for r in rows)
+        with_rule = [r for r in rows if (r.get("rule_code") or "").strip()]
+        rule_by_source = Counter((r.get("source_type") or "<none>") for r in with_rule)
+        distinct_rule_codes = sorted({(r.get("rule_code") or "").strip() for r in with_rule})
+        samples = [
+            {k: r.get(k) for k in ("rule_code", "source_type", "status_code", "law_name", "law_article")}
+            for r in rows[:8]
+        ]
+        return {
+            "total": len(rows),
+            "by_source_type": dict(by_source),
+            "rows_with_rule_code": len(with_rule),
+            "rule_code_by_source_type": dict(rule_by_source),
+            "distinct_rule_code_count": len(distinct_rule_codes),
+            "distinct_rule_code_sample": distinct_rule_codes[:10],
+            "row_samples": samples,
+        }
     except Exception as e:  # noqa: BLE001
-        return {"table": table, "exists": False, "error": str(e)[:160]}
+        return {"error": str(e)[:200]}
 
 
-def inspect_diagnosis(sb):
+def inspect_diagnosis_rules(sb):
     try:
         res = (
             sb.table("factory_diagnosis_results")
-            .select("id, factory_id, is_latest, result_data")
+            .select("id, factory_id, rule_count, result_data")
             .eq("is_latest", True)
             .limit(5)
             .execute()
@@ -46,13 +56,15 @@ def inspect_diagnosis(sb):
         out = []
         for row in (res.data or []):
             rd = row.get("result_data") or {}
-            insp = rd.get("inspection_required")
+            rules = rd.get("rules") if isinstance(rd, dict) else None
+            keyobs = rd.get("key_obligations") if isinstance(rd, dict) else None
             out.append({
                 "id": row.get("id"),
-                "factory_id": row.get("factory_id"),
-                "result_data_keys": sorted(rd.keys()) if isinstance(rd, dict) else str(type(rd)),
-                "inspection_required_len": len(insp) if isinstance(insp, list) else None,
-                "inspection_required_sample": (insp[0] if isinstance(insp, list) and insp else None),
+                "rule_count_col": row.get("rule_count"),
+                "rules_len": len(rules) if isinstance(rules, list) else None,
+                "rules_sample": (rules[0] if isinstance(rules, list) and rules else None),
+                "key_obligations_len": len(keyobs) if isinstance(keyobs, list) else None,
+                "key_obligations_sample": (keyobs[0] if isinstance(keyobs, list) and keyobs else None),
             })
         return out
     except Exception as e:  # noqa: BLE001
@@ -62,8 +74,8 @@ def inspect_diagnosis(sb):
 def main():
     sb = get_supabase()
     report = {
-        "candidate_tables": [probe_table(sb, t) for t in CANDIDATE_TABLES],
-        "latest_diagnosis": inspect_diagnosis(sb),
+        "work_schedules": inspect_work_schedules(sb),
+        "latest_diagnosis_rules": inspect_diagnosis_rules(sb),
     }
     print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
 

--- a/scripts/quality_coverage_report.py
+++ b/scripts/quality_coverage_report.py
@@ -1,0 +1,32 @@
+"""Phase 10 — read obligation_quality + admin_obligation_queue from the DB and
+print the coverage report. Mirrors what GET /admin/obligations/coverage returns,
+but runnable before the router is deployed.
+
+RLS-protected tables -> needs service_role key. Run with Railway env injected:
+    railway run sh -c 'PYTHONPATH=. python scripts/quality_coverage_report.py'
+"""
+import json
+from collections import Counter
+
+from db.supabase_client import get_supabase
+from services.obligation_quality_coverage import compute_coverage
+
+
+def main():
+    sb = get_supabase()
+    oq = sb.table("obligation_quality").select("obligation_id, quality_status, quality_reason").execute()
+    rows = oq.data or []
+
+    queue = sb.table("admin_obligation_queue").select("status").execute()
+    queue_by_status = Counter((r.get("status") or "<none>") for r in (queue.data or []))
+
+    print(json.dumps({
+        "obligation_quality_rows": len(rows),
+        "coverage": compute_coverage(rows),
+        "admin_obligation_queue_total": len(queue.data or []),
+        "admin_obligation_queue_by_status": dict(queue_by_status),
+    }, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_quality_batch.py
+++ b/scripts/run_quality_batch.py
@@ -7,15 +7,21 @@ Real obligation source (confirmed by live DB probe):
 Run from repo root:
     # preview only (no DB writes), default source = diagnosis:
     PYTHONPATH=. python scripts/run_quality_batch.py --dry-run
-    # persist + auto-load admin queue on CORRECTION_REQUIRED:
-    PYTHONPATH=. python scripts/run_quality_batch.py --commit
+    # persist + auto-load admin queue on CORRECTION_REQUIRED (needs service_role key):
+    SUPABASE_SERVICE_KEY=... PYTHONPATH=. python scripts/run_quality_batch.py --commit
     # alternate source:
     PYTHONPATH=. python scripts/run_quality_batch.py --source work_schedules --dry-run
 
 Obligations without a Check report -> TRACE_REQUIRED (real, not fabricated).
+
+NOTE: --commit writes to obligation_quality / admin_obligation_queue which have RLS
+enabled. The Supabase client must use the service_role key (SUPABASE_SERVICE_KEY),
+which bypasses RLS. The anon key (SUPABASE_KEY) can read for --dry-run but cannot
+write. This guard fails fast with a clear message instead of an RLS traceback.
 """
 import argparse
 import json
+import os
 
 from db.supabase_client import get_supabase
 from services.obligation_quality_batch import (
@@ -53,6 +59,15 @@ def main():
     ap.add_argument("--dry-run", action="store_true", help="evaluate + print only, no writes")
     args = ap.parse_args()
     commit = args.commit and not args.dry_run
+
+    if commit and not os.environ.get("SUPABASE_SERVICE_KEY"):
+        print(json.dumps({
+            "error": "SUPABASE_SERVICE_KEY_NOT_SET",
+            "message": "--commit writes to RLS-protected tables and requires the service_role key. "
+                       "Set SUPABASE_SERVICE_KEY (Supabase dashboard > Project Settings > API > service_role) "
+                       "then retry. --dry-run works with the anon key.",
+        }, ensure_ascii=False, indent=2))
+        raise SystemExit(1)
 
     sb = get_supabase()
     if args.source == "work_schedules":

--- a/scripts/run_quality_batch.py
+++ b/scripts/run_quality_batch.py
@@ -1,0 +1,67 @@
+"""Phase 10 — batch-evaluate all existing obligations into obligation_quality.
+
+Run from repo root:
+    # preview only (no DB writes):
+    PYTHONPATH=. python scripts/run_quality_batch.py --dry-run
+    # persist + auto-load admin queue on CORRECTION_REQUIRED:
+    PYTHONPATH=. python scripts/run_quality_batch.py --commit
+
+Reads factory_diagnosis_results(is_latest) -> inspection_required rules,
+evaluates the population with the VERIFIED evaluator, prints coverage JSON.
+Obligations without a Check report -> TRACE_REQUIRED (real, not fabricated).
+"""
+import argparse
+import json
+
+from db.supabase_client import get_supabase
+from services.obligation_quality_batch import (
+    collect_obligations_from_diagnosis,
+    evaluate_population,
+)
+from services.obligation_quality_coverage import compute_coverage
+from services.obligation_quality_store import record_evaluation
+
+
+def load_diagnosis_rows(sb):
+    res = (
+        sb.table("factory_diagnosis_results")
+        .select("result_data")
+        .eq("is_latest", True)
+        .execute()
+    )
+    return res.data or []
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--commit", action="store_true", help="persist to obligation_quality + admin queue")
+    ap.add_argument("--dry-run", action="store_true", help="evaluate + print only, no writes")
+    args = ap.parse_args()
+    commit = args.commit and not args.dry_run
+
+    sb = get_supabase()
+    rows = load_diagnosis_rows(sb)
+    obligations, conflicts = collect_obligations_from_diagnosis(rows)
+    results = evaluate_population(obligations, conflicts)
+    coverage = compute_coverage(results)
+
+    persisted = 0
+    if commit:
+        for r in results:
+            record_evaluation(
+                r["obligation_id"], r["quality_status"], r.get("quality_reason"), r.get("check_report_id")
+            )
+            persisted += 1
+
+    print(json.dumps({
+        "mode": "commit" if commit else "dry-run",
+        "diagnosis_rows": len(rows),
+        "obligation_count": len(obligations),
+        "conflicts": len(conflicts),
+        "coverage": coverage,
+        "persisted": persisted,
+    }, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_quality_batch.py
+++ b/scripts/run_quality_batch.py
@@ -1,12 +1,16 @@
 """Phase 10 — batch-evaluate all existing obligations into obligation_quality.
 
+Real obligation source (confirmed by live DB probe):
+  factory_diagnosis_results(is_latest).result_data.rules  — obligation_id = rule_code.
+  (work_schedules has no rule_code/law linkage — not an obligation catalogue.)
+
 Run from repo root:
-    # preview only (no DB writes), default source = work_schedules (LEGAL):
+    # preview only (no DB writes), default source = diagnosis:
     PYTHONPATH=. python scripts/run_quality_batch.py --dry-run
     # persist + auto-load admin queue on CORRECTION_REQUIRED:
     PYTHONPATH=. python scripts/run_quality_batch.py --commit
     # alternate source:
-    PYTHONPATH=. python scripts/run_quality_batch.py --source diagnosis --dry-run
+    PYTHONPATH=. python scripts/run_quality_batch.py --source work_schedules --dry-run
 
 Obligations without a Check report -> TRACE_REQUIRED (real, not fabricated).
 """
@@ -27,7 +31,6 @@ def load_work_schedule_rows(sb):
     res = (
         sb.table("work_schedules")
         .select("rule_code, law_name, law_article, obligation_type, description, summary, source_type")
-        .eq("source_type", "LEGAL")
         .execute()
     )
     return res.data or []
@@ -45,7 +48,7 @@ def load_diagnosis_rows(sb):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--source", choices=["work_schedules", "diagnosis"], default="work_schedules")
+    ap.add_argument("--source", choices=["diagnosis", "work_schedules"], default="diagnosis")
     ap.add_argument("--commit", action="store_true", help="persist to obligation_quality + admin queue")
     ap.add_argument("--dry-run", action="store_true", help="evaluate + print only, no writes")
     args = ap.parse_args()

--- a/scripts/run_quality_batch.py
+++ b/scripts/run_quality_batch.py
@@ -1,13 +1,13 @@
 """Phase 10 — batch-evaluate all existing obligations into obligation_quality.
 
 Run from repo root:
-    # preview only (no DB writes):
+    # preview only (no DB writes), default source = work_schedules (LEGAL):
     PYTHONPATH=. python scripts/run_quality_batch.py --dry-run
     # persist + auto-load admin queue on CORRECTION_REQUIRED:
     PYTHONPATH=. python scripts/run_quality_batch.py --commit
+    # alternate source:
+    PYTHONPATH=. python scripts/run_quality_batch.py --source diagnosis --dry-run
 
-Reads factory_diagnosis_results(is_latest) -> inspection_required rules,
-evaluates the population with the VERIFIED evaluator, prints coverage JSON.
 Obligations without a Check report -> TRACE_REQUIRED (real, not fabricated).
 """
 import argparse
@@ -16,10 +16,21 @@ import json
 from db.supabase_client import get_supabase
 from services.obligation_quality_batch import (
     collect_obligations_from_diagnosis,
+    collect_obligations_from_work_schedules,
     evaluate_population,
 )
 from services.obligation_quality_coverage import compute_coverage
 from services.obligation_quality_store import record_evaluation
+
+
+def load_work_schedule_rows(sb):
+    res = (
+        sb.table("work_schedules")
+        .select("rule_code, law_name, law_article, obligation_type, description, summary, source_type")
+        .eq("source_type", "LEGAL")
+        .execute()
+    )
+    return res.data or []
 
 
 def load_diagnosis_rows(sb):
@@ -34,14 +45,20 @@ def load_diagnosis_rows(sb):
 
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--source", choices=["work_schedules", "diagnosis"], default="work_schedules")
     ap.add_argument("--commit", action="store_true", help="persist to obligation_quality + admin queue")
     ap.add_argument("--dry-run", action="store_true", help="evaluate + print only, no writes")
     args = ap.parse_args()
     commit = args.commit and not args.dry_run
 
     sb = get_supabase()
-    rows = load_diagnosis_rows(sb)
-    obligations, conflicts = collect_obligations_from_diagnosis(rows)
+    if args.source == "work_schedules":
+        rows = load_work_schedule_rows(sb)
+        obligations, conflicts = collect_obligations_from_work_schedules(rows)
+    else:
+        rows = load_diagnosis_rows(sb)
+        obligations, conflicts = collect_obligations_from_diagnosis(rows)
+
     results = evaluate_population(obligations, conflicts)
     coverage = compute_coverage(results)
 
@@ -54,8 +71,9 @@ def main():
             persisted += 1
 
     print(json.dumps({
+        "source": args.source,
         "mode": "commit" if commit else "dry-run",
-        "diagnosis_rows": len(rows),
+        "source_rows": len(rows),
         "obligation_count": len(obligations),
         "conflicts": len(conflicts),
         "coverage": coverage,

--- a/services/obligation_quality_batch.py
+++ b/services/obligation_quality_batch.py
@@ -1,0 +1,92 @@
+"""Phase 10 — Obligation population batch helpers (service layer, no new engine).
+
+Pure functions to (1) collect the distinct obligation population from latest
+factory diagnosis results, and (2) evaluate the whole population with the
+VERIFIED Phase 9 evaluator. Where an obligation has no Check EvidenceReport yet,
+a well-formed EMPTY report is used — which the evaluator correctly maps to
+TRACE_REQUIRED (근거 미관측 / 추적 필요), NOT a fabricated result.
+
+IO (Supabase reads/writes) lives in scripts/run_quality_batch.py, not here.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from services.obligation_quality_evaluator import evaluate_quality
+
+
+def empty_check_report(obligation_id: Optional[str] = None) -> Dict[str, Any]:
+    """A well-formed Check report with nothing observed yet.
+
+    Truthfully represents "no evidence/claim/chain observed" -> evaluator returns
+    TRACE_REQUIRED. This is NOT a fake PASS; it encodes the real fact that the
+    obligation has not been Check-evaluated.
+    """
+    return {
+        "report_id": None,
+        "status_summary": {"claim": {}, "evidence": {}, "chain": {}},
+        "observation_records": [],
+    }
+
+
+def collect_obligations_from_diagnosis(
+    diagnosis_rows: List[dict],
+) -> Tuple[List[dict], Set[str]]:
+    """Collect distinct obligations (by obligation_id) from latest diagnosis rows.
+
+    Source = factory_diagnosis_results.result_data.inspection_required[] — the same
+    rules the schedule gate consults (rule_id/rule_code = obligation_id).
+    Returns (obligations, conflict_ids). conflict_ids = same obligation_id whose
+    law linkage disagrees across rows (a real data anomaly -> CORRECTION).
+    """
+    by_id: Dict[str, dict] = {}
+    conflicts: Set[str] = set()
+
+    for row in diagnosis_rows:
+        result_data = (row or {}).get("result_data") or {}
+        for rule in (result_data.get("inspection_required") or []):
+            oid = (rule.get("rule_id") or rule.get("rule_code") or "").strip()
+            if not oid:
+                continue
+            ob = {
+                "obligation_id": oid,
+                "law_name": rule.get("law_name") or "",
+                "law_article": rule.get("law_article") or "",
+                "obligation_type": rule.get("obligation_type") or "",
+                "obligation_summary": rule.get("obligation_summary") or rule.get("description") or "",
+            }
+            if oid in by_id:
+                prev = by_id[oid]
+                if (prev.get("law_name") or "") != (ob.get("law_name") or "") or (
+                    prev.get("law_article") or ""
+                ) != (ob.get("law_article") or ""):
+                    conflicts.add(oid)
+            else:
+                by_id[oid] = ob
+
+    return list(by_id.values()), conflicts
+
+
+def evaluate_population(
+    obligations: List[dict],
+    conflicts: Optional[Set[str]] = None,
+    reports_by_id: Optional[Dict[str, dict]] = None,
+) -> List[Dict[str, Any]]:
+    """Evaluate every obligation. Uses a real Check report if provided in
+    reports_by_id, else an empty (not-yet-evaluated) report.
+    """
+    conflicts = conflicts or set()
+    reports_by_id = reports_by_id or {}
+    out: List[Dict[str, Any]] = []
+    for ob in obligations:
+        oid = ob.get("obligation_id")
+        report = reports_by_id.get(oid) or empty_check_report(oid)
+        is_conflict = oid in conflicts
+        res = evaluate_quality(ob, report, duplicate=is_conflict)
+        out.append({
+            "obligation_id": oid,
+            "quality_status": res["quality_status"],
+            "quality_reason": res["quality_reason"],
+            "check_report_id": report.get("report_id"),
+        })
+    return out

--- a/services/obligation_quality_batch.py
+++ b/services/obligation_quality_batch.py
@@ -1,12 +1,13 @@
 """Phase 10 — Obligation population batch helpers (service layer, no new engine).
 
-Pure functions to (1) collect the distinct obligation population from latest
-factory diagnosis results, and (2) evaluate the whole population with the
-VERIFIED Phase 9 evaluator. Where an obligation has no Check EvidenceReport yet,
-a well-formed EMPTY report is used — which the evaluator correctly maps to
-TRACE_REQUIRED (근거 미관측 / 추적 필요), NOT a fabricated result.
+Pure functions to collect the distinct obligation population and evaluate it with
+the VERIFIED Phase 9 evaluator. Two confirmed sources:
+  - work_schedules (LEGAL) : the obligations actually in operation (real catalogue)
+  - factory_diagnosis_results.result_data.inspection_required : per-diagnosis rules
 
-IO (Supabase reads/writes) lives in scripts/run_quality_batch.py, not here.
+Where an obligation has no Check EvidenceReport yet, a well-formed EMPTY report is
+used — which the evaluator correctly maps to TRACE_REQUIRED (근거 미관측 / 추적 필요),
+NOT a fabricated result. IO (Supabase reads/writes) lives in the runner script.
 """
 from __future__ import annotations
 
@@ -16,11 +17,8 @@ from services.obligation_quality_evaluator import evaluate_quality
 
 
 def empty_check_report(obligation_id: Optional[str] = None) -> Dict[str, Any]:
-    """A well-formed Check report with nothing observed yet.
-
-    Truthfully represents "no evidence/claim/chain observed" -> evaluator returns
-    TRACE_REQUIRED. This is NOT a fake PASS; it encodes the real fact that the
-    obligation has not been Check-evaluated.
+    """A well-formed Check report with nothing observed yet -> evaluator returns
+    TRACE_REQUIRED. Encodes the real fact 'not Check-evaluated', not a fake PASS.
     """
     return {
         "report_id": None,
@@ -29,41 +27,71 @@ def empty_check_report(obligation_id: Optional[str] = None) -> Dict[str, Any]:
     }
 
 
-def collect_obligations_from_diagnosis(
-    diagnosis_rows: List[dict],
-) -> Tuple[List[dict], Set[str]]:
-    """Collect distinct obligations (by obligation_id) from latest diagnosis rows.
+def _merge_distinct(
+    by_id: Dict[str, dict], conflicts: Set[str], oid: str, ob: dict
+) -> None:
+    if oid in by_id:
+        prev = by_id[oid]
+        if (prev.get("law_name") or "") != (ob.get("law_name") or "") or (
+            prev.get("law_article") or ""
+        ) != (ob.get("law_article") or ""):
+            conflicts.add(oid)
+    else:
+        by_id[oid] = ob
 
-    Source = factory_diagnosis_results.result_data.inspection_required[] — the same
-    rules the schedule gate consults (rule_id/rule_code = obligation_id).
-    Returns (obligations, conflict_ids). conflict_ids = same obligation_id whose
-    law linkage disagrees across rows (a real data anomaly -> CORRECTION).
+
+def collect_obligations_from_work_schedules(
+    rows: List[dict],
+) -> Tuple[List[dict], Set[str]]:
+    """Distinct obligations (by rule_code) from work_schedules rows.
+
+    rule_code = obligation_id (same ID space the schedule gate uses).
+    conflict = same rule_code whose law linkage disagrees across rows.
     """
     by_id: Dict[str, dict] = {}
     conflicts: Set[str] = set()
+    for row in rows:
+        oid = (row.get("rule_code") or "").strip()
+        if not oid:
+            continue
+        ob = {
+            "obligation_id": oid,
+            "law_name": row.get("law_name") or "",
+            "law_article": row.get("law_article") or "",
+            "obligation_type": row.get("obligation_type") or "",
+            "obligation_summary": row.get("description") or row.get("summary") or "",
+        }
+        _merge_distinct(by_id, conflicts, oid, ob)
+    return list(by_id.values()), conflicts
 
+
+def collect_obligations_from_diagnosis(
+    diagnosis_rows: List[dict],
+) -> Tuple[List[dict], Set[str]]:
+    """Distinct obligations from factory_diagnosis_results.result_data.
+
+    Tries inspection_required first, then falls back to 'rules' (current schema
+    stores obligations under result_data.rules). obligation_id = rule_id/rule_code.
+    """
+    by_id: Dict[str, dict] = {}
+    conflicts: Set[str] = set()
     for row in diagnosis_rows:
         result_data = (row or {}).get("result_data") or {}
-        for rule in (result_data.get("inspection_required") or []):
+        rules = result_data.get("inspection_required") or result_data.get("rules") or []
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
             oid = (rule.get("rule_id") or rule.get("rule_code") or "").strip()
             if not oid:
                 continue
             ob = {
                 "obligation_id": oid,
                 "law_name": rule.get("law_name") or "",
-                "law_article": rule.get("law_article") or "",
+                "law_article": rule.get("law_article") or rule.get("article_no") or "",
                 "obligation_type": rule.get("obligation_type") or "",
                 "obligation_summary": rule.get("obligation_summary") or rule.get("description") or "",
             }
-            if oid in by_id:
-                prev = by_id[oid]
-                if (prev.get("law_name") or "") != (ob.get("law_name") or "") or (
-                    prev.get("law_article") or ""
-                ) != (ob.get("law_article") or ""):
-                    conflicts.add(oid)
-            else:
-                by_id[oid] = ob
-
+            _merge_distinct(by_id, conflicts, oid, ob)
     return list(by_id.values()), conflicts
 
 
@@ -72,8 +100,8 @@ def evaluate_population(
     conflicts: Optional[Set[str]] = None,
     reports_by_id: Optional[Dict[str, dict]] = None,
 ) -> List[Dict[str, Any]]:
-    """Evaluate every obligation. Uses a real Check report if provided in
-    reports_by_id, else an empty (not-yet-evaluated) report.
+    """Evaluate every obligation. Real Check report if provided in reports_by_id,
+    else an empty (not-yet-evaluated) report.
     """
     conflicts = conflicts or set()
     reports_by_id = reports_by_id or {}
@@ -81,8 +109,7 @@ def evaluate_population(
     for ob in obligations:
         oid = ob.get("obligation_id")
         report = reports_by_id.get(oid) or empty_check_report(oid)
-        is_conflict = oid in conflicts
-        res = evaluate_quality(ob, report, duplicate=is_conflict)
+        res = evaluate_quality(ob, report, duplicate=(oid in conflicts))
         out.append({
             "obligation_id": oid,
             "quality_status": res["quality_status"],

--- a/services/obligation_quality_coverage.py
+++ b/services/obligation_quality_coverage.py
@@ -1,0 +1,41 @@
+"""Phase 10 — Quality Coverage (pure aggregation, no DB, no new engine).
+
+Given obligation_quality rows -> distribution + top-10 reason causes.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from services.obligation_quality_evaluator import READY, TRACE_REQUIRED, CORRECTION_REQUIRED
+
+
+def compute_coverage(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """rows: [{obligation_id, quality_status, quality_reason}, ...]"""
+    total = len(rows)
+    distribution = {READY: 0, TRACE_REQUIRED: 0, CORRECTION_REQUIRED: 0}
+    reason_counts: Dict[str, int] = {}
+    unclassified = 0
+
+    for r in rows:
+        status = r.get("quality_status")
+        if status in distribution:
+            distribution[status] += 1
+        else:
+            unclassified += 1
+        reason = r.get("quality_reason")
+        if reason:
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+    top_reasons = [
+        {"reason": k, "count": v}
+        for k, v in sorted(reason_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:10]
+    ]
+    classified = distribution[READY] + distribution[TRACE_REQUIRED] + distribution[CORRECTION_REQUIRED]
+
+    return {
+        "total": total,
+        "distribution": distribution,
+        "top_reasons": top_reasons,
+        "unclassified": unclassified,
+        "fully_classified": total > 0 and classified == total,
+    }

--- a/tests/test_obligation_quality_coverage.py
+++ b/tests/test_obligation_quality_coverage.py
@@ -1,0 +1,96 @@
+"""Phase 10 — coverage + population batch tests (pure, no DB).
+
+    python -m pytest tests/test_obligation_quality_coverage.py -q
+"""
+from services.obligation_quality_coverage import compute_coverage
+from services.obligation_quality_batch import (
+    empty_check_report,
+    collect_obligations_from_diagnosis,
+    evaluate_population,
+)
+from services.obligation_quality_evaluator import READY, TRACE_REQUIRED, CORRECTION_REQUIRED
+
+
+def test_compute_coverage_basic():
+    rows = [
+        {"obligation_id": "a", "quality_status": READY, "quality_reason": "OK"},
+        {"obligation_id": "b", "quality_status": TRACE_REQUIRED, "quality_reason": "EVIDENCE_INSUFFICIENT"},
+        {"obligation_id": "c", "quality_status": TRACE_REQUIRED, "quality_reason": "EVIDENCE_INSUFFICIENT"},
+        {"obligation_id": "d", "quality_status": CORRECTION_REQUIRED, "quality_reason": "LAW_LINK_ERROR"},
+    ]
+    cov = compute_coverage(rows)
+    assert cov["total"] == 4
+    assert cov["distribution"] == {READY: 1, TRACE_REQUIRED: 2, CORRECTION_REQUIRED: 1}
+    assert cov["fully_classified"] is True
+    assert cov["top_reasons"][0] == {"reason": "EVIDENCE_INSUFFICIENT", "count": 2}
+
+
+def test_compute_coverage_empty():
+    cov = compute_coverage([])
+    assert cov["total"] == 0
+    assert cov["fully_classified"] is False
+
+
+def test_collect_dedup_and_conflict():
+    rows = [
+        {"result_data": {"inspection_required": [
+            {"rule_id": "R1", "law_name": "산안법", "law_article": "17"},
+            {"rule_code": "R2", "law_name": "산안법", "law_article": "18"},
+        ]}},
+        {"result_data": {"inspection_required": [
+            {"rule_id": "R1", "law_name": "산안법", "law_article": "17"},
+            {"rule_id": "R3", "law_name": "산안법", "law_article": "99"},
+            {"law_name": "산안법"},
+        ]}},
+        {"result_data": {"inspection_required": [
+            {"rule_id": "R3", "law_name": "다른법", "law_article": "1"},
+        ]}},
+    ]
+    obligations, conflicts = collect_obligations_from_diagnosis(rows)
+    ids = {o["obligation_id"] for o in obligations}
+    assert ids == {"R1", "R2", "R3"}
+    assert "R3" in conflicts
+    assert "R1" not in conflicts
+
+
+def test_evaluate_population_empty_report_is_trace():
+    obs = [{"obligation_id": "R1", "law_name": "산안법", "law_article": "17"}]
+    out = evaluate_population(obs)
+    assert out[0]["quality_status"] == TRACE_REQUIRED
+    assert out[0]["quality_reason"] == "EVIDENCE_INSUFFICIENT"
+
+
+def test_evaluate_population_law_missing_is_correction():
+    obs = [{"obligation_id": "R2", "law_name": "", "law_article": ""}]
+    out = evaluate_population(obs)
+    assert out[0]["quality_status"] == CORRECTION_REQUIRED
+    assert out[0]["quality_reason"] == "LAW_LINK_ERROR"
+
+
+def test_evaluate_population_conflict_is_correction():
+    obs = [{"obligation_id": "R3", "law_name": "산안법", "law_article": "99"}]
+    out = evaluate_population(obs, conflicts={"R3"})
+    assert out[0]["quality_status"] == CORRECTION_REQUIRED
+    assert out[0]["quality_reason"] == "DUPLICATE_OBLIGATION"
+
+
+def test_evaluate_population_real_report_can_be_ready():
+    obs = [{"obligation_id": "R4", "law_name": "산안법", "law_article": "17"}]
+    report = {
+        "report_id": "rptR4",
+        "status_summary": {
+            "claim": {"CLAIM_PRESENT": 1},
+            "evidence": {"EVIDENCE_ATTACHED": 1},
+            "chain": {"EVIDENCE_CHAIN_COMPLETE": 1},
+        },
+        "observation_records": [{}],
+    }
+    out = evaluate_population(obs, reports_by_id={"R4": report})
+    assert out[0]["quality_status"] == READY
+    assert out[0]["check_report_id"] == "rptR4"
+
+
+def test_empty_check_report_wellformed():
+    rep = empty_check_report("X")
+    assert "status_summary" in rep and "observation_records" in rep
+    assert rep["observation_records"] == []

--- a/tests/test_obligation_quality_coverage.py
+++ b/tests/test_obligation_quality_coverage.py
@@ -6,6 +6,7 @@ from services.obligation_quality_coverage import compute_coverage
 from services.obligation_quality_batch import (
     empty_check_report,
     collect_obligations_from_diagnosis,
+    collect_obligations_from_work_schedules,
     evaluate_population,
 )
 from services.obligation_quality_evaluator import READY, TRACE_REQUIRED, CORRECTION_REQUIRED
@@ -31,16 +32,30 @@ def test_compute_coverage_empty():
     assert cov["fully_classified"] is False
 
 
-def test_collect_dedup_and_conflict():
+def test_collect_from_work_schedules():
+    rows = [
+        {"rule_code": "R1", "law_name": "산안법", "law_article": "17"},
+        {"rule_code": "R1", "law_name": "산안법", "law_article": "17"},
+        {"rule_code": "R2", "law_name": "산안법", "law_article": "18"},
+        {"rule_code": "R2", "law_name": "다른법", "law_article": "1"},
+        {"rule_code": "", "law_name": "x"},
+        {"law_name": "no code"},
+    ]
+    obs, conflicts = collect_obligations_from_work_schedules(rows)
+    ids = {o["obligation_id"] for o in obs}
+    assert ids == {"R1", "R2"}
+    assert "R2" in conflicts
+    assert "R1" not in conflicts
+
+
+def test_collect_dedup_and_conflict_diagnosis():
     rows = [
         {"result_data": {"inspection_required": [
             {"rule_id": "R1", "law_name": "산안법", "law_article": "17"},
             {"rule_code": "R2", "law_name": "산안법", "law_article": "18"},
         ]}},
-        {"result_data": {"inspection_required": [
-            {"rule_id": "R1", "law_name": "산안법", "law_article": "17"},
-            {"rule_id": "R3", "law_name": "산안법", "law_article": "99"},
-            {"law_name": "산안법"},
+        {"result_data": {"rules": [
+            {"rule_id": "R3", "law_name": "산안법", "article_no": "99"},
         ]}},
         {"result_data": {"inspection_required": [
             {"rule_id": "R3", "law_name": "다른법", "law_article": "1"},
@@ -50,7 +65,6 @@ def test_collect_dedup_and_conflict():
     ids = {o["obligation_id"] for o in obligations}
     assert ids == {"R1", "R2", "R3"}
     assert "R3" in conflicts
-    assert "R1" not in conflicts
 
 
 def test_evaluate_population_empty_report_is_trace():


### PR DESCRIPTION
## 목적
검증된 Quality Evaluator(Phase 9)를 **실제 운영 의무에 적용(런타임 활성화)**. 새 엔진 없음, Evaluator 무수정. **Phase 9 PR #89 위에 stacked** (base = `obligation-quality/phase9-mvp`).

## ⚠ 조사 결과 (추측 아님 — 정직 보고)
tai-api에는 **운영 의무별 Check EvidenceReport가 아직 없음** (`HANDOFF_EVIDENCE_ENGINE.md`의 Evidence Engine은 법령 원문 파서이지 Check 리포트 아님). 결과적으로:
- Check 리포트 없는 의무 = 근거 미관측 = **TRACE_REQUIRED** (정상 의미. well-formed 빈 리포트로 evaluator가 정직 매핑 — 조작 아님)
- 법령 연결 누락/충돌 = **CORRECTION_REQUIRED**
- **READY = 0건** (아직 Check 검증된 의무 없음)

## ⚠ 작업 4 (Schedule Gate 전역 활성화) — 보류 권장
READY가 0인 현 상태에서 `enforce_quality`를 전역 True로 켜면 **모든 스케줄 생성이 차단**(운영 중단)된다. 따라서:
- 전역 default **False 유지** (변경 안 함)
- 게이트는 **per-call** `?enforce_quality=true` 로 시연/검증만
- Check 리포트 연결 → READY 발생 후 전역 활성화 권장

(전역 강제를 원하시면 명시 지시 주십시오 — 현재는 스케줄 0건이 됩니다.)

## 산출물
1. **Batch 러너** — `scripts/run_quality_batch.py` (`--dry-run` / `--commit`)
2. **인구 평가 로직** — `services/obligation_quality_batch.py` (`collect_obligations_from_diagnosis`, `evaluate_population`, `empty_check_report`)
3. **Coverage** — `services/obligation_quality_coverage.py` (`compute_coverage`) + `GET /admin/obligations/coverage`
4. **Admin Queue 적재** — `--commit` 시 CORRECTION_REQUIRED → `record_evaluation` → admin_obligation_queue 자동 등록 (Phase 9 store)
5. **테스트** — `tests/test_obligation_quality_coverage.py` (순수, DB 불필요)
6. **리포트 템플릿** — `reports/PHASE10_COVERAGE_REPORT.md` (실행 후 실제 숫자로 채움)

## 의무 모집 정의
"기존 의무 전체" = 최신 진단결과(`factory_diagnosis_results.is_latest`)의 `result_data.inspection_required[]` 룰을 obligation_id(rule_id/rule_code) distinct 수집. Schedule Gate가 조회하는 동일 출처라 커버리지가 일치. (별도 master 의무 테이블이 있으면 알려주십시오.)

## 실행 절차 (사람)
```bash
python -m pytest tests/test_obligation_quality_coverage.py -q          # 0) 순수 테스트
# 1) 마이그레이션: sql/20260603_obligation_quality_layer.sql → Supabase taieng
PYTHONPATH=. python scripts/run_quality_batch.py --dry-run             # 2) 미리보기
PYTHONPATH=. python scripts/run_quality_batch.py --commit              # 3) 적재
curl -s https://api.taieng.co.kr/admin/obligations/coverage | jq       # 4) Coverage
curl -s -X POST "https://api.taieng.co.kr/legal-engine/generate-schedules/<FACTORY_ID>?enforce_quality=true" | jq  # 5) Gate 시연
```

## 성공 기준
기존 의무 전체가 READY/TRACE_REQUIRED/CORRECTION_REQUIRED 중 하나 → `compute_coverage.fully_classified == true`. 실행 후 리포트에 실제 숫자 기록.

## 검증 상태: UNVERIFIED
순수 테스트 작성 완료(실행 필요). 배치/Coverage/Gate 실데이터 숫자는 사람이 위 명령 실행 후 확정 — 추측 숫자 기재 금지.

## 금지사항 준수
Check/LEG 수정 / 새 엔진 / 법령 재판단: **없음.** Evaluator 무수정, Check 결과 소비만.

**Merge 금지** (검증 로그 확인 전).