### PR TITLE
feat(pricing): 가격 정책 단일 테이블(price_master) 통합 + 카드 SSOT 일원화

### DIFF
--- a/router_registry/payment.py
+++ b/router_registry/payment.py
@@ -8,6 +8,7 @@ ROUTERS = [
     {"module": "routers.contracts_engine", "prefix": "/matching/contracts", "tags": ["계약서"]},
     {"module": "routers.quotes"},
     {"module": "routers.price_setting"},
+    {"module": "routers.price_master_admin"},
     {"module": "routers.product_pricing"},
     {"module": "routers.price_policy"},
     {"module": "routers.connection_commission"},

--- a/routers/price_master_admin.py
+++ b/routers/price_master_admin.py
@@ -1,0 +1,154 @@
+# routers/price_master_admin.py — 통합 가격 테이블(price_master) 관리 API
+# v1.0.0 (2026-06-05): price-setting 페이지용 CRUD.
+#   price_master(가격 본체) + price_service_feature(노출 서비스 항목) 관리.
+#   가격 카드(public_pricing)가 참조하는 단일 SSOT를 이 API로 입력/수정/생성한다.
+from datetime import datetime
+from typing import Optional, List
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from db.supabase_client import get_supabase
+
+router = APIRouter(prefix="/price-master", tags=["가격 통합관리"])
+
+
+# ── 모델 ──────────────────────────────────────────────────────
+
+class PriceMasterUpsert(BaseModel):
+    service_type: Optional[str] = None      # DIAGNOSIS / SAAS / ...
+    sector: Optional[str] = None            # BUILDING / INDUSTRY / CONSTRUCTION / COMMON
+    tier_code: Optional[str] = None
+    criteria_type: Optional[str] = None     # FLOOR_AREA / WORKER_COUNT / CONTRACT_AMOUNT / FLAT
+    criteria_min: Optional[float] = None
+    criteria_max: Optional[float] = None
+    amount: Optional[int] = None
+    vat_included: Optional[bool] = None
+    vat_rate: Optional[float] = None
+    billing_unit: Optional[str] = None      # ONCE / MONTHLY / ANNUAL
+    display_name: Optional[str] = None
+    sub_label: Optional[str] = None
+    icon: Optional[str] = None
+    is_recommended: Optional[bool] = None
+    is_active: Optional[bool] = None
+    sort_order: Optional[int] = None
+
+
+class FeatureUpsert(BaseModel):
+    feature_text: str
+    feature_type: Optional[str] = "INCLUDE"
+    icon: Optional[str] = None
+    sort_order: Optional[int] = 0
+    is_active: Optional[bool] = True
+
+
+# ── price_master CRUD ────────────────────────────────────────
+
+@router.get("")
+def list_prices(service_type: str = None, sector: str = None, is_active: bool = None):
+    sb = get_supabase()
+    q = sb.table("price_master").select("*")
+    if service_type:
+        q = q.eq("service_type", service_type.upper())
+    if sector:
+        q = q.eq("sector", sector.upper())
+    if is_active is not None:
+        q = q.eq("is_active", is_active)
+    rows = q.order("service_type").order("sort_order").execute().data or []
+
+    ids = [r["id"] for r in rows]
+    feat_map: dict = {}
+    if ids:
+        feats = (
+            sb.table("price_service_feature").select("*")
+            .in_("price_id", ids).order("sort_order").execute().data or []
+        )
+        for f in feats:
+            feat_map.setdefault(f["price_id"], []).append(f)
+    for r in rows:
+        r["features"] = feat_map.get(r["id"], [])
+    return {"status": "success", "data": rows}
+
+
+@router.get("/{price_id}")
+def get_price(price_id: str):
+    sb = get_supabase()
+    res = sb.table("price_master").select("*").eq("id", price_id).single().execute()
+    if not res.data:
+        raise HTTPException(status_code=404, detail="가격 항목을 찾을 수 없습니다")
+    feats = (
+        sb.table("price_service_feature").select("*")
+        .eq("price_id", price_id).order("sort_order").execute().data or []
+    )
+    data = res.data
+    data["features"] = feats
+    return {"status": "success", "data": data}
+
+
+@router.post("")
+def create_price(body: PriceMasterUpsert):
+    """신규 가격 항목 생성."""
+    sb = get_supabase()
+    row = {k: v for k, v in body.dict().items() if v is not None}
+    for req in ("service_type", "tier_code"):
+        if not row.get(req):
+            raise HTTPException(status_code=400, detail=f"{req}는 필수입니다")
+    row["service_type"] = row["service_type"].upper()
+    if row.get("sector"):
+        row["sector"] = row["sector"].upper()
+    res = sb.table("price_master").insert(row).execute()
+    return {"status": "success", "data": res.data[0] if res.data else None}
+
+
+@router.patch("/{price_id}")
+def update_price(price_id: str, body: PriceMasterUpsert):
+    sb = get_supabase()
+    old = sb.table("price_master").select("*").eq("id", price_id).single().execute()
+    if not old.data:
+        raise HTTPException(status_code=404, detail="가격 항목을 찾을 수 없습니다")
+    update = {k: v for k, v in body.dict().items() if v is not None}
+    if not update:
+        raise HTTPException(status_code=400, detail="변경할 항목이 없습니다")
+    if update.get("service_type"):
+        update["service_type"] = update["service_type"].upper()
+    if update.get("sector"):
+        update["sector"] = update["sector"].upper()
+    update["updated_at"] = datetime.now().isoformat()
+    res = sb.table("price_master").update(update).eq("id", price_id).execute()
+    return {"status": "success", "data": res.data[0] if res.data else None}
+
+
+@router.delete("/{price_id}")
+def deactivate_price(price_id: str):
+    """비활성화(soft). 물리 삭제 안 함."""
+    sb = get_supabase()
+    res = (
+        sb.table("price_master")
+        .update({"is_active": False, "updated_at": datetime.now().isoformat()})
+        .eq("id", price_id).execute()
+    )
+    return {"status": "success", "data": res.data[0] if res.data else None}
+
+
+# ── feature CRUD ─────────────────────────────────────────────
+
+@router.put("/{price_id}/features")
+def replace_features(price_id: str, items: List[FeatureUpsert]):
+    """해당 가격의 노출 서비스 항목 전체 교체."""
+    sb = get_supabase()
+    owner = sb.table("price_master").select("id").eq("id", price_id).single().execute()
+    if not owner.data:
+        raise HTTPException(status_code=404, detail="가격 항목을 찾을 수 없습니다")
+    sb.table("price_service_feature").delete().eq("price_id", price_id).execute()
+    rows = []
+    for i, it in enumerate(items):
+        rows.append({
+            "price_id": price_id,
+            "feature_text": it.feature_text,
+            "feature_type": it.feature_type or "INCLUDE",
+            "icon": it.icon,
+            "sort_order": it.sort_order if it.sort_order is not None else i,
+            "is_active": it.is_active if it.is_active is not None else True,
+        })
+    data = []
+    if rows:
+        data = sb.table("price_service_feature").insert(rows).execute().data or []
+    return {"status": "success", "data": data, "count": len(data)}

--- a/routers/public_pricing.py
+++ b/routers/public_pricing.py
@@ -1,6 +1,10 @@
 # routers/public_pricing.py — 공개 가격 API (인증 불필요)
-# v2.0.0 (2026-05-16): features/target/is_recommended/is_custom 필드 추가, 프론트 완전 연동
-# v1.1.0 (2026-04-14): /saas-plans + /diagnosis-reports 엔드포인트 추가
+# v3.0.0 (2026-06-05): price_master 단일 테이블로 통합. price_saas_plan/price_diagnosis_report 직접 참조 제거.
+#   - 데이터 소스: price_master + price_service_feature (SSOT)
+#   - 기존 응답 키(saas_plans/diagnosis_plans, features 등) 호환 유지
+#   - 신규: GET /public/pricing/resolve — 기준값(연면적/근로자수/공사금액)으로 플랜 자동 산정
+# v2.0.0 (2026-05-16): features/target/is_recommended/is_custom 필드 추가
+# v1.1.0 (2026-04-14): /saas-plans + /diagnosis-reports 추가
 import time
 from fastapi import APIRouter
 from db.supabase_client import get_supabase
@@ -23,34 +27,60 @@ def _set_cache(key: str, data):
     _cache[key] = {"ts": time.time(), "data": data}
 
 
+# ── price_master 조회 + feature 조인 ──────────────────────────
+
+MASTER_FIELDS = (
+    "id, service_type, sector, tier_code, criteria_type, criteria_min, criteria_max,"
+    "amount, vat_included, vat_rate, billing_unit, display_name, sub_label, icon,"
+    "is_recommended, is_active, sort_order"
+)
+
+
+def _load(service_type: str, sector: str = None):
+    """price_master에서 service_type(+sector) 활성 행을 features와 함께 로드."""
+    sb = get_supabase()
+    q = (
+        sb.table("price_master")
+        .select(MASTER_FIELDS)
+        .eq("service_type", service_type)
+        .eq("is_active", True)
+    )
+    if sector:
+        q = q.eq("sector", sector.upper())
+    rows = q.order("sort_order").execute().data or []
+
+    ids = [r["id"] for r in rows]
+    feat_map: dict = {}
+    if ids:
+        feats = (
+            sb.table("price_service_feature")
+            .select("price_id, feature_text, feature_type, icon, sort_order, is_active")
+            .in_("price_id", ids)
+            .eq("is_active", True)
+            .order("sort_order")
+            .execute()
+            .data or []
+        )
+        for f in feats:
+            feat_map.setdefault(f["price_id"], []).append(f["feature_text"])
+
+    for r in rows:
+        r["features"] = feat_map.get(r["id"], [])
+    return rows
+
+
 # ══════════════════════════════════════════════════════════════
 # SaaS Plans
 # ══════════════════════════════════════════════════════════════
 
-SAAS_FIELDS = (
-    "id, plan_code, plan_name, display_name, description, sector_code, billing_unit,"
-    "monthly_base_fee, annual_discount_rate, included_users, extra_user_fee_v2,"
-    "sms_included, kakao_included, doc_included, include_tbm,"
-    "include_task_assign, include_group_mgmt, include_miss_alert,"
-    "include_safety_content, include_dashboard, annual_free_months,"
-    "badge_color, sort_order, is_active, target, features, is_recommended, is_custom"
-)
-
-
 @router.get("/saas-plans")
 def get_saas_plans(sector: str = None):
-    """SaaS 구독 플랜 목록 (is_active=true, 인증 불필요)."""
-    cache_key = f"saas_plans_v2:{sector or 'ALL'}"
+    """SaaS 구독 플랜 목록 (price_master service_type=SAAS, 인증 불필요)."""
+    cache_key = f"saas_plans_v3:{sector or 'ALL'}"
     cached = _get_cached(cache_key)
     if cached:
         return {"data": cached}
-
-    sb = get_supabase()
-    q = sb.table("price_saas_plan").select(SAAS_FIELDS).eq("is_active", True)
-    if sector:
-        q = q.eq("sector_code", sector.upper())
-    res = q.order("sort_order").execute()
-    data = res.data or []
+    data = _load("SAAS", sector)
     _set_cache(cache_key, data)
     return {"data": data}
 
@@ -59,32 +89,15 @@ def get_saas_plans(sector: str = None):
 # Diagnosis Reports
 # ══════════════════════════════════════════════════════════════
 
-DIAG_FIELDS = (
-    "id, facility_type_code, facility_type_name, sector_display,"
-    "basic_fee, process_fee, equipment_fee, total_report_fee,"
-    "free_fee, inquiry_label, price_version, sort_order, is_active,"
-    "features, icon, goods_name, is_recommended, is_special, sub_label"
-)
-
-
 @router.get("/diagnosis-reports")
-def get_diagnosis_reports():
-    """법령진단 리포트 단건 가격 목록 (is_active=true, 인증 불필요)."""
-    cached = _get_cached("diagnosis_reports_v2")
+def get_diagnosis_reports(sector: str = None):
+    """법령진단 단건 가격 목록 (price_master service_type=DIAGNOSIS, 인증 불필요)."""
+    cache_key = f"diagnosis_reports_v3:{sector or 'ALL'}"
+    cached = _get_cached(cache_key)
     if cached:
         return {"data": cached}
-
-    sb = get_supabase()
-    res = (
-        sb.table("price_diagnosis_report")
-        .select(DIAG_FIELDS)
-        .eq("is_active", True)
-        .eq("price_version", "v2")
-        .order("sort_order")
-        .execute()
-    )
-    data = res.data or []
-    _set_cache("diagnosis_reports_v2", data)
+    data = _load("DIAGNOSIS", sector)
+    _set_cache(cache_key, data)
     return {"data": data}
 
 
@@ -95,30 +108,53 @@ def get_diagnosis_reports():
 @router.get("/all")
 def public_all_pricing(sector: str = None):
     """pricing.html에서 사용. SaaS + 법령진단 가격 동시 반환."""
-    cached = _get_cached(f"all_v2:{sector or 'ALL'}")
+    cache_key = f"all_v3:{sector or 'ALL'}"
+    cached = _get_cached(cache_key)
     if cached is not None:
         return {"status": "success", "cached": True, **cached}
-
-    sb = get_supabase()
-
-    saas_q = sb.table("price_saas_plan").select(SAAS_FIELDS).eq("is_active", True)
-    if sector:
-        saas_q = saas_q.eq("sector_code", sector.upper())
-    saas = saas_q.order("sort_order").execute().data or []
-
-    diag = (
-        sb.table("price_diagnosis_report")
-        .select(DIAG_FIELDS)
-        .eq("is_active", True)
-        .eq("price_version", "v2")
-        .order("sort_order")
-        .execute()
-        .data or []
-    )
-
-    payload = {"saas_plans": saas, "diagnosis_plans": diag}
-    _set_cache(f"all_v2:{sector or 'ALL'}", payload)
+    payload = {
+        "saas_plans": _load("SAAS", sector),
+        "diagnosis_plans": _load("DIAGNOSIS", sector),
+    }
+    _set_cache(cache_key, payload)
     return {"status": "success", "cached": False, **payload}
+
+
+# ══════════════════════════════════════════════════════════════
+# 가격 자동 산정 (기준값 → 플랜)
+# ══════════════════════════════════════════════════════════════
+
+@router.get("/resolve")
+def resolve_price(service_type: str, sector: str, value: float = None):
+    """기준값으로 적용 플랜을 산정.
+    - service_type: DIAGNOSIS / SAAS
+    - sector: BUILDING(연면적) / INDUSTRY(근로자수) / CONSTRUCTION(공사금액)
+    - value: 기준값. criteria_min <= value < criteria_max 인 행을 반환(FLAT은 value 무관).
+    """
+    rows = _load(service_type.upper(), sector.upper())
+    if not rows:
+        return {"status": "not_found", "data": None}
+
+    if value is None:
+        # 기준값 미입력 → 추천 우선, 없으면 첫 행
+        chosen = next((r for r in rows if r.get("is_recommended")), rows[0])
+        return {"status": "success", "data": chosen, "matched_by": "default"}
+
+    match = None
+    for r in rows:
+        cmin = r.get("criteria_min")
+        cmax = r.get("criteria_max")
+        lo_ok = cmin is None or value >= float(cmin)
+        hi_ok = cmax is None or value < float(cmax)
+        if r.get("criteria_type") == "FLAT":
+            continue
+        if lo_ok and hi_ok:
+            match = r
+            break
+    if match is None:
+        # 구간 초과 시 FLAT(맞춤) 또는 마지막 행
+        match = next((r for r in rows if r.get("criteria_type") == "FLAT"), rows[-1])
+    return {"status": "success", "data": match, "matched_by": "criteria"}
 
 
 # ── 레거시 호환 ──────────────────────────────────────────────
@@ -130,9 +166,9 @@ def public_saas_pricing(sector: str = None):
 
 
 @router.get("/diagnosis")
-def public_diagnosis_pricing():
+def public_diagnosis_pricing(sector: str = None):
     """레거시 — /diagnosis-reports 사용 권장."""
-    return get_diagnosis_reports()
+    return get_diagnosis_reports(sector)
 
 
 @router.delete("/cache")

--- a/sql/20260605_archive_legacy_price_tables.sql
+++ b/sql/20260605_archive_legacy_price_tables.sql
@@ -1,0 +1,32 @@
+-- 20260605_archive_legacy_price_tables.sql
+-- 가격 테이블 통합(price_master) 후 구 테이블 격리 스크립트.
+--
+-- ⚠ 적용 순서 (반드시 지킬 것):
+--   1) 본 PR(feat/price-master-unification)의 라우터 변경이 머지·배포되어
+--      public_pricing / price_master_admin 이 price_master 만 참조하는 것을 확인.
+--   2) 카드(공개 pricing.html)와 admin price-setting 동작 확인.
+--   3) 그 다음에 본 스크립트 실행 (운영 무중단 확인 후).
+--
+-- 격리 방식: 물리 삭제 없음. archive 스키마로 이동(rename)하여 되돌리기 가능.
+--   복구가 필요하면: ALTER TABLE archive.<t> SET SCHEMA public;
+
+CREATE SCHEMA IF NOT EXISTS archive;
+
+-- (A) 가격 카드가 더 이상 직접 참조하지 않는 구 카드 테이블.
+--     price_master로 데이터가 이관되었으므로 격리.
+ALTER TABLE IF EXISTS public.price_diagnosis_report SET SCHEMA archive;
+ALTER TABLE IF EXISTS public.price_saas_plan        SET SCHEMA archive;
+
+-- (B) 행이 없고(0건) 카드/주요 라우터 코드 참조가 없는 미사용 테이블.
+ALTER TABLE IF EXISTS public.price_quotes        SET SCHEMA archive;
+ALTER TABLE IF EXISTS public.price_standard_wage SET SCHEMA archive;
+
+-- ── 격리하지 않는 테이블 (다른 라우터가 사용 중 — 유지) ──
+--   price_policy            : routers/price_policy.py, payment
+--   price_commission        : routers/matching_commission.py, matching_svc
+--   price_repair_brokerage  : routers/price_setting.py (수리중개)
+--   price_safety_management : routers/price_setting.py (안전관리대행)
+--   price_consulting        : routers/price_setting.py (컨설팅)
+--   price_change_log        : 변경 이력 자동 기록
+--   price_discount / price_region_surcharge / price_travel_rule :
+--      현재 카드 미참조이나 추가 확인 후 별도 차수에서 격리 검토 (이번엔 보류)


### PR DESCRIPTION
## 목적
여러 곳에 흩어진 가격 정책을 **단일 테이블 `price_master`** 로 통합하고, 가격 카드(공개 pricing.html)와 admin price-setting이 **오직 이 테이블만 참조**하도록 일원화합니다. 구 가격 테이블은 archive 스키마로 격리(되돌리기 가능).

> 목업 데이터 단계 — 기존 행은 무시하고 현재 노출 정보로 새 구조 시드 완료.

## DB (이미 적용됨, Supabase `vwlahtguyggrhvslabax`)
신규 테이블 2개:
- **`price_master`** (SSOT): `service_type`(DIAGNOSIS/SAAS), `sector`, `tier_code`, `criteria_type`(FLOOR_AREA/WORKER_COUNT/CONTRACT_AMOUNT/FLAT), `criteria_min/max`(기준값 구간), `amount`, `vat_included`/`vat_rate`, `billing_unit`(ONCE/MONTHLY), `display_name`/`sub_label`/`icon`/`is_recommended`/`is_active`/`sort_order`
- **`price_service_feature`**: 카드에 노출되는 서비스 항목(`price_id` FK, `feature_text`, `feature_type`, `sort_order`)

시드: 진단 3행(건물 소형/대형, 산업) + SaaS 10행(건물·산업·건설 등급), 각 행에 feature 연결. 기준값으로 산업=근로자수·건물=연면적·건설=공사금액 구간을 정규화.

## 코드 변경
1. `routers/public_pricing.py` v3.0.0 — 데이터 소스를 `price_master`+`price_service_feature`로 교체. 기존 응답 키(`saas_plans`/`diagnosis_plans`/`features`) 호환 유지. **신규 `GET /public/pricing/resolve?service_type=&sector=&value=`** — 기준값으로 적용 플랜 자동 산정.
2. `routers/price_master_admin.py` (신규) — price-setting 페이지용 CRUD. 가격 본체 GET/POST/PATCH/DELETE(soft) + `PUT /{id}/features`(노출 항목 교체). **신규 생성(POST) 지원**.
3. `router_registry/payment.py` — `price_master_admin` 등록.

## 격리 (머지·배포 후 수동 적용)
`sql/20260605_archive_legacy_price_tables.sql` — 물리 삭제 없이 archive 스키마로 이동:
- 격리: `price_diagnosis_report`, `price_saas_plan`(price_master로 이관됨), `price_quotes`/`price_standard_wage`(0행·미참조)
- **유지**(타 라우터 사용 중): `price_policy`, `price_commission`, `price_repair_brokerage`, `price_safety_management`, `price_consulting`, `price_change_log`
- 보류(추가 확인 후): `price_discount`, `price_region_surcharge`, `price_travel_rule`

⚠ 적용 순서: **라우터 변경 머지·배포 → 카드/admin 동작 확인 → 그 다음 격리 SQL 실행.** (순서 어기면 구 테이블 참조가 깨질 수 있음 — 단 본 PR로 직접 참조는 이미 제거됨)

## 영향
- 가격 카드는 이제 `price_master` 단일 출처. admin에서 가격·서비스내용·노출항목 모두 관리 가능.
- 응답 스키마 호환 유지했으나, 프런트가 구 필드명(`total_report_fee`, `monthly_base_fee`, `plan_code` 등)에 강결합돼 있으면 매핑 조정 필요 — 머지 후 pricing.html/admin 프런트 점검 권장.

## 검증 상태
DB 생성·시드 완료(13행 + features 확인). 라우터 코드 작성 완료. **앱 기동/엔드포인트 응답은 배포 후 확인 필요(UNVERIFIED).**