### PR TITLE
feat(payment): 결제완료 결과 페이지에 진단 상세입력 이어가기 분기

### DIFF
--- a/templates/payment/result.html
+++ b/templates/payment/result.html
@@ -15,7 +15,35 @@
 function getParams(){var p={};new URLSearchParams(location.search).forEach(function(v,k){p[k]=v;});return p;}
 function fmt(n){return n?Number(n).toLocaleString()+'원':'-';}
 function goHome(){(window.top||window).location.href='https://taieng.co.kr';}
-function renderOk(p){var rc=document.getElementById('rc'),sec=5,ti;rc.innerHTML='<div class="icon-wrap success"><i class="ti tabler-circle-check"></i></div><h4 class="fw-bold mb-2">결제가 완료됐습니다.</h4><p class="text-body-secondary mb-4">서비스가 시작됩니다.</p><div class="detail-table mb-4"><div class="detail-row"><span style="color:#6c757d">상품명</span><span style="font-weight:600">'+(p.goodname||'TAI Safe')+'</span></div><div class="detail-row"><span style="color:#6c757d">결제금액</span><span style="font-weight:600">'+fmt(p.price)+'</span></div><div class="detail-row"><span style="color:#6c757d">결제수단</span><span style="font-weight:600">'+(p.paymethod||'카드')+'</span></div>'+(p.applnum?'<div class="detail-row"><span style="color:#6c757d">승인번호</span><span style="font-weight:600">'+p.applnum+'</span></div>':'')+(p.expired_at?'<div class="detail-row"><span style="color:#6c757d">서비스 만료일</span><span style="font-weight:600">'+p.expired_at.slice(0,10)+'</span></div>':'')+'</div><button class="btn btn-primary btn-action w-100" onclick="goHome()">서비스 시작하기 →</button><div class="countdown" id="cd">'+sec+'초 후 자동 이동</div>';ti=setInterval(function(){sec--;var e=document.getElementById('cd');if(e)e.textContent=sec+'초 후 자동 이동';if(sec<=0){clearInterval(ti);goHome();}},1000);}
+// 진단 결제 여부 판별: product_type=DIAGNOSIS 또는 상품명에 법령진단/LDX 포함
+function isDiagnosis(p){
+  var pt=(p.product_type||'').toUpperCase();
+  var gn=(p.goodname||'');
+  return pt.indexOf('DIAGNOSIS')>=0 || gn.indexOf('법령진단')>=0 || gn.indexOf('LDX')>=0;
+}
+// 결제 완료 후 진단 상세입력으로 이어가기 (회원 로그인 상태로 oid 들고 진입)
+function goDiagnosisInput(oid){
+  var u='https://taieng.co.kr/free-diagnosis?paid=1';
+  if(oid)u+='&oid='+encodeURIComponent(oid);
+  (window.top||window).location.href=u;
+}
+function renderOkDiagnosis(p){
+  var rc=document.getElementById('rc');
+  rc.innerHTML='<div class="icon-wrap success"><i class="ti tabler-circle-check"></i></div>'
+    +'<h4 class="fw-bold mb-2">결제가 완료됐습니다.</h4>'
+    +'<p class="text-body-secondary mb-4">이제 시설·공정·설비 정보를 입력하면 법령진단이 시작됩니다.</p>'
+    +'<div class="detail-table mb-4">'
+    +'<div class="detail-row"><span style="color:#6c757d">상품명</span><span style="font-weight:600">'+(p.goodname||'법령진단')+'</span></div>'
+    +'<div class="detail-row"><span style="color:#6c757d">결제금액</span><span style="font-weight:600">'+fmt(p.price)+'</span></div>'
+    +(p.applnum?'<div class="detail-row"><span style="color:#6c757d">승인번호</span><span style="font-weight:600">'+p.applnum+'</span></div>':'')
+    +'</div>'
+    +'<button class="btn btn-primary btn-action w-100" onclick="goDiagnosisInput(\''+(p.oid||'')+'\')">상세입력 계속하기 →</button>'
+    +'<div class="countdown">입력 중 중단해도 로그인하면 이어서 진행할 수 있습니다.</div>';
+}
+function renderOk(p){
+  // 진단 결제는 홈이 아니라 상세입력으로 유도
+  if(isDiagnosis(p)){renderOkDiagnosis(p);return;}
+  var rc=document.getElementById('rc'),sec=5,ti;rc.innerHTML='<div class="icon-wrap success"><i class="ti tabler-circle-check"></i></div><h4 class="fw-bold mb-2">결제가 완료됐습니다.</h4><p class="text-body-secondary mb-4">서비스가 시작됩니다.</p><div class="detail-table mb-4"><div class="detail-row"><span style="color:#6c757d">상품명</span><span style="font-weight:600">'+(p.goodname||'TAI Safe')+'</span></div><div class="detail-row"><span style="color:#6c757d">결제금액</span><span style="font-weight:600">'+fmt(p.price)+'</span></div><div class="detail-row"><span style="color:#6c757d">결제수단</span><span style="font-weight:600">'+(p.paymethod||'카드')+'</span></div>'+(p.applnum?'<div class="detail-row"><span style="color:#6c757d">승인번호</span><span style="font-weight:600">'+p.applnum+'</span></div>':'')+(p.expired_at?'<div class="detail-row"><span style="color:#6c757d">서비스 만료일</span><span style="font-weight:600">'+p.expired_at.slice(0,10)+'</span></div>':'')+'</div><button class="btn btn-primary btn-action w-100" onclick="goHome()">서비스 시작하기 →</button><div class="countdown" id="cd">'+sec+'초 후 자동 이동</div>';ti=setInterval(function(){sec--;var e=document.getElementById('cd');if(e)e.textContent=sec+'초 후 자동 이동';if(sec<=0){clearInterval(ti);goHome();}},1000);}
 function renderFail(msg,oid){var rc=document.getElementById('rc');rc.innerHTML='<div class="icon-wrap fail"><i class="ti tabler-circle-x"></i></div><h4 class="fw-bold mb-2">결제에 실패했습니다.</h4><p class="text-body-secondary mb-3">다시 시도해 주세요.</p><div class="detail-table mb-4"><div class="detail-row"><span style="color:#6c757d">사유</span><span style="color:#dc3545;font-weight:600">'+(msg||'오류')+'</span></div>'+(oid?'<div class="detail-row"><span style="color:#6c757d">주문번호</span><span style="font-size:.8rem">'+oid+'</span></div>':'')+'</div><div class="d-flex gap-2"><a href="https://taieng.co.kr/pricing.html" target="_top" class="btn btn-primary btn-action flex-grow-1">다시 시도</a><a href="https://taieng.co.kr" target="_top" class="btn btn-outline-secondary btn-action">홈으로</a></div>';}
 (function(){if(window.top!==window.self){try{window.top.location.replace(location.href);return;}catch(e){}}var p=getParams();if(!p.resultCode){renderFail('파라미터 없음');return;}if(p.resultCode==='00'||p.resultCode==='0000')renderOk(p);else renderFail(decodeURIComponent(p.msg||'오류코드 '+p.resultCode),p.oid);})();
 </script>


### PR DESCRIPTION
## 변경 요약

결제완료 결과 페이지에서 진단 결제 시 상세입력으로 이어가는 분기 추가.

### 변경
- `templates/payment/result.html` — 진단 결제(상품명에 `법령진단`/`LDX` 포함 또는 `product_type=DIAGNOSIS`) 성공 시, 홈 이동 대신 "상세입력 계속하기 →" 버튼으로 `https://taieng.co.kr/free-diagnosis?paid=1&oid=...` 유도. SaaS 등 기타 결제는 기존 홈 이동 유지(회귀 없음).

### 비고
- 엔진/Rule/스키마/법해석 변경 없음. 결제 라우터·서비스 로직 변경 없음(결과 페이지 템플릿만).
- taieng 프런트 측 `?paid=1&oid=` 수신 처리는 PR #19(머지됨)에 포함.