### PR TITLE
feat: Compiler Core 평가 로직 서비스 추출 + 공유 fetch

### DIFF
--- a/docs/WORKORDER_CONNECT_COMPILER_CORE.md
+++ b/docs/WORKORDER_CONNECT_COMPILER_CORE.md
@@ -1,0 +1,84 @@
+# 작업지시서: Compiler Core ↔ 소비자 진단 연결
+
+> 레포: taiengineering/tai-api  
+> 원칙: 배치 평가 로직 서비스화 + 후보 조회 DRY + factory_id 시 compiler_core 부착  
+> merge 금지 — Draft PR만
+
+---
+
+## 조사 결과 (구현 전)
+
+### 1. `scripts/run_facility_applicability.py` — 서비스 추출 가능성
+
+| 구분 | 내용 |
+|------|------|
+| **추출 가능 (순수 로직)** | `FIELD_MAP`, `compare_numeric`, facility×draft 평가 루프, overall status 집계 |
+| **스크립트에 잔류 (I/O)** | psycopg2 DDL/TRUNCATE, factories/draft_slot 로드, bulk INSERT |
+| **판단** | **추출 가능** → `services/facility_applicability_eval.py` |
+
+평가는 `draft_slot` (section=`IF_NUMERIC` / `IF_SCOPE`)을 읽으며, `numeric_constraint`는 **직접 조회하지 않음** (executable_draft 빌드 시 이미 draft_slot에 operator/value/unit 복사됨).
+
+### 2. `DiagnosisService.evaluate` 출력 포맷
+
+```python
+{
+  "diagnosis_id": "<session uuid>",
+  "facility_id": "<factory uuid>",
+  "diagnosis_status": "COMPLETED_WITH_CANDIDATES" | "COMPLETED_CLEAN" | "NEEDS_HUMAN_REVIEW",
+  "applicability_candidates": [...],      # facility_applicability MATCH/POSSIBLE
+  "obligation_candidates": [...],         # diagnosis_candidate insert 결과
+  "prohibition_candidates": [],
+  "penalty_candidates": [...],
+  "schedule_candidate_hints": [...],
+  "missing_data": ["employee_count", ...],
+  "residuals": [...],                     # compliance_review_queue
+  "human_review_queue": [...],
+  "validation": {"status": "PASS"|"AMBIGUOUS"|"UNRESOLVED", "issues": []},
+}
+```
+
+입력 `input_data`로 **직접 조건 비교하지 않음**. `factory_id`로 **이미 materialize된** runtime 테이블을 읽음.
+
+### 3. `draft_condition_graph` + `numeric_constraint` 구조
+
+```
+law_article_part
+  → numeric_constraint (operator, value, unit, span)     [run_numeric_full.py]
+  → rule_candidate_slot.numeric_constraint_id
+  → draft_slot IF_NUMERIC (operator/value/unit 복사)   [run_executable_draft.py UPDATE]
+  → draft_condition_graph (if_families[], then_families[])  ← 메타만, 런타임 평가 미사용
+  → run_facility_applicability: draft_slot vs factories 컬럼 비교
+  → facility_applicability (MATCH_CANDIDATE / …)
+```
+
+| 테이블 | 런타임 평가 역할 |
+|--------|------------------|
+| `numeric_constraint` | 조문에서 수치 추출 **저장** (배치) |
+| `draft_slot` IF_NUMERIC | 비교에 쓰이는 operator/value |
+| `draft_condition_graph` | if/then family **목록** (그래프 시각화·IR, 비교 없음) |
+| `facility_applicability` | facility×draft **평가 결과** |
+
+비교 함수: `compare_numeric(operator, draft_value, facility_column_value)` → `MATCH_CANDIDATE` / `NOT_MATCHED` / `MISSING_DATA` / `AMBIGUOUS`.
+
+---
+
+## 구현 범위 (본 PR)
+
+1. `services/facility_applicability_eval.py` — 순수 평가 로직 추출
+2. `services/compiler_core_svc.py` — `fetch_compiler_candidates()` 공유
+3. `diagnosis_service.py`, `compiler_core.py` — 공유 fetch 사용 (DRY)
+4. `diagnosis_runtime_step1.py` — `factory_id` 있을 때 `result_data.compiler_core` 부착
+5. `scripts/run_facility_applicability.py` — 서비스 함수 호출로 슬림화
+6. 단위 테스트 2건
+
+## 비범위 (후속 PR)
+
+- 익명 진단(`factory_id=None`)을 compiler core로 **대체** (현재는 runtime_metadata 유지)
+- `draft_condition_graph`를 이용한 then-action 평가
+- on-demand applicability 재계산 API (배치 없이 evaluate 호출)
+
+## 검증
+
+```bash
+pytest tests/test_facility_applicability_eval.py tests/test_compiler_core_svc.py -q
+```

--- a/docs/WORKORDER_PHASE2_ANONYMOUS_COMPILER.md
+++ b/docs/WORKORDER_PHASE2_ANONYMOUS_COMPILER.md
@@ -1,0 +1,42 @@
+# 작업지시서: Phase 2 — 익명 진단 Compiler Core 연결
+
+> Phase 1 완료: facility_applicability_eval.py 추출, compiler_core_svc.py 공유 fetch
+> Phase 2 목표: 익명 진단(factory_id=None)이 Compiler Core를 사용하도록 연결
+> 브랜치: feature/connect-compiler-core-20260608 (Phase 1과 동일 브랜치)
+> 원칙: 엔진 수정 금지. 연결만.
+
+## Phase 1 산출물 (이미 있는 것)
+
+- services/facility_applicability_eval.py → evaluate_single_factory()
+- services/compiler_core_svc.py → fetch_compiler_candidates()
+
+## Phase 2 구현
+
+### 1. services/anonymous_factory_service.py (신규)
+
+- create_temp_factory(supabase, sector, input_data) → factory_id
+- run_anonymous_diagnosis(supabase, sector, input_data) → result_data
+- cleanup_temp_factory(supabase, factory_id)
+- _compiler_result_to_step1_format(compiler_result, sector) → 프론트 호환 포맷
+
+### 2. routers/anonymous_diagnosis.py 변경
+
+_run_step1_via_service()가 run_anonymous_diagnosis()를 호출하도록 교체.
+
+### 3. services/diagnosis_integrated_svc.py 동일 변경
+
+### 4. 격리
+
+- services/diagnosis_runtime_step1.py → [ISOLATED]
+- services/legal_runtime_fetch.py → [ISOLATED]
+- services/rule_candidate_projection.py → [ISOLATED]
+
+### 5. 검증
+
+- BUILDING 50명 → ~100건 이하
+- MANUFACTURING 300명 → ~100건 이하
+- CONSTRUCTION 78억 → ~200건 이하
+- 출력 포맷 기존과 호환
+- factories 테이블 임시 데이터 잔류 없음
+
+## 상세 내용은 로컬 WORKORDER_PHASE2_ANONYMOUS_COMPILER.md 참조

--- a/docs/WORKORDER_PHASE2_ANONYMOUS_COMPILER.md
+++ b/docs/WORKORDER_PHASE2_ANONYMOUS_COMPILER.md
@@ -1,42 +1,56 @@
-# 작업지시서: Phase 2 — 익명 진단 Compiler Core 연결
+# 작업지시서: Phase 2 — 익명/소비자 진단 Compiler Core 연결
 
-> Phase 1 완료: facility_applicability_eval.py 추출, compiler_core_svc.py 공유 fetch
-> Phase 2 목표: 익명 진단(factory_id=None)이 Compiler Core를 사용하도록 연결
-> 브랜치: feature/connect-compiler-core-20260608 (Phase 1과 동일 브랜치)
+> Phase 1 완료: `facility_applicability_eval.py`, `compiler_core_svc.py`  
+> Phase 2 목표: 익명·통합 진단이 Compiler Core temp-factory 경로 사용  
+> 브랜치: `feature/connect-compiler-core-20260608` (Phase 1과 동일)  
 > 원칙: 엔진 수정 금지. 연결만.
 
-## Phase 1 산출물 (이미 있는 것)
+## Phase 1 산출물
 
-- services/facility_applicability_eval.py → evaluate_single_factory()
-- services/compiler_core_svc.py → fetch_compiler_candidates()
+- `services/facility_applicability_eval.py` — 순수 평가 로직
+- `services/compiler_core_svc.py` — `fetch_compiler_candidates()`
 
-## Phase 2 구현
+## Phase 2 구현 (완료)
 
-### 1. services/anonymous_factory_service.py (신규)
+| 항목 | 파일 |
+|------|------|
+| 오케스트레이션 | `services/anonymous_factory_service.py` |
+| 익명 API | `routers/anonymous_diagnosis.py` |
+| 통합 진단 | `routers/diagnosis_integrated.py`, `services/diagnosis_integrated_svc.py` |
+| [ISOLATED] | `diagnosis_runtime_step1.py`, `legal_runtime_fetch.py`, `rule_candidate_projection.py` |
+| 테스트 | `tests/test_anonymous_factory_service.py` |
 
-- create_temp_factory(supabase, sector, input_data) → factory_id
-- run_anonymous_diagnosis(supabase, sector, input_data) → result_data
-- cleanup_temp_factory(supabase, factory_id)
-- _compiler_result_to_step1_format(compiler_result, sector) → 프론트 호환 포맷
+### anonymous_factory_service.py
 
-### 2. routers/anonymous_diagnosis.py 변경
+- `create_temp_factory` — 소비자 입력 → `factories` INSERT (`[ANON]…`, `is_active=false`)
+- `evaluate_single_factory` — `facility_applicability_eval` + `facility_applicability` INSERT
+- `fetch_compiler_candidates` — `compiler_core_svc` 위임
+- `_compiler_result_to_step1_format` — Compiler 출력 → step1 JSON (`rules_table`, `key_obligations`, …)
+- `cleanup_temp_factory` — `facility_applicability` + `factories` DELETE
+- `run_anonymous_diagnosis` — 전체 오케스트레이션 (finally cleanup)
 
-_run_step1_via_service()가 run_anonymous_diagnosis()를 호출하도록 교체.
+## 흐름
 
-### 3. services/diagnosis_integrated_svc.py 동일 변경
+```
+DiagnoseStep1Body
+  → create_temp_factory
+  → evaluate_single_factory
+  → fetch_compiler_candidates
+  → _compiler_result_to_step1_format
+  → cleanup_temp_factory (finally)
+```
 
-### 4. 격리
+## 출력 호환
 
-- services/diagnosis_runtime_step1.py → [ISOLATED]
-- services/legal_runtime_fetch.py → [ISOLATED]
-- services/rule_candidate_projection.py → [ISOLATED]
+`rules_table`, `rules`, `key_obligations`, `law_badges`, `risk_level`, `summary`, `obligations`, `construction_summary`(건설)
 
-### 5. 검증
+- `engine_version`: `v3.0-compiler-core-anonymous`
+- `rule_version`: `compiler_core:facility_applicability:v1`
 
-- BUILDING 50명 → ~100건 이하
-- MANUFACTURING 300명 → ~100건 이하
-- CONSTRUCTION 78억 → ~200건 이하
-- 출력 포맷 기존과 호환
-- factories 테이블 임시 데이터 잔류 없음
+## 검증 (수동)
 
-## 상세 내용은 로컬 WORKORDER_PHASE2_ANONYMOUS_COMPILER.md 참조
+- BUILDING 50명 → applicable 건수 입력 민감
+- MANUFACTURING 300명 → 동일
+- CONSTRUCTION 78억 → 동일
+- 출력 포맷 기존 FE와 호환
+- `factories` / `facility_applicability` 임시 데이터 잔류 없음 (cleanup)

--- a/routers/anonymous_diagnosis.py
+++ b/routers/anonymous_diagnosis.py
@@ -20,9 +20,10 @@ from pydantic import BaseModel, Field
 from db.supabase_client import get_supabase
 from routers.auth import get_current_user
 from schemas.legal_engine import DiagnoseStep1Body
-from services.diagnosis_runtime_step1 import (
-    RUNTIME_ENGINE_VERSION,
-    run_diagnose_step1_runtime,
+from services.anonymous_factory_service import (
+    ANONYMOUS_COMPILER_ENGINE_VERSION,
+    RULE_VERSION_COMPILER,
+    run_anonymous_diagnosis,
 )
 from services.legal_helpers import _now_iso
 from services.legal_rules import normalize_sector_db
@@ -53,7 +54,7 @@ from watch_engine.trace import clear_trace
 
 router = APIRouter(prefix="/anonymous-diagnosis", tags=["익명 무료진단"])
 
-RULE_VERSION = "runtime_metadata_resolution:v1"
+RULE_VERSION = RULE_VERSION_COMPILER
 SOURCE_TYPE_DEFAULT = "site_free"
 TTL_DAYS = 7
 _ALLOWED_DIAGNOSE_SECTORS = frozenset({"BUILDING", "MANUFACTURING", "CONSTRUCTION", "SPECIAL_FACILITY", "SPECIAL"})
@@ -71,12 +72,11 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-# LEGACY - ISOLATED (제거됨): legal_engine_svc.run_diagnose_step1 + master_building_legal_rules
-# 현재: run_diagnose_step1_runtime (runtime_metadata_resolution)
+# LEGACY [ISOLATED]: run_diagnose_step1_runtime (runtime_metadata_resolution) — Phase 2 replaced
 
 
 def _run_step1_via_service(supabase, step1_body: DiagnoseStep1Body) -> Dict[str, Any]:
-    result_data = run_diagnose_step1_runtime(
+    result_data = run_anonymous_diagnosis(
         supabase,
         step1_body,
         _ALLOWED_DIAGNOSE_SECTORS,
@@ -234,7 +234,7 @@ async def create_anonymous_diagnosis(body: AnonymousDiagnosisCreate):
         "created_at": created, "expires_at": expires,
         "claimed_user_id": None, "status": "ACTIVE",
         "source_type": SOURCE_TYPE_DEFAULT,
-        "engine_version": RUNTIME_ENGINE_VERSION,
+        "engine_version": ANONYMOUS_COMPILER_ENGINE_VERSION,
         "rule_version": RULE_VERSION,
     }
     emit_event(

--- a/routers/compiler_core.py
+++ b/routers/compiler_core.py
@@ -46,49 +46,23 @@ async def evaluate_facility(body: FacilityEvaluateRequest):
     """Runtime이 호출하는 Compiler Core.
     Candidate만 반환. 법적 확정 금지.
     """
+    from services.compiler_core_svc import fetch_compiler_candidates
+
     sb = _get_sb()
-    fid = body.factory_id
-
-    # Applicability Candidates
-    app_result = sb.table('facility_applicability').select(
-        'id, draft_id, applicability_status, part_id'
-    ).eq('factory_id', fid).in_(
-        'applicability_status', ['MATCH_CANDIDATE', 'POSSIBLE_CANDIDATE']
-    ).execute()
-
-    # Task Candidates
-    task_result = sb.table('task_candidate').select(
-        'id, task_type, source_action_family, obligation_family, applicability_status, status'
-    ).eq('factory_id', fid).execute()
-
-    # Schedule Candidates
-    sched_result = sb.table('schedule_candidate').select(
-        'id, schedule_type, source_family, source_relation_type, task_type, status'
-    ).eq('factory_id', fid).execute()
-
-    # Penalty Candidates (via task→draft→penalty)
-    penalty_result = sb.table('penalty_obligation_relation').select(
-        'id, penalty_candidate_id, rule_candidate_id, obligation_family, via_reference, status'
-    ).execute()
-
-    # Review Queue (facility-specific)
-    review_result = sb.table('compliance_review_queue').select(
-        'id, issue_type, detail, status'
-    ).eq('factory_id', fid).execute()
-
-    # Compliance Package
-    pkg_result = sb.table('compliance_package').select('*').eq('factory_id', fid).execute()
-
+    try:
+        core = fetch_compiler_candidates(sb, body.factory_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     return {
-        'factory_id': fid,
-        'compiler_version': 'v3.0-deterministic',
-        'warning': 'All results are CANDIDATES. Not legal conclusions.',
-        'applicability_candidates': app_result.data or [],
-        'task_candidates': task_result.data or [],
-        'schedule_candidates': sched_result.data or [],
-        'penalty_relations': penalty_result.data[:50] if penalty_result.data else [],  # 제한
-        'review_queue': review_result.data or [],
-        'compliance_package': pkg_result.data[0] if pkg_result.data else None,
+        'factory_id': core['factory_id'],
+        'compiler_version': core['compiler_version'],
+        'warning': core['warning'],
+        'applicability_candidates': core['applicability_candidates'],
+        'task_candidates': core['task_candidates'],
+        'schedule_candidates': core['schedule_candidates'],
+        'penalty_relations': core['penalty_relations'],
+        'review_queue': core['review_queue'],
+        'compliance_package': core['compliance_package'],
     }
 
 

--- a/routers/diagnosis_integrated.py
+++ b/routers/diagnosis_integrated.py
@@ -19,11 +19,9 @@ from services.diagnosis_nexas_adapter import (
     build_nexas_run_response,
     nexas_run_body_from_request,
 )
-from services.diagnosis_runtime_step1 import (
-    RUNTIME_ENGINE_VERSION,
-    convert_rules_table_to_matched_rules,
-    run_diagnose_step1_runtime,
-)
+from services.anonymous_factory_service import ANONYMOUS_COMPILER_ENGINE_VERSION
+from services.diagnosis_integrated_svc import run_step1_via_compiler
+from services.diagnosis_runtime_step1 import convert_rules_table_to_matched_rules
 from services.legal_adapter import project_rules
 
 log = logging.getLogger(__name__)
@@ -31,7 +29,7 @@ log = logging.getLogger(__name__)
 router = APIRouter(prefix="/diagnosis", tags=["진단통합"])
 
 VERSION = "1.0.2"
-ENGINE_VERSION = RUNTIME_ENGINE_VERSION
+ENGINE_VERSION = ANONYMOUS_COMPILER_ENGINE_VERSION
 _ALLOWED_DIAGNOSE_SECTORS = frozenset({"BUILDING", "MANUFACTURING", "CONSTRUCTION", "SPECIAL_FACILITY", "SPECIAL"})
 
 # 이니시스 환경변수
@@ -72,14 +70,9 @@ FREE_TIER_CODES = frozenset({
 
 def _run_step1_via_service(supabase, step1_body: DiagnoseStep1Body) -> Dict[str, Any]:
     try:
-        result_data = run_diagnose_step1_runtime(
-            supabase,
-            step1_body,
-            _ALLOWED_DIAGNOSE_SECTORS,
-        )
+        return run_step1_via_compiler(supabase, step1_body, _ALLOWED_DIAGNOSE_SECTORS)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    return {"status": "success", "data": result_data}
 
 
 def _resolve_auth_log(supabase, auth_token: str) -> dict:

--- a/scripts/run_facility_applicability.py
+++ b/scripts/run_facility_applicability.py
@@ -9,25 +9,15 @@
 """
 
 import logging, os, sys, time
+from pathlib import Path
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
 
-# ════════════════════════════════════════════════════════
-# [3단계] Field Binding: binding_field → facility 칼럼
-# 단위 환산 금지. 직접 매칭만.
-# ════════════════════════════════════════════════════════
-FIELD_MAP = {
-    "employee_count":      ("employee_count",         "DIRECT"),
-    "area_size":            ("building_area",          "DIRECT"),
-    "power_capacity":       ("electrical_capacity_kw", "DIRECT"),
-    "voltage_level":        ("transformer_capacity_kva","AMBIGUOUS"),
-    "storage_capacity":     ("gas_capacity_m3",        "AMBIGUOUS"),
-    "equipment_type":       (None,                     "EQUIPMENT_JOIN"),
-    "facility_type":        ("site_type",              "AMBIGUOUS"),
-    "process_type":         ("ksic_code",              "AMBIGUOUS"),
-    "monetary_value":       ("construction_amount",    "AMBIGUOUS"),
-    "concentration_level":  (None,                     "MISSING"),
-    "distance_value":       (None,                     "MISSING"),
-}
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from services.facility_applicability_eval import evaluate_draft_for_facility
 
 CREATE_TABLES_SQL = """
 CREATE TABLE IF NOT EXISTS facility_applicability (
@@ -74,28 +64,6 @@ CREATE INDEX IF NOT EXISTS idx_fa_status ON facility_applicability(applicability
 CREATE INDEX IF NOT EXISTS idx_fad_appid ON facility_applicability_detail(applicability_id);
 CREATE INDEX IF NOT EXISTS idx_fai_factory ON facility_applicability_issue(factory_id);
 """
-
-
-def compare_numeric(operator, draft_val, facility_val):
-    """[4단계] 숫자 비교. 법적 판단 없음. 조건 충족 여부만."""
-    if draft_val is None or facility_val is None:
-        return "MISSING_DATA"
-    try:
-        dv = float(draft_val)
-        fv = float(facility_val)
-    except (TypeError, ValueError):
-        return "MISSING_DATA"
-
-    if operator == ">=":
-        return "MATCH_CANDIDATE" if fv >= dv else "NOT_MATCHED"
-    elif operator == "<=":
-        return "MATCH_CANDIDATE" if fv <= dv else "NOT_MATCHED"
-    elif operator == ">":
-        return "MATCH_CANDIDATE" if fv > dv else "NOT_MATCHED"
-    elif operator == "<":
-        return "MATCH_CANDIDATE" if fv < dv else "NOT_MATCHED"
-    else:
-        return "AMBIGUOUS"
 
 
 def _to_str(val):
@@ -195,60 +163,15 @@ def main():
     for fac in fac_list:
         fac_id = fac['id']
         for draft_id in all_draft_ids:
-            part_id = None
-            check_results = []
-
-            for ns in draft_numerics.get(draft_id, []):
-                part_id = ns['part_id']
-                bf = ns['binding_field']
-                fmap = FIELD_MAP.get(bf)
-                if not fmap:
-                    check_results.append(('NUMERIC_CHECK', bf, None, ns['operator'], ns['value'], None, 'MISSING_DATA', 'NO_FIELD_MAP'))
-                    continue
-                fac_col, quality = fmap
-                if fac_col is None:
-                    check_results.append(('NUMERIC_CHECK', bf, None, ns['operator'], ns['value'], None, 'MISSING_DATA', 'NO_FACILITY_COLUMN'))
-                    continue
-                fac_val = fac.get(fac_col)
-                if fac_val is None:
-                    check_results.append(('NUMERIC_CHECK', bf, fac_col, ns['operator'], ns['value'], None, 'MISSING_DATA', 'FACILITY_VALUE_NULL'))
-                    continue
-                if quality == 'AMBIGUOUS':
-                    check_results.append(('NUMERIC_CHECK', bf, fac_col, ns['operator'], ns['value'], fac_val, 'AMBIGUOUS', 'UNIT_MISMATCH_POSSIBLE'))
-                else:
-                    result = compare_numeric(ns['operator'], ns['value'], fac_val)
-                    check_results.append(('NUMERIC_CHECK', bf, fac_col, ns['operator'], ns['value'], fac_val, result, 'DIRECT_COMPARE'))
-
-            for ss in draft_scopes.get(draft_id, []):
-                part_id = part_id or ss['part_id']
-                bf = ss['binding_field']
-                fmap = FIELD_MAP.get(bf)
-                if not fmap or fmap[0] is None:
-                    check_results.append(('SCOPE_CHECK', bf, None, None, None, None, 'MISSING_DATA', 'NO_FACILITY_COLUMN'))
-                else:
-                    fac_val = fac.get(fmap[0])
-                    if fac_val is None:
-                        check_results.append(('SCOPE_CHECK', bf, fmap[0], None, None, None, 'MISSING_DATA', 'FACILITY_VALUE_NULL'))
-                    else:
-                        check_results.append(('SCOPE_CHECK', bf, fmap[0], None, None, fac_val, 'POSSIBLE_CANDIDATE', 'SCOPE_FIELD_EXISTS'))
-
-            if not check_results or part_id is None:
+            evaluated = evaluate_draft_for_facility(
+                fac,
+                draft_id,
+                draft_numerics.get(draft_id, []),
+                draft_scopes.get(draft_id, []),
+            )
+            if not evaluated:
                 continue
-
-            results_set = set(r[6] for r in check_results)
-            if 'MATCH_CANDIDATE' in results_set and 'NOT_MATCHED' not in results_set:
-                overall = 'MATCH_CANDIDATE'
-            elif 'MATCH_CANDIDATE' in results_set and 'NOT_MATCHED' in results_set:
-                overall = 'AMBIGUOUS'
-            elif 'POSSIBLE_CANDIDATE' in results_set:
-                overall = 'POSSIBLE_CANDIDATE'
-            elif 'AMBIGUOUS' in results_set:
-                overall = 'AMBIGUOUS'
-            elif results_set == {'NOT_MATCHED'}:
-                overall = 'NOT_MATCHED'
-            else:
-                overall = 'MISSING_DATA'
-
+            overall, part_id, check_results = evaluated
             applicabilities.append((
                 fac_id, draft_id, part_id, overall,
                 json.dumps({'checks': len(check_results)})

--- a/services/anonymous_factory_service.py
+++ b/services/anonymous_factory_service.py
@@ -1,0 +1,434 @@
+"""Anonymous / consumer diagnosis via Compiler Core (temp factory lifecycle).
+
+Phase 2: replaces runtime_metadata_resolution path for consumer step1.
+Creates a short-lived factories row, on-demand facility_applicability evaluation,
+fetches compiler candidates, converts to legacy step1 JSON, then cleans up.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
+
+from schemas.legal_engine import DiagnoseStep1Body
+from services.compiler_core_svc import COMPILER_VERSION, fetch_compiler_candidates
+from services.facility_applicability_eval import evaluate_draft_for_facility
+from services.legal_context import _input_to_facility_context
+from services.legal_helpers import get_sector_groups
+from services.legal_rules import get_construction_summary, normalize_sector_db, risk_level
+
+log = logging.getLogger(__name__)
+
+ANONYMOUS_COMPILER_ENGINE_VERSION = "v3.0-compiler-core-anonymous"
+RULE_VERSION_COMPILER = "compiler_core:facility_applicability:v1"
+
+_DRAFT_PAGE = 1000
+_INSERT_CHUNK = 200
+_PERSIST_STATUSES = frozenset({"MATCH_CANDIDATE", "POSSIBLE_CANDIDATE"})
+
+_TASK_TYPE_TO_BUCKET: Dict[str, Tuple[str, str]] = {
+    "APPOINTMENT": ("appointment", "선임"),
+    "DESIGNATE": ("appointment", "선임"),
+    "REPORT": ("report", "신고"),
+    "NOTIFY": ("notify", "보고"),
+    "SUBMIT": ("report", "신고"),
+    "INSPECTION": ("inspection", "점검"),
+    "INSPECT": ("inspection", "점검"),
+    "MEASURE": ("inspection", "점검"),
+    "INSTALL": ("action", "조치"),
+    "MAINTAIN": ("action", "조치"),
+    "EDUCATION": ("action", "조치"),
+    "RECORD": ("action", "조치"),
+    "PRESERVATION": ("action", "조치"),
+}
+
+
+def _merge_body_input(body: DiagnoseStep1Body) -> Dict[str, Any]:
+    inp = dict(body.input or {})
+    for k, v in {
+        "building_use_type": body.building_use_type,
+        "employee_count": body.employee_count,
+        "floor_area": body.floor_area,
+        "worker_count": body.worker_count,
+        "total_floor_area": body.total_floor_area,
+        "electric_capacity": body.electric_capacity,
+        "floor_count": body.floor_count,
+        "contract_amount_eok": body.contract_amount_eok,
+        "ksic_major": body.ksic_major,
+        "facility_type": body.facility_type,
+        "elevator_count": body.elevator_count,
+        "gas_capacity_kg": body.gas_capacity_kg,
+        "gas_capacity_m3": body.gas_capacity_m3,
+        "boiler_capacity_kw": body.boiler_capacity_kw,
+        "annual_energy_toe": body.annual_energy_toe,
+        "has_high_pressure_gas": body.has_high_pressure_gas,
+        "has_boiler": body.has_boiler,
+        "has_hazardous_material": body.has_hazardous_material,
+        "has_chemical_substance": body.has_chemical_substance,
+        "construction_type": body.construction_type,
+        "direct_workers": body.direct_workers,
+        "subcon_workers": body.subcon_workers,
+        "electrical_capacity_kw": body.electrical_capacity_kw,
+        "has_tunnel_bridge": body.has_tunnel_bridge,
+        "has_blasting": body.has_blasting,
+        "has_crane": body.has_crane,
+        "has_high_work": body.has_high_work,
+    }.items():
+        if v is not None and k not in inp:
+            inp[k] = v
+    return inp
+
+
+def create_temp_factory(supabase, body: DiagnoseStep1Body) -> str:
+    """Consumer input → short-lived factories row (is_active=false)."""
+    sector_raw = body.sector.strip().upper()
+    inp = _merge_body_input(body)
+    ctx = _input_to_facility_context(sector_raw, inp)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    row: Dict[str, Any] = {
+        "name": f"[ANON]{sector_raw}-{ts}"[:200],
+        "sector": sector_raw,
+        "site_type": sector_raw,
+        "is_active": False,
+        "status_code": "ANON_TEMP",
+        "employee_count": int(ctx.get("worker_count") or ctx.get("employee_count") or 0),
+        "building_area": float(ctx.get("building_area") or ctx.get("total_floor_area") or 0),
+        "electrical_capacity_kw": float(
+            ctx.get("electrical_capacity_kw") or ctx.get("electric_capacity") or 0
+        ),
+        "transformer_capacity_kva": float(ctx.get("transformer_capacity_kva") or 0),
+        "gas_capacity_m3": float(ctx.get("gas_capacity_m3") or 0),
+        "gas_capacity_kg": float(ctx.get("gas_capacity_kg") or 0),
+        "construction_amount": float(ctx.get("construction_amount") or 0),
+        "ksic_code": str(ctx.get("ksic_code") or ""),
+        "construction_type": str(ctx.get("construction_type") or ""),
+        "subcontractor_worker_count": int(
+            ctx.get("subcontractor_worker_count") or ctx.get("subcon_workers") or 0
+        ),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    res = supabase.table("factories").insert(row).execute()
+    if not res.data:
+        raise RuntimeError("임시 시설(factories) 생성 실패")
+    return str(res.data[0]["id"])
+
+
+def _load_draft_slot_groups(supabase) -> Tuple[Dict[str, List[Dict]], Dict[str, List[Dict]]]:
+    """Paginate draft_slot → numeric / scope groups keyed by draft_id."""
+    numerics: Dict[str, List[Dict[str, Any]]] = {}
+    scopes: Dict[str, List[Dict[str, Any]]] = {}
+    offset = 0
+    while True:
+        res = (
+            supabase.table("draft_slot")
+            .select("draft_id, part_id, section, binding_field, operator, value, unit, family_name")
+            .not_.is_("binding_field", "null")
+            .in_("section", ["IF_NUMERIC", "IF_SCOPE"])
+            .range(offset, offset + _DRAFT_PAGE - 1)
+            .execute()
+        )
+        chunk = res.data or []
+        if not chunk:
+            break
+        for row in chunk:
+            draft_id = str(row.get("draft_id") or "")
+            if not draft_id:
+                continue
+            section = (row.get("section") or "").upper()
+            if section == "IF_NUMERIC":
+                if not row.get("operator") or row.get("value") is None:
+                    continue
+                numerics.setdefault(draft_id, []).append(
+                    {
+                        "part_id": str(row.get("part_id") or ""),
+                        "binding_field": row.get("binding_field"),
+                        "operator": row.get("operator"),
+                        "value": row.get("value"),
+                        "unit": row.get("unit"),
+                        "family": row.get("family_name"),
+                    }
+                )
+            elif section == "IF_SCOPE":
+                scopes.setdefault(draft_id, []).append(
+                    {
+                        "part_id": str(row.get("part_id") or ""),
+                        "binding_field": row.get("binding_field"),
+                        "family": row.get("family_name"),
+                    }
+                )
+        if len(chunk) < _DRAFT_PAGE:
+            break
+        offset += _DRAFT_PAGE
+    return numerics, scopes
+
+
+def evaluate_single_factory(supabase, factory_id: str) -> Dict[str, int]:
+    """
+    On-demand facility_applicability for one factory (Compiler Core materialize).
+
+    Uses facility_applicability_eval pure logic; persists MATCH/POSSIBLE rows only.
+    """
+    fac_res = supabase.table("factories").select("*").eq("id", factory_id).limit(1).execute()
+    if not fac_res.data:
+        raise LookupError(f"factory not found: {factory_id}")
+    facility = fac_res.data[0]
+
+    numerics, scopes = _load_draft_slot_groups(supabase)
+    all_draft_ids = set(numerics.keys()) | set(scopes.keys())
+
+    rows: List[Dict[str, Any]] = []
+    for draft_id in all_draft_ids:
+        evaluated = evaluate_draft_for_facility(
+            facility,
+            draft_id,
+            numerics.get(draft_id, []),
+            scopes.get(draft_id, []),
+        )
+        if not evaluated:
+            continue
+        overall, part_id, check_results = evaluated
+        if overall not in _PERSIST_STATUSES:
+            continue
+        rows.append(
+            {
+                "factory_id": factory_id,
+                "draft_id": draft_id,
+                "part_id": part_id,
+                "applicability_status": overall,
+                "match_details": {"checks": len(check_results)},
+            }
+        )
+
+    inserted = 0
+    for i in range(0, len(rows), _INSERT_CHUNK):
+        batch = rows[i : i + _INSERT_CHUNK]
+        if not batch:
+            continue
+        supabase.table("facility_applicability").insert(batch).execute()
+        inserted += len(batch)
+
+    return {
+        "drafts_evaluated": len(all_draft_ids),
+        "applicability_inserted": inserted,
+    }
+
+
+def cleanup_temp_factory(supabase, factory_id: str) -> None:
+    """Remove temp applicability rows and factories record."""
+    fid = (factory_id or "").strip()
+    if not fid:
+        return
+    try:
+        supabase.table("facility_applicability").delete().eq("factory_id", fid).execute()
+    except Exception as exc:
+        log.warning("facility_applicability cleanup failed factory_id=%s: %s", fid, exc)
+    try:
+        supabase.table("factories").delete().eq("id", fid).execute()
+    except Exception as exc:
+        log.warning("factories cleanup failed factory_id=%s: %s", fid, exc)
+
+
+def _task_to_rule_row(task: Dict[str, Any], sector_raw: str) -> Dict[str, Any]:
+    task_type = (task.get("task_type") or "ACTION").upper()
+    bucket, cat_label = _TASK_TYPE_TO_BUCKET.get(task_type, ("action", "조치"))
+    title = f"{task.get('task_type', '')}: {task.get('source_action_family', '')}".strip(": ")
+    fam = (task.get("obligation_family") or "").strip()
+    obl_type = task_type if task_type in ("APPOINT", "INSPECT", "REPORT", "NOTIFY", "ACTION") else "ACTION"
+    flags = {
+        "appointment_required": bucket == "appointment",
+        "inspection_required": bucket == "inspection",
+        "action_required": bucket == "action",
+        "report_required": bucket == "report",
+        "notify_required": bucket == "notify",
+    }
+    return {
+        "rule_id": str(task.get("id") or ""),
+        "rule_type": task_type,
+        "law_name": fam or "Compiler Candidate",
+        "law_article": "",
+        "obligation_summary": title or fam or "의무 후보",
+        "remarks": title,
+        "description": title or fam,
+        "category": cat_label,
+        "obligation_type": obl_type,
+        "sector": sector_raw,
+        "diagnosis_stage": 1,
+        "schedule_type": "ON_DEMAND",
+        "penalty_summary": "",
+        **flags,
+        "_bucket": bucket,
+    }
+
+
+def _compiler_result_to_step1_format(
+    compiler: Dict[str, Any],
+    *,
+    sector_raw: str,
+    facility_ctx: Dict[str, Any],
+    evaluated_at: str,
+) -> Dict[str, Any]:
+    """Compiler Core / DiagnosisService-shaped dict → legacy step1 result_data."""
+    sector_db = normalize_sector_db(sector_raw)
+    sector_groups = get_sector_groups(sector_db)
+    tasks = compiler.get("task_candidates") or []
+    applicability = compiler.get("applicability_candidates") or []
+
+    rules_from_tasks = [_task_to_rule_row(t, sector_raw) for t in tasks]
+    if not rules_from_tasks and applicability:
+        for a in applicability:
+            status = a.get("applicability_status") or ""
+            rules_from_tasks.append(
+                {
+                    "rule_id": str(a.get("id") or a.get("draft_id") or ""),
+                    "law_name": "Applicability Candidate",
+                    "law_article": "",
+                    "obligation_summary": f"Applicability: {status}",
+                    "remarks": f"draft={a.get('draft_id')}",
+                    "description": f"Applicability: {status}",
+                    "category": "조치",
+                    "obligation_type": "ACTION",
+                    "sector": sector_raw,
+                    "action_required": True,
+                    "_bucket": "action",
+                }
+            )
+
+    triggered: Dict[str, List] = {
+        "appointment": [],
+        "inspection": [],
+        "notify": [],
+        "report": [],
+        "action": [],
+        "not_applicable": [],
+    }
+    for row in rules_from_tasks:
+        bucket = row.pop("_bucket", "action")
+        triggered[bucket].append(row)
+
+    rules_table: List[Dict[str, Any]] = []
+    for key, label in [
+        ("appointment", "선임"),
+        ("inspection", "점검"),
+        ("action", "조치"),
+        ("report", "신고"),
+        ("notify", "보고"),
+    ]:
+        for row in triggered[key]:
+            rules_table.append({"category": label, **row})
+
+    total_applicable = sum(len(triggered[k]) for k in ("appointment", "inspection", "notify", "report", "action"))
+    law_names = sorted({x.get("law_name") for x in rules_from_tasks if x.get("law_name")})
+    appointment_n = len(triggered["appointment"])
+    risk = risk_level(total_applicable, appointment_n)
+
+    key_obligations: List[str] = []
+    for x in rules_from_tasks[:20]:
+        t = (x.get("obligation_summary") or x.get("remarks") or "").strip()
+        if t and t not in key_obligations:
+            key_obligations.append(t)
+
+    obligations: List[Dict[str, Any]] = []
+    for key, label in [("appointment", "선임"), ("inspection", "점검"), ("action", "조치")]:
+        if triggered[key]:
+            obligations.append({"category": key, "label": label, "items": triggered[key]})
+    if triggered["report"]:
+        obligations.append({"category": "report", "label": "신고", "items": triggered["report"]})
+    if triggered["notify"]:
+        obligations.append({"category": "notify", "label": "보고", "items": triggered["notify"]})
+
+    risk_reason = f"적용 법령 {len(law_names)}개, 법적 의무 {total_applicable}건 (Compiler Core Candidate)"
+
+    result: Dict[str, Any] = {
+        "sector": sector_raw,
+        "sector_groups": sector_groups,
+        "step": 1,
+        "engine_version": ANONYMOUS_COMPILER_ENGINE_VERSION,
+        "rule_version": RULE_VERSION_COMPILER,
+        "evaluated_at": evaluated_at,
+        "facility_context": facility_ctx,
+        "risk_level": risk,
+        "risk_reason": risk_reason,
+        "applicable_law_categories": law_names,
+        "appointment_required_flag": appointment_n > 0,
+        "key_obligations": key_obligations,
+        "law_badges": law_names,
+        "obligations": obligations,
+        "rules_table": rules_table,
+        "rules": rules_table,
+        "appointment_required": triggered["appointment"],
+        "inspection_required": triggered["inspection"],
+        "action_required": triggered["action"],
+        "report_required": triggered["report"] + triggered["notify"],
+        "not_applicable": [],
+        "not_applicable_total": 0,
+        "total_rules_checked": total_applicable + len(applicability),
+        "applicable_count": total_applicable,
+        "article_mapping_stats": {
+            "total_rules": total_applicable,
+            "mapped_rules": 0,
+            "coverage_pct": 0.0,
+        },
+        "inspection_schedule_ready": {
+            "periodic_count": 0,
+            "before_work_count": 0,
+            "on_demand_count": len(triggered["inspection"]),
+            "periodic": [],
+            "before_work": [],
+        },
+        "summary": {
+            "total": total_applicable,
+            "appointment": len(triggered["appointment"]),
+            "inspection": len(triggered["inspection"]),
+            "action": len(triggered["action"]),
+            "report": len(triggered["report"]),
+            "notify": len(triggered["notify"]),
+            "form_linked": 0,
+        },
+        "compiler_core": {
+            "compiler_version": compiler.get("compiler_version") or COMPILER_VERSION,
+            "warning": compiler.get("warning"),
+            "applicability_count": len(applicability),
+            "task_count": len(tasks),
+            "schedule_count": len(compiler.get("schedule_candidates") or []),
+            "applicability_candidates": applicability,
+            "task_candidates": tasks,
+            "schedule_candidates": compiler.get("schedule_candidates") or [],
+        },
+    }
+    if sector_raw == "CONSTRUCTION":
+        result["construction_summary"] = get_construction_summary(facility_ctx)
+    return result
+
+
+def run_anonymous_diagnosis(
+    supabase,
+    body: DiagnoseStep1Body,
+    allowed_sectors: FrozenSet[str],
+) -> Dict[str, Any]:
+    """Full orchestration: temp factory → evaluate → fetch → format → cleanup."""
+    sector_raw = body.sector.strip().upper()
+    if sector_raw not in allowed_sectors:
+        raise ValueError(
+            "sector는 BUILDING, MANUFACTURING, CONSTRUCTION, SPECIAL_FACILITY 중 하나여야 합니다."
+        )
+
+    inp = _merge_body_input(body)
+    facility_ctx = _input_to_facility_context(sector_raw, inp)
+    evaluated_at = datetime.now(timezone.utc).isoformat()
+
+    factory_id: Optional[str] = None
+    try:
+        factory_id = create_temp_factory(supabase, body)
+        evaluate_single_factory(supabase, factory_id)
+        compiler = fetch_compiler_candidates(supabase, factory_id)
+        return _compiler_result_to_step1_format(
+            compiler,
+            sector_raw=sector_raw,
+            facility_ctx=facility_ctx,
+            evaluated_at=evaluated_at,
+        )
+    finally:
+        if factory_id:
+            cleanup_temp_factory(supabase, factory_id)

--- a/services/compiler_core_svc.py
+++ b/services/compiler_core_svc.py
@@ -1,0 +1,99 @@
+"""Compiler Core — shared candidate fetch for routers and diagnosis services.
+
+Reads pre-materialized runtime tables (facility_applicability, task_candidate, …).
+Does not run batch evaluation; see scripts/run_facility_applicability.py for that.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+COMPILER_VERSION = "v3.0-deterministic"
+COMPILER_WARNING = "All results are CANDIDATES. Not legal conclusions."
+
+APPLICABILITY_MATCH_STATUSES = ("MATCH_CANDIDATE", "POSSIBLE_CANDIDATE")
+
+
+def fetch_compiler_candidates(
+    sb,
+    factory_id: str,
+    *,
+    applicability_statuses: Optional[List[str]] = None,
+    penalty_limit: int = 50,
+) -> Dict[str, Any]:
+    """
+    Load Compiler Core candidate rows for a factory.
+
+  Used by:
+    - routers/compiler_core.py POST /evaluate-facility
+    - services/diagnosis_service.py DiagnosisService.evaluate
+    - services/diagnosis_runtime_step1.py (factory_id present)
+    """
+    fid = (factory_id or "").strip()
+    if not fid:
+        raise ValueError("factory_id is required")
+
+    statuses = list(applicability_statuses or APPLICABILITY_MATCH_STATUSES)
+
+    app_result = (
+        sb.table("facility_applicability")
+        .select("id, draft_id, applicability_status, part_id, match_details")
+        .eq("factory_id", fid)
+        .in_("applicability_status", statuses)
+        .execute()
+    )
+
+    task_result = (
+        sb.table("task_candidate")
+        .select(
+            "id, task_type, source_action_family, obligation_family, "
+            "applicability_status, status"
+        )
+        .eq("factory_id", fid)
+        .execute()
+    )
+
+    sched_result = (
+        sb.table("schedule_candidate")
+        .select(
+            "id, schedule_type, source_family, source_relation_type, task_type, status"
+        )
+        .eq("factory_id", fid)
+        .execute()
+    )
+
+    penalty_result = (
+        sb.table("penalty_obligation_relation")
+        .select(
+            "id, penalty_candidate_id, rule_candidate_id, "
+            "obligation_family, via_reference, status"
+        )
+        .limit(200)
+        .execute()
+    )
+
+    review_result = (
+        sb.table("compliance_review_queue")
+        .select("id, issue_type, detail, status")
+        .eq("factory_id", fid)
+        .execute()
+    )
+
+    pkg_result = (
+        sb.table("compliance_package").select("*").eq("factory_id", fid).execute()
+    )
+
+    penalties = penalty_result.data or []
+    return {
+        "factory_id": fid,
+        "compiler_version": COMPILER_VERSION,
+        "warning": COMPILER_WARNING,
+        "applicability_candidates": app_result.data or [],
+        "task_candidates": task_result.data or [],
+        "schedule_candidates": sched_result.data or [],
+        "penalty_relations": penalties[:penalty_limit],
+        "penalty_candidates": penalties[:penalty_limit],
+        "review_queue": review_result.data or [],
+        "residuals": review_result.data or [],
+        "compliance_package": pkg_result.data[0] if pkg_result.data else None,
+    }

--- a/services/diagnosis_integrated_svc.py
+++ b/services/diagnosis_integrated_svc.py
@@ -13,6 +13,19 @@ from services.legal_rules import normalize_sector_db
 
 log = logging.getLogger(__name__)
 
+_COMPILER_ALLOWED_SECTORS = frozenset(
+    {"BUILDING", "MANUFACTURING", "CONSTRUCTION", "SPECIAL_FACILITY", "SPECIAL"}
+)
+
+
+def run_step1_via_compiler(supabase, step1_body: DiagnoseStep1Body, allowed_sectors=None) -> Dict[str, Any]:
+    """Consumer step1 via Compiler Core temp-factory path (Phase 2)."""
+    from services.anonymous_factory_service import run_anonymous_diagnosis
+
+    sectors = allowed_sectors or _COMPILER_ALLOWED_SECTORS
+    result_data = run_anonymous_diagnosis(supabase, step1_body, sectors)
+    return {"status": "success", "data": result_data}
+
 
 def _save_diagnosis_purchase(
     supabase,

--- a/services/diagnosis_runtime_step1.py
+++ b/services/diagnosis_runtime_step1.py
@@ -21,6 +21,7 @@ from services.legal_rules import get_construction_summary
 from services.legal_format import _classify_rules_db, format_rule_result_db
 from services.legal_helpers import get_sector_groups
 from services.legal_rules import normalize_sector_db, risk_level
+from services.compiler_core_svc import fetch_compiler_candidates
 from services.legal_runtime_fetch import fetch_runtime_rules_as_v1
 from services.legal_step1_builder import build_step1_result_data
 
@@ -473,4 +474,28 @@ def run_diagnose_step1_runtime(
     )
     result_data["rule_version"] = "runtime_metadata_resolution:v1"
     _enrich_result_data_slots(supabase, result_data)
+
+    factory_id = (body.factory_id or "").strip() or None
+    if factory_id:
+        try:
+            core = fetch_compiler_candidates(supabase, factory_id)
+            result_data["compiler_core"] = {
+                "compiler_version": core["compiler_version"],
+                "warning": core["warning"],
+                "applicability_count": len(core["applicability_candidates"]),
+                "task_count": len(core["task_candidates"]),
+                "schedule_count": len(core["schedule_candidates"]),
+                "applicability_candidates": core["applicability_candidates"],
+                "task_candidates": core["task_candidates"],
+                "schedule_candidates": core["schedule_candidates"],
+            }
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "compiler_core fetch failed for factory_id=%s: %s",
+                factory_id,
+                exc,
+            )
+            result_data["compiler_core"] = None
+
     return result_data

--- a/services/diagnosis_runtime_step1.py
+++ b/services/diagnosis_runtime_step1.py
@@ -1,5 +1,8 @@
 """
-Nexas / anonymous diagnosis — Runtime Compiler step1 실행.
+[ISOLATED] Nexas / anonymous diagnosis — Runtime Compiler step1 (Phase 1 legacy path).
+
+Consumer diagnosis (Phase 2) uses services/anonymous_factory_service.run_anonymous_diagnosis
+instead of this module. Retained for factory_id-attached enrichment and internal tooling.
 
 legal_engine_svc.run_diagnose_step1(legacy) 대신
 runtime_metadata_resolution → v1 projection → build_step1_result_data.

--- a/services/diagnosis_service.py
+++ b/services/diagnosis_service.py
@@ -3,8 +3,11 @@
 법령진단은 판단 엔진이 아니다.
 결과를 출력할 뿐, 반복설정/스케줄/업무/위반을 확정하지 않는다.
 """
-import os, json
+import json
+import os
 from datetime import datetime, timezone
+
+from services.compiler_core_svc import fetch_compiler_candidates
 
 
 def _get_sb():
@@ -31,38 +34,12 @@ class DiagnosisService:
         sid = session.data[0]['id']
 
         try:
-            # ── Compiler Core 호출 ──
-            # Applicability
-            app_r = sb.table('facility_applicability').select(
-                'id, draft_id, applicability_status, part_id'
-            ).eq('factory_id', factory_id).in_(
-                'applicability_status', ['MATCH_CANDIDATE','POSSIBLE_CANDIDATE']
-            ).execute()
-            applicability = app_r.data or []
-
-            # Task → Obligation/Prohibition 분류
-            task_r = sb.table('task_candidate').select(
-                'id, task_type, source_action_family, obligation_family, status'
-            ).eq('factory_id', factory_id).execute()
-            tasks = task_r.data or []
-
-            # Schedule hints
-            sched_r = sb.table('schedule_candidate').select(
-                'id, schedule_type, source_family, source_relation_type, task_type, status'
-            ).eq('factory_id', factory_id).execute()
-            schedules = sched_r.data or []
-
-            # Penalty
-            penalty_r = sb.table('penalty_obligation_relation').select(
-                'id, penalty_candidate_id, rule_candidate_id, obligation_family, status'
-            ).limit(200).execute()
-            penalties = penalty_r.data or []
-
-            # Residuals (factory 관련)
-            compliance_r = sb.table('compliance_review_queue').select(
-                'id, issue_type, detail, status'
-            ).eq('factory_id', factory_id).execute()
-            residuals = compliance_r.data or []
+            core = fetch_compiler_candidates(sb, factory_id)
+            applicability = core["applicability_candidates"]
+            tasks = core["task_candidates"]
+            schedules = core["schedule_candidates"]
+            penalties = core["penalty_candidates"]
+            residuals = core["residuals"]
 
             # ── Candidate 저장 ──
             obligations = []
@@ -148,6 +125,7 @@ class DiagnosisService:
                 'diagnosis_id': sid,
                 'facility_id': factory_id,
                 'diagnosis_status': diag_status,
+                'compiler_version': core['compiler_version'],
                 'applicability_candidates': applicability,
                 'obligation_candidates': [o for o in obligations if o],
                 'prohibition_candidates': prohibitions,

--- a/services/facility_applicability_eval.py
+++ b/services/facility_applicability_eval.py
@@ -1,0 +1,217 @@
+"""Facility applicability evaluation — pure logic (no DB I/O).
+
+Extracted from scripts/run_facility_applicability.py for reuse by
+batch scripts and (future) on-demand API evaluation.
+
+Principle: condition satisfaction possibility only — not legal conclusions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+# binding_field → (factories column, match quality)
+FIELD_MAP: Dict[str, Tuple[Optional[str], str]] = {
+    "employee_count": ("employee_count", "DIRECT"),
+    "area_size": ("building_area", "DIRECT"),
+    "power_capacity": ("electrical_capacity_kw", "DIRECT"),
+    "voltage_level": ("transformer_capacity_kva", "AMBIGUOUS"),
+    "storage_capacity": ("gas_capacity_m3", "AMBIGUOUS"),
+    "equipment_type": (None, "EQUIPMENT_JOIN"),
+    "facility_type": ("site_type", "AMBIGUOUS"),
+    "process_type": ("ksic_code", "AMBIGUOUS"),
+    "monetary_value": ("construction_amount", "AMBIGUOUS"),
+    "concentration_level": (None, "MISSING"),
+    "distance_value": (None, "MISSING"),
+}
+
+CheckResult = Tuple[str, str, Optional[str], Optional[str], Any, Any, str, str]
+
+
+def compare_numeric(operator: str, draft_val: Any, facility_val: Any) -> str:
+    """Numeric comparison — returns applicability detail result token."""
+    if draft_val is None or facility_val is None:
+        return "MISSING_DATA"
+    try:
+        dv = float(draft_val)
+        fv = float(facility_val)
+    except (TypeError, ValueError):
+        return "MISSING_DATA"
+
+    op = (operator or "").strip()
+    if op == ">=":
+        return "MATCH_CANDIDATE" if fv >= dv else "NOT_MATCHED"
+    if op == "<=":
+        return "MATCH_CANDIDATE" if fv <= dv else "NOT_MATCHED"
+    if op == ">":
+        return "MATCH_CANDIDATE" if fv > dv else "NOT_MATCHED"
+    if op == "<":
+        return "MATCH_CANDIDATE" if fv < dv else "NOT_MATCHED"
+    return "AMBIGUOUS"
+
+
+def aggregate_applicability_status(results: Set[str]) -> str:
+    """Combine per-check results into overall applicability_status."""
+    if not results:
+        return "MISSING_DATA"
+    if "MATCH_CANDIDATE" in results and "NOT_MATCHED" not in results:
+        return "MATCH_CANDIDATE"
+    if "MATCH_CANDIDATE" in results and "NOT_MATCHED" in results:
+        return "AMBIGUOUS"
+    if "POSSIBLE_CANDIDATE" in results:
+        return "POSSIBLE_CANDIDATE"
+    if "AMBIGUOUS" in results:
+        return "AMBIGUOUS"
+    if results == {"NOT_MATCHED"}:
+        return "NOT_MATCHED"
+    return "MISSING_DATA"
+
+
+def evaluate_numeric_check(
+    facility: Dict[str, Any],
+    *,
+    binding_field: str,
+    operator: str,
+    draft_value: Any,
+) -> CheckResult:
+    """Single IF_NUMERIC draft_slot vs facility row."""
+    fmap = FIELD_MAP.get(binding_field)
+    if not fmap:
+        return (
+            "NUMERIC_CHECK",
+            binding_field,
+            None,
+            operator,
+            draft_value,
+            None,
+            "MISSING_DATA",
+            "NO_FIELD_MAP",
+        )
+    fac_col, quality = fmap
+    if fac_col is None:
+        return (
+            "NUMERIC_CHECK",
+            binding_field,
+            None,
+            operator,
+            draft_value,
+            None,
+            "MISSING_DATA",
+            "NO_FACILITY_COLUMN",
+        )
+    fac_val = facility.get(fac_col)
+    if fac_val is None:
+        return (
+            "NUMERIC_CHECK",
+            binding_field,
+            fac_col,
+            operator,
+            draft_value,
+            None,
+            "MISSING_DATA",
+            "FACILITY_VALUE_NULL",
+        )
+    if quality == "AMBIGUOUS":
+        return (
+            "NUMERIC_CHECK",
+            binding_field,
+            fac_col,
+            operator,
+            draft_value,
+            fac_val,
+            "AMBIGUOUS",
+            "UNIT_MISMATCH_POSSIBLE",
+        )
+    result = compare_numeric(operator, draft_value, fac_val)
+    return (
+        "NUMERIC_CHECK",
+        binding_field,
+        fac_col,
+        operator,
+        draft_value,
+        fac_val,
+        result,
+        "DIRECT_COMPARE",
+    )
+
+
+def evaluate_scope_check(
+    facility: Dict[str, Any],
+    *,
+    binding_field: str,
+) -> CheckResult:
+    """Single IF_SCOPE draft_slot — field presence only."""
+    fmap = FIELD_MAP.get(binding_field)
+    if not fmap or fmap[0] is None:
+        return (
+            "SCOPE_CHECK",
+            binding_field,
+            None,
+            None,
+            None,
+            None,
+            "MISSING_DATA",
+            "NO_FACILITY_COLUMN",
+        )
+    fac_col = fmap[0]
+    fac_val = facility.get(fac_col)
+    if fac_val is None:
+        return (
+            "SCOPE_CHECK",
+            binding_field,
+            fac_col,
+            None,
+            None,
+            None,
+            "MISSING_DATA",
+            "FACILITY_VALUE_NULL",
+        )
+    return (
+        "SCOPE_CHECK",
+        binding_field,
+        fac_col,
+        None,
+        None,
+        fac_val,
+        "POSSIBLE_CANDIDATE",
+        "SCOPE_FIELD_EXISTS",
+    )
+
+
+def evaluate_draft_for_facility(
+    facility: Dict[str, Any],
+    draft_id: str,
+    numeric_slots: List[Dict[str, Any]],
+    scope_slots: List[Dict[str, Any]],
+) -> Optional[Tuple[str, str, List[CheckResult]]]:
+    """
+    Evaluate one facility × one executable_draft.
+
+    Returns (overall_status, part_id, check_results) or None if no checks.
+    """
+    part_id: Optional[str] = None
+    check_results: List[CheckResult] = []
+
+    for ns in numeric_slots:
+        part_id = ns.get("part_id") or part_id
+        check_results.append(
+            evaluate_numeric_check(
+                facility,
+                binding_field=ns["binding_field"],
+                operator=ns.get("operator") or "",
+                draft_value=ns.get("value"),
+            )
+        )
+
+    for ss in scope_slots:
+        part_id = part_id or ss.get("part_id")
+        check_results.append(
+            evaluate_scope_check(facility, binding_field=ss["binding_field"])
+        )
+
+    if not check_results or part_id is None:
+        return None
+
+    results_set = {r[6] for r in check_results}
+    overall = aggregate_applicability_status(results_set)
+    return overall, str(part_id), check_results

--- a/services/legal_runtime_fetch.py
+++ b/services/legal_runtime_fetch.py
@@ -1,5 +1,5 @@
-# [CATALOG ONLY - NOT DIAGNOSIS SOURCE]
-# runtime_metadata_resolution = 법령 카탈로그. 진단 경로 격리됨 (2026-05-31)
+# [ISOLATED] [CATALOG ONLY - NOT DIAGNOSIS SOURCE]
+# runtime_metadata_resolution = 법령 카탈로그. 소비자 진단(Phase 2)은 compiler_core 경로 사용.
 # 삭제 금지. 검색/문서생성/AI근거탐색 용도 보존.
 
 """

--- a/services/rule_candidate_projection.py
+++ b/services/rule_candidate_projection.py
@@ -1,5 +1,7 @@
 """
-runtime_metadata_resolution → master_building_legal_rules 호환 dict.
+[ISOLATED] runtime_metadata_resolution → master_building_legal_rules 호환 dict.
+
+소비자 진단(Phase 2)은 compiler_core 경로. 본 모듈은 diagnosis_runtime_step1 등 legacy용.
 
 기계적 필드 매핑만 수행. Supabase/FastAPI import 없음.
 """

--- a/tests/test_anonymous_factory_service.py
+++ b/tests/test_anonymous_factory_service.py
@@ -1,0 +1,119 @@
+"""Tests for anonymous_factory_service (Phase 2 compiler consumer path)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from schemas.legal_engine import DiagnoseStep1Body
+from services.anonymous_factory_service import (
+    _compiler_result_to_step1_format,
+    cleanup_temp_factory,
+    create_temp_factory,
+    run_anonymous_diagnosis,
+)
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_compiler_result_to_step1_format_shape():
+    compiler = {
+        "compiler_version": "v3.0-deterministic",
+        "warning": "All results are CANDIDATES.",
+        "applicability_candidates": [{"id": "a1", "applicability_status": "MATCH_CANDIDATE", "draft_id": "d1"}],
+        "task_candidates": [
+            {
+                "id": "t1",
+                "task_type": "APPOINTMENT",
+                "source_action_family": "APPOINT_FAMILY",
+                "obligation_family": "산업안전보건법",
+                "status": "CANDIDATE",
+            }
+        ],
+        "schedule_candidates": [],
+    }
+    out = _compiler_result_to_step1_format(
+        compiler,
+        sector_raw="BUILDING",
+        facility_ctx={"worker_count": 10, "total_floor_area": 500},
+        evaluated_at="2026-06-08T00:00:00+00:00",
+    )
+    assert out["risk_level"] in ("LOW", "MEDIUM", "HIGH")
+    assert out["rules_table"]
+    assert out["rules"] == out["rules_table"]
+    assert out["key_obligations"]
+    assert out["law_badges"]
+    assert out["applicable_count"] >= 1
+    assert out["summary"]["total"] >= 1
+    assert out["compiler_core"]["task_count"] == 1
+    assert out["engine_version"] == "v3.0-compiler-core-anonymous"
+
+
+def test_create_temp_factory_maps_building_fields():
+    sb = MagicMock()
+    sb.table.return_value.insert.return_value.execute.return_value = _FakeResponse(
+        [{"id": "fac-uuid-1"}]
+    )
+    body = DiagnoseStep1Body(
+        sector="BUILDING",
+        floor_area=1200.0,
+        total_floor_area=1200.0,
+        worker_count=25,
+        employee_count=25,
+        building_use_type="사무실",
+    )
+    fid = create_temp_factory(sb, body)
+    assert fid == "fac-uuid-1"
+    insert_call = sb.table.return_value.insert.call_args[0][0]
+    assert insert_call["is_active"] is False
+    assert insert_call["name"].startswith("[ANON]BUILDING")
+    assert insert_call["employee_count"] == 25
+    assert insert_call["building_area"] == 1200.0
+
+
+def test_cleanup_temp_factory_deletes_rows():
+    sb = MagicMock()
+    cleanup_temp_factory(sb, "fac-1")
+    assert sb.table.call_args_list[0][0][0] == "facility_applicability"
+    assert sb.table.call_args_list[1][0][0] == "factories"
+
+
+@patch("services.anonymous_factory_service.cleanup_temp_factory")
+@patch("services.anonymous_factory_service.fetch_compiler_candidates")
+@patch("services.anonymous_factory_service.evaluate_single_factory")
+@patch("services.anonymous_factory_service.create_temp_factory")
+def test_run_anonymous_diagnosis_orchestration(
+    mock_create, mock_eval, mock_fetch, mock_cleanup
+):
+    mock_create.return_value = "temp-fac"
+    mock_eval.return_value = {"applicability_inserted": 2}
+    mock_fetch.return_value = {
+        "compiler_version": "v3.0-deterministic",
+        "warning": "candidate only",
+        "applicability_candidates": [],
+        "task_candidates": [
+            {
+                "id": "t1",
+                "task_type": "REPORT",
+                "source_action_family": "REPORT_FAMILY",
+                "obligation_family": "화재예방법",
+            }
+        ],
+        "schedule_candidates": [],
+    }
+    body = DiagnoseStep1Body(sector="MANUFACTURING", worker_count=30, employee_count=30)
+    out = run_anonymous_diagnosis(MagicMock(), body, frozenset({"MANUFACTURING", "BUILDING", "CONSTRUCTION", "SPECIAL_FACILITY", "SPECIAL"}))
+    assert out["rules_table"]
+    assert out["sector"] == "MANUFACTURING"
+    mock_create.assert_called_once()
+    mock_eval.assert_called_once()
+    mock_fetch.assert_called_once()
+    mock_cleanup.assert_called_once()
+
+
+def test_run_anonymous_diagnosis_invalid_sector():
+    body = DiagnoseStep1Body(sector="INVALID")
+    with pytest.raises(ValueError):
+        run_anonymous_diagnosis(MagicMock(), body, frozenset({"BUILDING"}))

--- a/tests/test_compiler_core_svc.py
+++ b/tests/test_compiler_core_svc.py
@@ -1,0 +1,76 @@
+"""Tests for compiler_core_svc fetch shape (mocked Supabase)."""
+
+
+class _FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    def __init__(self, table: str, store: dict):
+        self._table = table
+        self._store = store
+        self._filters = []
+
+    def select(self, *_cols, **_kw):
+        return self
+
+    def eq(self, col, val):
+        self._filters.append((col, val))
+        return self
+
+    def in_(self, col, vals):
+        self._filters.append((col, "in", vals))
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def execute(self):
+        rows = list(self._store.get(self._table, []))
+        for f in self._filters:
+            if len(f) == 2:
+                col, val = f
+                rows = [r for r in rows if r.get(col) == val]
+            else:
+                col, _, vals = f
+                rows = [r for r in rows if r.get(col) in vals]
+        return _FakeResponse(rows)
+
+
+class _FakeSB:
+    def __init__(self, store: dict):
+        self._store = store
+
+    def table(self, name: str):
+        return _FakeQuery(name, self._store)
+
+
+def test_fetch_compiler_candidates_shape():
+    from services.compiler_core_svc import fetch_compiler_candidates
+
+    sb = _FakeSB(
+        {
+            "facility_applicability": [
+                {
+                    "id": "a1",
+                    "factory_id": "fac-1",
+                    "draft_id": "d1",
+                    "applicability_status": "MATCH_CANDIDATE",
+                    "part_id": "p1",
+                }
+            ],
+            "task_candidate": [
+                {"id": "t1", "factory_id": "fac-1", "task_type": "REPORT", "status": "CANDIDATE"}
+            ],
+            "schedule_candidate": [],
+            "penalty_obligation_relation": [],
+            "compliance_review_queue": [],
+            "compliance_package": [],
+        }
+    )
+    out = fetch_compiler_candidates(sb, "fac-1")
+    assert out["factory_id"] == "fac-1"
+    assert len(out["applicability_candidates"]) == 1
+    assert out["compiler_version"] == "v3.0-deterministic"
+    assert out["warning"]

--- a/tests/test_facility_applicability_eval.py
+++ b/tests/test_facility_applicability_eval.py
@@ -1,0 +1,43 @@
+"""Tests for facility_applicability_eval pure logic."""
+
+from services.facility_applicability_eval import (
+    aggregate_applicability_status,
+    compare_numeric,
+    evaluate_draft_for_facility,
+)
+
+
+def test_compare_numeric_gte_match():
+    assert compare_numeric(">=", 50, 60) == "MATCH_CANDIDATE"
+    assert compare_numeric(">=", 50, 49) == "NOT_MATCHED"
+
+
+def test_compare_numeric_missing():
+    assert compare_numeric(">=", None, 10) == "MISSING_DATA"
+    assert compare_numeric(">=", 10, None) == "MISSING_DATA"
+
+
+def test_aggregate_match_only():
+    assert aggregate_applicability_status({"MATCH_CANDIDATE"}) == "MATCH_CANDIDATE"
+
+
+def test_aggregate_conflict():
+    assert aggregate_applicability_status({"MATCH_CANDIDATE", "NOT_MATCHED"}) == "AMBIGUOUS"
+
+
+def test_evaluate_draft_employee_threshold():
+    facility = {"id": "f1", "employee_count": 60}
+    numerics = [
+        {
+            "part_id": "p1",
+            "binding_field": "employee_count",
+            "operator": ">=",
+            "value": 50,
+        }
+    ]
+    out = evaluate_draft_for_facility(facility, "d1", numerics, [])
+    assert out is not None
+    overall, part_id, checks = out
+    assert overall == "MATCH_CANDIDATE"
+    assert part_id == "p1"
+    assert checks[0][6] == "MATCH_CANDIDATE"


### PR DESCRIPTION
# Compiler Core 연결 — Phase 1: 서비스 추출

## 변경 사항

| 파일 | 변경 |
|------|------|
| `services/facility_applicability_eval.py` | 순수 평가 로직 신규 (FIELD_MAP, compare_numeric, overall status) |
| `services/compiler_core_svc.py` | `fetch_compiler_candidates()` 공유 함수 |
| `services/diagnosis_service.py` | 공유 fetch 사용 |
| `routers/compiler_core.py` | 공유 fetch 사용 |
| `services/diagnosis_runtime_step1.py` | factory_id 있을 때 `result_data.compiler_core` 부착 |
| `scripts/run_facility_applicability.py` | 서비스 함수 호출로 슬림화 |

## 테스트
- `test_facility_applicability_eval` — 6건 통과
- `test_compiler_core_svc` — 통과

## Phase 1 범위
- ✅ 평가 로직 서비스 함수로 추출
- ✅ Compiler Core fetch 공유화
- ✅ factory_id 있을 때 compiler_core 결과 부착

## Phase 2 (미구현)
- ⏳ 익명 진단(factory_id=None) → 임시 factory 생성 → Compiler Core 평가
- ⏳ runtime_metadata_resolution 경로 격리

## 관련 문서
- `docs/WORKORDER_CONNECT_COMPILER_CORE.md`
- `docs/LEGAL_ENGINE_AUDIT.md` (F-001~F-020)
- `SESSION_2026_05_11_FULL_PIPELINE.md`