### PR TITLE
docs: 입력부 표준화 세션 핸드오프 (2026-06-06)

### DIFF
--- a/docs/HANDOFF_2026-06-06.md
+++ b/docs/HANDOFF_2026-06-06.md
@@ -1,0 +1,56 @@
+# 핸드오프 — 2026-06-06 (입력부 표준화 세션)
+
+## 0. 한 줄 요약
+법령엔진 **입력부 직전까지** 표준화 작업 중. 입력부(엔진 판정 로직 + factories/factory_process/equipment_assets 데이터 모델)와 입력 화면 자체는 **불변**. 1단계(입력 계약 확정·문서화) 완료. 다음은 2단계(입력 페이지 ↔ 계약 대조표).
+
+---
+
+## 1. 진짜 목적 (이전 세션 혼선 정리됨)
+- 목적 = **법령엔진 파이프라인의 입력부 표준화**. UI/결제는 그 표준 입력을 채우는 수단.
+- 입력 페이지가 불완전 → 표준화와 함께 **입력 항목 정합화**:
+  1) 누락 보완(엔진이 쓰는데 UI에 없음 → 추가)
+  2) 오입력 차단(자유입력 오류·단위 불일치 → 코드형/표준형으로 교정. **진단은 코드형 선택만, SaaS는 자유입력 허용**)
+  3) 불필요 제거(엔진이 안 쓰는 입력 → 삭제)
+- 경계: **입력부 직전까지만**. 엔진·스키마·데이터모델·입력화면 판정로직은 GPT 영역 = 건드리지 않음.
+
+## 2. 확정된 표준 (사실)
+- 입력 계층: `factories`(시설) → `factory_process`(공정) → `equipment_assets`(설비). **factory_id 중심. 진단·SaaS 공용 단일 표준.**
+  - 설비: equipment_assets.factory_process_id → factory_process.id → factory_id
+- 엔진 입력 정본 = **`diagnosis_input_fields`** (is_active=true). 섹터별 필드 목록이 "정답".
+- 진단 실행부 `services/diagnosis_service.py` evaluate()는 입력으로 직접 판정하지 않고, factory_id로 이미 만들어진 후보(facility_applicability/task_candidate 등)를 모아 출력. → 입력→매칭 본엔진은 별도(GPT 영역), 입력 계약 출처는 diagnosis_input_fields가 맞음.
+- 결제 라우터 routers/diagnosis.py는 factory_id 중심(견적/접근권한/계약 contracts 기반).
+
+## 3. 이번 세션 완료/머지 (tai-api)
+- **PR #97 머지** (`319932f`): `docs/INPUT_CONTRACT_STANDARD.md` — 입력부 표준 계약 문서. **이게 정합화의 기준선. 다음 작업은 반드시 이 문서 먼저 읽을 것.**
+- 섹터별 계약 요약은 그 문서 §2 참조 (BUILDING/CONSTRUCTION/INDUSTRIAL, FREE/PAID 티어, 코드형/필수 표시).
+
+## 4. 이번 세션 롤백 (잘못 만든 것 되돌림)
+초반에 목적을 "결제후 신규 3페이지 만들기"로 오해해 만든 것들을 표준(factories 중심)에 맞춰 되돌림:
+- 테이블 `diagnosis_input_draft` → **archive 스키마로 격리**. 복구: `ALTER TABLE archive.diagnosis_input_draft SET SCHEMA public;`
+- `router_registry/diagnosis.py` 에서 등록 해제 (원복, `4ef2dbf`)
+- `routers/diagnosis_input_draft.py` → 빈 stub으로 비활성 (`344a8a7`). 사용 금지.
+- 교훈: 임시저장은 별도 버퍼가 아니라 **표준 경로**(factories.diagnosis_status='DRAFT', tadmin 입력화면의 기존 saveDraft → /diagnosis/create·PATCH)를 쓴다.
+
+## 5. 입력부 직전 흐름 — 이번 세션 이전에 머지된 것 (taieng, nexas/, Cloudflare Pages)
+신규 유료 플로우(가격표→1페이지→이니시스 결제). 입력부 직전까지의 결제 UI:
+- PR #19 신규 플로우, #20 건설 억원입력, #21 이니시스 단건결제, #22 정확입력 안내. tai-api PR #95 result.html.
+- `nexas/paid-diagnosis.html`: 회원게이트→섹터+기준값→/public/pricing/resolve 가격확인→청약철회동의→이니시스 prepare→결제. CONSTRUCTION은 억원입력(×1억 환산).
+- 주의: 결제후 result.html이 free-diagnosis로 보내던 인계부는 **입력부(tadmin 진단입력)로의 인계로 재점검 필요** (계획 3단계).
+
+## 6. 입력 화면 위치 (SaaS=safe.taieng.co.kr, 저장소 tai-admin)
+- 경로: `tadmin/full-version/html/horizontal-menu-template/`
+- 진단 입력(입력부, 불변 대상): `diagnosis-input-building.html`, `diagnosis-input-construction.html`, `diagnosis-input-industry-paid1~3.html`, `diagnosis-step1~3.html`
+- SaaS 운영(시설/공정/설비): `factory-list.html`, `process-manage.html`/`process-select.html`, `my-equipment.html`/`equipment-qr-manager.html`
+- diagnosis-input-building.html 확인됨: saveDraft()→/diagnosis/create·PATCH, tri-state-toggle.js·autofill-address.js 공통 컴포넌트, 코드형 select+tri_state 구조.
+
+## 7. 다음 작업 (2단계) — 미착수
+**입력 페이지 ↔ INPUT_CONTRACT_STANDARD 대조표 작성** (수정 아닌 진단표, 산출물=문서):
+- BUILDING부터 한 섹터씩. diagnosis-input-building.html 필드 vs 계약 §2 → 누락/오입력/불필요 도출.
+- 이후 3단계(결제 인계 정리), 4단계(화면 정합화 — 한 화면씩).
+
+## 8. 작업 원칙 (엄수)
+- 한 페이지/한 단계씩 → 검증 → 멈춤 → 다음. **조사 폭주 금지** (이번 세션 초반 조사로 여러 번 헤맴).
+- 입력부·엔진·스키마·데이터모델 무수정. 정합화는 화면 필드 조정만.
+- GitHub 수정 = `45cm-gateway:create_or_update_file` 전체교체(sha 지정). str_replace/view는 로컬 도구.
+- 운영 DB DDL = 되돌릴 수 있게(rename/archive, 물리삭제 금지).
+- Supabase project_id = `vwlahtguyggrhvslabax`. 저장소: taiengineering/tai-api, taiengineering/taieng(nexas/), taiengineering/tai-admin(tadmin/=safe).


### PR DESCRIPTION
입력부 표준화 세션 핸드오프 문서. 다음 세션이 바로 이어받기 위한 상태/경계/다음작업 정리.

- 목적·경계(입력부 직전까지, 엔진/데이터모델 불변)
- 확정된 표준(factories→factory_process→equipment_assets, diagnosis_input_fields 정본)
- 완료: PR #97 INPUT_CONTRACT_STANDARD.md
- 롤백: diagnosis_input_draft(테이블 archive 격리 + 라우터 비활성)
- 다음: 2단계 입력페이지↔계약 대조표(BUILDING부터)