### PR TITLE
feat: 법령진단 입력 표준화 (STEP 1/A/B')

### DIFF
--- a/docs/ENGINE_CONNECTION_AUDIT.md
+++ b/docs/ENGINE_CONNECTION_AUDIT.md
@@ -1,0 +1,474 @@
+# Engine Connection Audit — 9 Engines Consumer Path
+
+**Repo:** `taiengineering/tai-api`  
+**Date:** 2026-06-08  
+**Scope:** Analysis only (no code changes)  
+**DB:** Supabase `vwlahtguyggrhvslabax` (counts verified via MCP)  
+**Work order:** `docs/WORKORDER_ENGINE_CONNECTION_AUDIT.md` (로컬 기준; 레포 미동기화)
+
+---
+
+## Executive Summary
+
+9개 엔진 중 **소비자(익명 진단·Safe 앱·작업자 앱)까지 단일 파이프라인으로 연결된 엔진은 없음**. 대부분 **이중 스택(Legacy + Runtime)** 또는 **엔진 데이터와 소비자 경로의 분리** 상태.
+
+| # | Engine | Judgment | 핵심 이유 |
+|---|--------|----------|-----------|
+| 1 | Check/Inspection | **PARTIAL** | DB 327세트/5,184항목 존재, 익명 진단·작업자 앱은 Runtime 경로; 85% 세트에 일정 미생성 |
+| 2 | Document | **DISCONNECTED** | `documents`=0, 소비자는 `runtime_document_data`; 마스터 63건은 관리자 전용 |
+| 3 | Equipment | **PARTIAL** | 자산 1,285건 CRUD 연결, `equipment_checkins`=0 — 점검 기록 흐름 미가동 |
+| 4 | Schedule | **PARTIAL** | Legacy `work_schedules`(60) vs Runtime `runtime_schedule`(339) 병행, 브릿지 테이블 0건 |
+| 5 | Education | **PARTIAL** | 마스터 20건·설정 API 연결, `education_history`=0 |
+| 6 | Contract | **PARTIAL** | SaaS `contracts`(4) vs 매칭 `matching_contracts`(0) 이원화 |
+| 7 | Notification | **PARTIAL** | SaaS `notifications`(0) vs Runtime 큐(0); 엔진 API는 메트릭/데드레터 위주 |
+| 8 | Runtime | **CONNECTED** | 20,129 work orders, 50,301 evidence — 브릿지 API가 소비자 진입점 |
+| 9 | SaaS | **CONNECTED** | auth/users/companies/factories 정상 CRUD, 128사/342공장 |
+
+**최우선 이슈:** 익명·통합 진단이 Phase 2 Compiler Core로 전환되면서 `evidence.chain` 생성 경로(`leg_candidate_adapter` → `obligation_standard_builder`)가 **소비자 경로에서 완전히 우회**됨.
+
+---
+
+## DB Snapshot (2026-06-08)
+
+| Table | Count | Consumer reads? |
+|-------|------:|-----------------|
+| `inspection_sets` | 327 | SaaS `/inspection-sets` ✅ / 익명진단 ❌ |
+| `inspection_set_items` | 5,184 | `worker_home` 설비점검 ✅ / 익명진단 ❌ / `inspection_bridge` ❌(주석 오류) |
+| `work_schedules` | 60 | `/inspection/checklist` ✅ |
+| `runtime_inspection_bridge` | 324 | `/bridge/inspection/sets` |
+| `runtime_checklist_item` | 802 | `/bridge/inspection/checklists` |
+| `runtime_operational_work_order` | 20,129 | `/bridge/my-inspection` ✅ |
+| `runtime_inspection_session` | 100 | 작업자 점검 수행 ✅ |
+| `documents` | **0** | `/documents` (Legacy) — 빈 테이블 |
+| `document_form_master` | 63 | `/engine/forms` (관리자) |
+| `generated_document` | 28 | `/document-engine/documents/{id}/generated` |
+| `runtime_document_data` | 1 | `/document-engine/documents`, `/bridge/documents` |
+| `runtime_form_schema` | 323 | 문서엔진 스키마 |
+| `equipment_assets` | 1,285 | `/equipment-assets` ✅ |
+| `equipment_checkins` | **0** | `/equipment-checkins` (API 존재, 미사용) |
+| `work_schedules` (inspection_set linked) | 60 | 327세트 중 18%만 연결 |
+| `runtime_schedule` | 339 | `/runtime/schedules` |
+| `runtime_schedule_instance` | **0** | `/bridge/schedules` — 빈 테이블 |
+| `runtime_instance` | 339 | Runtime projection |
+| `education_master` | 20 | `/education` ✅ |
+| `education_history` | **0** | 교육 이수 기록 미가동 |
+| `contracts` | 4 | `/contracts` (SaaS 견적→계약) |
+| `matching_contracts` | **0** | `/matching/contracts` (AI 계약엔진) |
+| `quotes` | 23 | `/contracts` 견적 |
+| `notifications` | **0** | `/notifications` (SaaS 인박스) |
+| `notification_queue` | **0** | — |
+| `runtime_notification_queue` | **0** | `/notification-engine` |
+| `runtime_compliance_evidence` | 50,301 | `/bridge/compliance-evidence` |
+| `runtime_candidate` | 7 | Binding Engine (극소) |
+| `runtime_task` | 339 | Runtime cockpit |
+| `companies` | 128 | SaaS Core |
+| `factories` | 342 | SaaS Core |
+
+---
+
+## Judgment Legend
+
+| Code | Meaning |
+|------|---------|
+| **CONNECTED** | Router → Service → DB → Consumer UI/API end-to-end 동작 |
+| **PARTIAL** | 일부 경로만 연결; 데이터·소비자·엔진 중 하나 이상 단절 |
+| **DISCONNECTED** | DB/엔진 데이터 존재하나 소비자가 읽는 테이블이 다름 |
+| **DEAD** | API 존재하나 DB 0건 또는 write freeze로 실질 미가동 |
+| **ACTIVE_NO_ENGINE** | 소비자 API 활성이나 엔진 테이블 우회 |
+
+---
+
+## Engine 1: Check / Inspection
+
+**Judgment: PARTIAL**
+
+### Router → Service → DB
+
+| Router | Service / Logic | DB Tables |
+|--------|-----------------|-----------|
+| `routers/inspection_sets.py` | `services/inspection_sets_svc/*` | `inspection_sets`, `inspection_set_items`, `master_building_legal_rules`(조인 시도) |
+| `routers/inspection_schedule.py` | 인라인 | `inspection_sets`, `work_schedules` |
+| `routers/inspection_checklist.py` | 인라인 + `LEGAL_INSPECTION_ITEMS` 하드코드 | `work_schedules`, `inspection_set_items`(생성만) |
+| `routers/schedule_engine.py` | 인라인 | `inspection_sets` → `work_schedules` |
+| `routers/inspection_bridge.py` | 인라인 | `runtime_inspection_bridge`, `runtime_checklist_item` |
+| `routers/my_inspection_bridge.py` | 인라인 | `runtime_inspection_session`, `runtime_operational_work_order` |
+| `routers/worker_home.py` | 인라인 | `equipment_assets`, `inspection_sets`, `inspection_set_items` |
+| `services/legal_adapter.py` | `project_rules()` | `inspection_sets` (진단→Binding 시) |
+| `services/runtime_activation_service.py` | `_sync_inspection_set()` | `inspection_sets`, `inspection_set_items` |
+
+Registry: `router_registry/inspection.py` (12 routers)
+
+### 기획 경로 vs 실제 경로
+
+```mermaid
+flowchart LR
+  subgraph planned [기획]
+    D1[Diagnosis] --> BE[Binding Engine]
+    BE --> IS[inspection_sets]
+    IS --> ISI[inspection_set_items]
+    ISI --> WS[work_schedules]
+    WS --> Worker[작업자 앱]
+  end
+
+  subgraph actual_anon [실제 — 익명/통합 진단 Phase 2]
+    D2[POST /anonymous-diagnosis] --> CC[Compiler Core temp factory]
+    CC --> MEM[in-memory obligations]
+    MEM --> TR[diagnosis_transform]
+    TR --> Nexas[Nexas UI]
+  end
+
+  subgraph actual_saas [실제 — SaaS 운영]
+    LE[LEGAL_ENGINE 배치] --> IS2[inspection_sets 326건]
+    IS2 --> ISI2[items 5,184]
+    RT[Runtime 20K WO] --> MI[/bridge/my-inspection]
+  end
+```
+
+| 구간 | 기획 | 실제 |
+|------|------|------|
+| 진단 → 점검세트 | `project_rules` → `inspection_sets` | 익명: **미호출**(temp factory 즉시 삭제). 통합: `factory_id`+`company_id` 있을 때만 non-blocking 호출 |
+| 세트 → 항목 | `generate-items` / activation sync | 324/327 세트에 항목 존재 (LEGAL_ENGINE 생성) |
+| 항목 → 소비자 | 점검 UI에서 items 표시 | **작업자 앱**: Runtime checklist (802건). **설비 QR**: `worker_home`만 items 직접 조회. **익명 진단**: items 미노출 |
+| evidence.chain | `leg_candidate_adapter` → `obligation.evidence.chain` | Compiler 경로: **chain 필드 없음** → Transform `evidence: []` |
+
+### Priority Q1: 327세트 / 5,184항목이 소비자에게 보이는가?
+
+| 소비자 | API | items 노출 | 판정 |
+|--------|-----|-----------|------|
+| 익명 진단 (Nexas) | `/anonymous-diagnosis/{token}/transform` | ❌ obligations만 (compiler task 요약) | **미노출** |
+| Safe 관리자 | `GET /inspection-sets` | ❌ 목록만 (items 별도 API 없음) | **부분** |
+| 점검리스트 | `GET /inspection/schedules` | `work_schedules` 기반 (60건) | **18%만** |
+| 작업자 앱 | `GET /bridge/my-inspection` | Runtime session (100건) | **Runtime 경로** |
+| 설비 QR | `worker_home` equipment endpoint | `inspection_set_items` 직접 조회 | **연결됨** (단, checkins 0) |
+
+- 277/327 세트(85%)에 `work_schedules` 없음 → 점검리스트 UI 미노출
+- `anchor_confirmed`=59건만 기준일 확정
+
+### Priority Q1b: evidence.chain 어디서 끊겼는가?
+
+```
+[기획 — v5.10 / integrity audit 경로]
+legal_v510_svc.run_diagnose_step1_v510
+  → leg_candidate_adapter.to_candidate_contract  ← evidence_chain 생성
+  → obligation_standard_builder.build_obligations ← evidence: { chain: [...] }
+
+[실제 — 소비자 Phase 2]
+anonymous_factory_service.run_anonymous_diagnosis
+  → compiler_core_svc.fetch_compiler_candidates
+  → _compiler_result_to_step1_format   ← evidence_chain 필드 없음
+  → diagnosis_transform._extract_obligations ← evidence: [] (빈 배열)
+
+[Binding Engine — 제한적]
+diagnosis_integrated POST /diagnosis/run
+  → project_rules (factory_id + company_id 필요)
+  → inspection_sets 생성 (세트만, items는 activation 시)
+```
+
+**끊김 지점:**
+1. **F-001 CRITICAL** — Compiler → step1 변환 시 `evidence_chain` 미생성
+2. **F-002 HIGH** — `obligation_standard_builder`가 소비자 라우터 어디에도 호출되지 않음
+3. **F-003 HIGH** — `diagnosis_transform`이 `evidence.chain` 구조를 읽지 않고 flat `evidence: []` 반환
+4. **F-004 MEDIUM** — `leg_candidate_adapter`는 `legal_v510_svc` / 검증 스크립트 전용; 익명·통합 진단 미사용
+
+---
+
+## Engine 2: Document
+
+**Judgment: DISCONNECTED**
+
+### Router → Service → DB
+
+| Router | Service | DB Tables |
+|--------|---------|-----------|
+| `routers/documents.py` | `services/document_svc.py` | `documents` (Legacy 파일 저장) |
+| `routers/document_engine_api.py` | `services/document_engine_svc.py` | `runtime_form_schema`, `runtime_document_data`, `generated_document`, `evidence_vault_link` |
+| `routers/document_engine.py` | `document_engine/fetchers`, `renderer` | `generated_document`, Storage |
+| `routers/engine_document.py` | 인라인 | `document_form_master`, `form_templates` |
+| `routers/runtime_bridge.py` | `document_engine_svc` | `runtime_document_data` (브릿지) |
+| `routers/legacy_freeze.py` | — | Legacy write **410 차단** |
+
+Registry: `router_registry/document_engine.py` (7 routers)
+
+### 기획 vs 실제
+
+| Layer | 기획 | 실제 DB | 소비자가 읽는 테이블 |
+|-------|------|---------|-------------------|
+| 파일 보관 | `documents` | **0건** | ❌ (빈 테이블) |
+| 서식 마스터 | `document_form_master` | 63건 | 관리자 `/engine/forms` only |
+| Runtime 문서 | `runtime_document_data` | 1건 | `/document-engine/documents`, `/bridge/documents` |
+| PDF 생성물 | `generated_document` | 28건 | generate 엔드포인트 후 조회 |
+| 스키마 | `runtime_form_schema` | 323건 | 문서엔진 내부 |
+
+**F-005 HIGH** — `documents`=0인데 Legacy `/documents` 라우터는 여전히 등록. Write는 `legacy_freeze`로 차단, Read는 빈 결과.
+
+**F-006 HIGH** — 소비자 문서 경로는 Runtime(`runtime_document_data`)으로 이전됐으나 실데이터 1건. 63개 마스터 서식·28개 생성 PDF와 **미연결**.
+
+**F-007 MEDIUM** — `document_engine.py` (TBM PDF) fetcher 레지스트리에 `DOC-OSH-056` 1건만 등록 — 대부분 서식 미연결.
+
+---
+
+## Engine 3: Equipment
+
+**Judgment: PARTIAL**
+
+### Router → Service → DB
+
+| Router | DB Tables |
+|--------|-----------|
+| `routers/equipment_assets.py` | `equipment_assets`, `equipment_model_master`, `v_equipment_unified` |
+| `routers/equipment_checkins.py` | `equipment_checkins`, `work_schedules`(완료 처리), `notifications`(NG/HOLD 알림) |
+| `routers/engine_equipment.py` | 엔진 설정용 마스터 |
+| `routers/worker_home.py` | `equipment_assets` → `inspection_sets` → `inspection_set_items` |
+
+Registry: `router_registry/construction.py`
+
+### 기획 vs 실제
+
+```mermaid
+flowchart LR
+  QR[QR 스캔] --> CI[POST /equipment-checkins]
+  CI --> EC[equipment_checkins]
+  EC --> WS[work_schedules DONE]
+  EC --> INS[inspection 기록 연계]
+  WS --> RT[Runtime evidence]
+
+  style EC fill:#f99
+  style INS fill:#f99
+```
+
+| 구간 | 상태 |
+|------|------|
+| 자산 CRUD | ✅ 1,285건, API 연결 |
+| QR 체크인 API | ✅ 구현 완료 |
+| 체크인 DB | ❌ **0건** — 흐름 미가동 |
+| 체크인 → 일정 완료 | 코드 존재 (`schedule_id` + OK 시 `work_schedules` update) |
+| 체크인 → Runtime evidence | ❌ 연결 없음 |
+| 설비 → 점검항목 | ✅ `worker_home` (items 조회) |
+
+**F-008 HIGH** — `equipment_checkins`=0: 점검 기록 파이프라인 **코드만 존재, 운영 데이터 없음**.
+
+**F-009 MEDIUM** — `worker_home` 설비 조회가 `equipment_assets.name` 컬럼 참조하나 실제 스키마는 `asset_name` — 런타임 404 가능성.
+
+---
+
+## Engine 4: Schedule
+
+**Judgment: PARTIAL**
+
+### Router → Service → DB
+
+| Router | Service | DB |
+|--------|---------|-----|
+| `routers/schedule_engine.py` | 인라인 | `inspection_sets` → `work_schedules` |
+| `routers/work_schedules.py` | 인라인 | `work_schedules` |
+| `routers/schedule_pipeline.py` | 인라인 | 파이프라인 orchestration |
+| `routers/overdue_checker.py` | 인라인 | `work_schedules` |
+| `routers/runtime_schedule_api.py` | `runtime_schedule_service` | `runtime_schedule`, `runtime_task` |
+| `routers/runtime_bridge.py` | `persistence_svc` | `runtime_schedule_instance` (**0건**) |
+
+### 기획 vs 실제
+
+| Stack | Table | Count | Consumer |
+|-------|-------|------:|----------|
+| Legacy | `work_schedules` | 60 | `/inspection/checklist`, `equipment_checkins` |
+| Runtime | `runtime_schedule` | 339 | `/runtime/schedules` |
+| Runtime | `runtime_instance` | 339 | projection layer |
+| Bridge | `runtime_schedule_instance` | **0** | `/bridge/schedules` |
+
+**F-010 HIGH** — 이중 스택: Legacy 일정 60건 vs Runtime 339건. 브릿지 테이블 0건으로 `/bridge/schedules`는 항상 빈 배열.
+
+**F-011 MEDIUM** — 277 inspection_sets에 일정 미생성 (`schedule_engine` 수동 트리거 필요).
+
+---
+
+## Engine 5: Education
+
+**Judgment: PARTIAL**
+
+### Router → Service → DB
+
+| Router | DB Tables |
+|--------|-----------|
+| `routers/education.py` | `education_master`, `company_education_setting`, `education_setting`, `education_history` |
+| `routers/education_assign.py` | `education_assignments` (배정) |
+
+Registry: `router_registry/construction.py`
+
+| Table | Count | Status |
+|-------|------:|--------|
+| `education_master` | 20 | ✅ 마스터 연결 |
+| `education_history` | **0** | ❌ 이수 기록 미가동 |
+
+**F-012 MEDIUM** — 설정·마스터 API는 CONNECTED, 이수 이력(`education_history`) DEAD.
+
+---
+
+## Engine 6: Contract
+
+**Judgment: PARTIAL**
+
+### Router → Service → DB
+
+| Router | Service | DB |
+|--------|---------|-----|
+| `routers/contracts.py` | 인라인 | `quotes`, `contracts`, `companies` |
+| `routers/contracts_engine.py` | `contract_engine_svc`, `contract_ai` | `matching_contracts`, `matching_requests`, `matching_results`, Storage |
+| `routers/quotes.py` | 인라인 | `quotes` |
+
+Registry: `router_registry/payment.py`
+
+| Track | Table | Count | Entry |
+|-------|-------|------:|-------|
+| SaaS 견적→계약 | `contracts` | 4 | `/contracts` |
+| AI 매칭 계약 | `matching_contracts` | **0** | `/matching/contracts/generate` |
+
+**F-013 MEDIUM** — 두 계약 트랙이 공존하나 `matching_contracts` 미가동. 소비자(매칭 플랫폼) 경로 DEAD, SaaS 계약 4건만 ACTIVE.
+
+---
+
+## Engine 7: Notification
+
+**Judgment: PARTIAL**
+
+### Router → Service → DB
+
+| Router | DB Tables |
+|--------|-----------|
+| `routers/notifications.py` (SaaS) | `notifications`, `notification_settings` |
+| `routers/notification_engine_api.py` | `runtime_notification_queue`, `runtime_notification_event`, metrics/deadletter |
+| `routers/notification_bridge.py` | Runtime bridge |
+| `routers/notification_inbox_api.py` | 인박스 |
+| `equipment_checkins.py` | `notifications` (NG/HOLD 시 insert) |
+
+| Table | Count |
+|-------|------:|
+| `notifications` | **0** |
+| `notification_queue` | **0** |
+| `runtime_notification_queue` | **0** |
+
+**F-014 MEDIUM** — SaaS 인박스·Runtime 큐 모두 0건. API·크론(`trigger-due-alerts`)은 존재하나 발송 이력 없음.
+
+**F-015 LOW** — `notification_engine_api`는 운영 메트릭/데드레터 조회 위주; 소비자 인박스는 `notifications.py` / `notification_inbox_api`.
+
+---
+
+## Engine 8: Runtime
+
+**Judgment: CONNECTED**
+
+### Router → Service → DB
+
+Registry: `router_registry/runtime_bridge.py` (24 routers)
+
+| Router | DB | Count |
+|--------|-----|------:|
+| `my_inspection_bridge` | `runtime_inspection_session`, `runtime_operational_work_order` | 100 / 20,129 |
+| `evidence_bridge` | `runtime_compliance_evidence` | 50,301 |
+| `runtime_cockpit_api` | `runtime_cockpit_service` → tasks/docs/evidence | — |
+| `runtime_candidate_api` | Binding → Activation | `runtime_candidate` 7 |
+| `runtime_bridge` | bridge to evaluator/persistence | — |
+| `obligation_bridge` | obligation projection | — |
+
+Runtime이 **실질 운영 데이터의 허브**. 작업자 점검·증빙·일정 projection이 여기 집중.
+
+**F-016 MEDIUM** — `runtime_candidate`=7건으로 Binding Engine 투입 극소. 대부분 데이터가 Legacy/배치(`LEGAL_ENGINE`) 또는 직접 Runtime 생성 경로.
+
+**F-017 LOW** — `inspection_bridge.py` 주석 "inspection_set_items=0"은 **DB 사실(5,184건)과 불일치** — stale documentation in code.
+
+---
+
+## Engine 9: SaaS Core
+
+**Judgment: CONNECTED**
+
+### Router → DB
+
+Registry: `router_registry/saas_core.py`
+
+| Router | DB Tables | Count |
+|--------|-----------|------:|
+| `auth.py` | `users`, `otp_store` | users ~20 |
+| `companies.py` | `companies` | 128 |
+| `factories.py` | `factories`, `buildings` | 342 |
+| `users.py` | `users` | — |
+| `onboarding.py` | onboarding flow + `inspection_set_items` count | — |
+| `notifications.py` | (see Engine 7) | 0 |
+| `system_codes.py` | `system_codes` | — |
+
+SaaS Core는 인증·테넌트·시설 CRUD가 정상 연결. 엔진 데이터와는 별도 레이어.
+
+---
+
+## Cross-Cutting: Consumer Diagnosis Path (Phase 2)
+
+현재 익명·통합 진단 step1 공통 경로:
+
+```
+POST /anonymous-diagnosis | POST /diagnosis/run
+  → diagnosis_integrated_svc.run_step1_via_compiler
+  → anonymous_factory_service.run_anonymous_diagnosis
+      1. create_temp_factory (factories INSERT)
+      2. evaluate_single_factory (facility_applicability INSERT)
+      3. fetch_compiler_candidates
+      4. _compiler_result_to_step1_format
+      5. cleanup_temp_factory (DELETE factories + applicability)
+```
+
+**영향:**
+- 진단 결과는 **DB에 영구 저장되지 않음** (anonymous_diagnosis는 `diagnosis_auth_log.result_data` JSONB에만 저장)
+- `inspection_sets` / `project_rules` / `evidence.chain` **우회**
+- `factory_id` 있는 통합 진단만 Binding Engine non-blocking 호출
+
+**F-018 CRITICAL** — Compiler Phase 2가 소비자 진단의 단일 경로가 되면서, 기획된 Legal→Inspection→Evidence 파이프라인과 **구조적 분리** 발생.
+
+---
+
+## Findings Index
+
+| ID | Severity | Engine | Finding |
+|----|----------|--------|---------|
+| F-001 | **CRITICAL** | Inspection | Compiler `_compiler_result_to_step1_format`이 `evidence_chain` 미생성 → 소비자 evidence.chain 항상 빈 값 |
+| F-002 | **HIGH** | Inspection | `obligation_standard_builder`가 프로덕션 소비자 라우터에서 미호출 |
+| F-003 | **HIGH** | Inspection | `diagnosis_transform._extract_obligations`가 `evidence.chain` 구조 미지원, `evidence: []` 고정 |
+| F-004 | **MEDIUM** | Inspection | `leg_candidate_adapter`는 v5.10/검증 전용; 익명·통합 진단 미연결 |
+| F-005 | **HIGH** | Document | `documents` 테이블 0건 + Legacy read API 잔존 |
+| F-006 | **HIGH** | Document | 63 마스터 서식·28 generated_document가 Runtime 소비자 경로(1건)와 단절 |
+| F-007 | **MEDIUM** | Document | `document_engine.py` fetcher 1종만 등록 |
+| F-008 | **HIGH** | Equipment | `equipment_checkins`=0, QR 점검 파이프라인 미가동 |
+| F-009 | **MEDIUM** | Equipment | `worker_home` 컬럼명 불일치 가능 (`name` vs `asset_name`) |
+| F-010 | **HIGH** | Schedule | Legacy(60) / Runtime(339) / Bridge(0) 삼중 스택, 브릿지 dead |
+| F-011 | **MEDIUM** | Schedule | 277/327 inspection_sets에 work_schedules 없음 |
+| F-012 | **MEDIUM** | Education | `education_history`=0, 이수 기록 DEAD |
+| F-013 | **MEDIUM** | Contract | `matching_contracts`=0, AI 계약 엔진 미가동 |
+| F-014 | **MEDIUM** | Notification | SaaS·Runtime 알림 큐 모두 0건 |
+| F-015 | **LOW** | Notification | 엔진 API vs 인박스 API 역할 분산 |
+| F-016 | **MEDIUM** | Runtime | `runtime_candidate`=7, Binding 투입 극소 |
+| F-017 | **LOW** | Runtime | `inspection_bridge` stale 주석 (items=0 ≠ 실제 5,184) |
+| F-018 | **CRITICAL** | Cross | Phase 2 Compiler 소비자 경로가 Legal→Inspection→Evidence 엔진 체인 우회 |
+| F-019 | **HIGH** | Inspection | 5,184 items가 익명 진단·작업자 Runtime 경로에 미노출; SaaS·설비QR만 부분 노출 |
+| F-020 | **MEDIUM** | Inspection | `inspection_sets_svc`가 `master_building_legal_rules` 조인 — 테이블 부재 시 enrichment 실패 (LEGAL_ENGINE_AUDIT F-003 연계) |
+
+---
+
+## Recommended Investigation Order (참고 — 수정 아님)
+
+1. **evidence.chain 복구 설계** — Compiler output에 `rule_id`/`source_bucket` 전파 → Transform 호환
+2. **inspection_sets → work_schedules 일괄 생성** — 277 orphan sets
+3. **Document 테이블 단일화** — `runtime_document_data` ← `document_form_master` 시드 연결
+4. **equipment_checkins 파일럿** — 1개 factory에서 E2E 검증
+5. **Schedule 브릿지** — `runtime_schedule_instance` backfill 또는 bridge 라우터를 `runtime_schedule`로 교체 검토
+6. **inspection_bridge 주석/로직** — 5,184 items 인지하도록 정합성 수정 (별도 work order)
+
+---
+
+## Audit Method
+
+- Router registry 9그룹 (`inspection`, `document_engine`, `construction`, `payment`, `runtime_bridge`, `saas_core`) 파일 추적
+- `grep '.table('` 로 DB 접근 테이블 확인
+- Supabase MCP `execute_sql` 로 건수 검증
+- 소비자 경로: `anonymous_diagnosis`, `diagnosis_integrated`, `diagnosis_transform`, bridge routers
+- 코드 수정 없음
+
+---
+
+*End of audit.*

--- a/docs/ENGINE_PIPELINE_MAP.md
+++ b/docs/ENGINE_PIPELINE_MAP.md
@@ -1,0 +1,416 @@
+# Engine Pipeline Map — 소비자 여정 & 엔진 연결 지도
+
+**Repo:** `taiengineering/tai-api`  
+**Date:** 2026-06-08  
+**Work order:** `docs/WORKORDER_ENGINE_PIPELINE_MAP.md` (레포 미동기화 — 본 문서는 코드 추적 기준)  
+**방법:** Router → Service → DB read/write → 다음 단계. **건수·DB 통계로 판단하지 않음.**
+
+---
+
+## 0. 전체 지도 (요약)
+
+현재 코드베이스에는 **소비자 진단·SaaS 운영·Runtime 점검**이 **3개의 평행 트랙**으로 존재한다.
+
+```mermaid
+flowchart TB
+  subgraph T1 [트랙 A — 소비자 진단 Compiler Temp]
+    AD[POST /anonymous-diagnosis]
+    DR[POST /diagnosis/run]
+    AFS[anonymous_factory_service]
+    CC[compiler_core_svc.fetch_compiler_candidates]
+    AD --> AFS
+    DR --> AFS
+    AFS --> CC
+    AFS -->|cleanup| DEL[DELETE factories + facility_applicability]
+  end
+
+  subgraph T2 [트랙 B — 기획 Compiler Session / SaaS Setup]
+    DE[POST /api/v1/diagnosis-engine/evaluate]
+    DS[DiagnosisService.evaluate]
+    SS[POST /api/v1/saas-setup/extract]
+    DE --> DS --> DSDB[(diagnosis_session / diagnosis_candidate)]
+    SS --> SSSDB[(saas_setup_candidate)]
+  end
+
+  subgraph T3 [트랙 C — SaaS 운영 Legacy + Runtime]
+    IS[inspection_sets / work_schedules]
+    MI[/bridge/my-inspection]
+    EC[equipment_checkins]
+    IS --> MI
+    EC -.->|미연결| MI
+  end
+
+  T1 -.->|factory_id+company_id 시 project_rules| T3
+  T1 -.->|auto_create 없음| IS
+  T2 -.->|register 로그만| T3
+```
+
+| 트랙 | 소비자 | 진단 엔진 진입 | 점검·일정·문서 후속 |
+|------|--------|----------------|-------------------|
+| **A** | Nexas 무료/유료 진단 | `run_anonymous_diagnosis` | Binding·세트·항목 **대부분 미연결** |
+| **B** | Admin/내부 SaaS 온보딩 설계 | `DiagnosisService` + `saas_setup` | 승인 후 `saas_registration_log` (Runtime 실등록 코드 없음) |
+| **C** | Safe 앱·작업자 앱 | `legal_engine/apply`, 건설 `auto_diagnose` 등 | `inspection_sets`, `work_schedules`, Runtime bridge |
+
+---
+
+## A. 소비자 여정 4종 — 단계별 추적
+
+### A-1. 무료 진단: `POST /anonymous-diagnosis` → 결과 조회 → 플랜 추천
+
+**Registry:** `router_registry/public.py` → `routers.anonymous_diagnosis`
+
+| Step | Endpoint / 함수 | Router | Service | DB Read | DB Write | 다음 단계 |
+|------|-----------------|--------|---------|---------|----------|-----------|
+| 1 | `POST /anonymous-diagnosis` | `anonymous_diagnosis.create_anonymous_diagnosis` | `_build_step1_body` → `_run_step1_via_service` | — | — | step1 실행 |
+| 2 | Compiler step1 | ↑ | `anonymous_factory_service.run_anonymous_diagnosis` | `draft_slot`, `factories`, `facility_applicability`, `task_candidate`, `schedule_candidate`, … | `factories` INSERT, `facility_applicability` INSERT | format |
+| 2b | | ↑ | `compiler_core_svc.fetch_compiler_candidates` | `facility_applicability`, `task_candidate`, `schedule_candidate`, `penalty_obligation_relation`, `compliance_review_queue` | — | — |
+| 2c | | ↑ | `_compiler_result_to_step1_format` | — (메모리) | — | **leg_candidate_adapter 미호출** |
+| 2d | | ↑ | `cleanup_temp_factory` | — | `facility_applicability` DELETE, `factories` DELETE | temp 제거 |
+| 3 | Trace | ↑ | `watch_engine.create_trace` / `emit_event` | — | (trace bus) | — |
+| 4 | 결과 저장 | ↑ | 인라인 | — | `anonymous_diagnosis_results` INSERT (`partial_result`, `full_result` JSONB) | 조회 가능 |
+| 5 | Document hook (non-blocking) | ↑ | `watch_engine.document.activate_documents_for_workflow` | `document_form_master` | `generated_document` INSERT (조건부) | **소비자 문서함(`runtime_document_data`)과 무관** |
+| 6 | `GET /anonymous-diagnosis/{token}` | `get_anonymous_diagnosis` | `_fetch_row` | `anonymous_diagnosis_results` SELECT | — | partial/full |
+| 7 | `GET /anonymous-diagnosis/{token}/transform` | `transform_anonymous_diagnosis` | `diagnosis_transform._extract_*` | `anonymous_diagnosis_results` (full_result JSONB만) | — | UI 표준 스키마 |
+| 8 | `GET /anonymous-diagnosis/{token}/recommend-plan` | `recommend_plan_by_token` | `diagnosis_plan_recommend._recommend_*` | `anonymous_diagnosis_results` | — | 플랜 코드 (DB 없음) |
+
+**끊긴 연결 (코드상 호출 없음):**
+- `inspection_set_auto.auto_create_inspection_sets_from_diagnosis` ❌
+- `legal_adapter.project_rules` ❌ (factory_id 없음 + temp factory 삭제)
+- `saas_setup.extract` ❌ (`diagnosis_session` 미생성)
+- `to_candidate_contract` / `build_obligations` ❌
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant AD as anonymous_diagnosis
+  participant AFS as anonymous_factory_service
+  participant CC as compiler_core_svc
+  participant DB as Supabase
+  participant TR as diagnosis_transform
+  participant PR as plan_recommend
+
+  U->>AD: POST /anonymous-diagnosis
+  AD->>AFS: run_anonymous_diagnosis
+  AFS->>DB: INSERT factories (temp)
+  AFS->>DB: INSERT facility_applicability
+  AFS->>CC: fetch_compiler_candidates
+  CC->>DB: SELECT task_candidate ...
+  AFS->>AFS: _compiler_result_to_step1_format
+  AFS->>DB: DELETE temp factory
+  AD->>DB: INSERT anonymous_diagnosis_results
+  U->>AD: GET /{token}/transform
+  AD->>TR: _extract_obligations(full_result)
+  U->>AD: GET /{token}/recommend-plan
+  AD->>PR: _recommend_* (in-memory)
+```
+
+---
+
+### A-2. 유료 진단: `POST /diagnosis/run` → 점검 항목 생성 → 일정
+
+**Registry:** `router_registry/diagnosis.py` → `routers.diagnosis_integrated`
+
+| Step | Endpoint | Router | Service | DB Read | DB Write | 다음 단계 |
+|------|----------|--------|---------|---------|----------|-----------|
+| 0a | `POST /diagnosis/auth/prepare` | `diagnosis_integrated` | — | — | — | 이니시스 |
+| 0b | `POST /diagnosis/disclaimer` | ↑ | `diagnosis_integrated_svc.save_disclaimer` | `diagnosis_auth_log` | `diagnosis_disclaimer_log` INSERT | — |
+| 1 | `POST /diagnosis/run` | `run_diagnosis` | `diagnosis_integrated_svc.run_diagnosis` | `diagnosis_auth_log`, `diagnosis_disclaimer_log` | — | step1 |
+| 2 | Step1 (Phase 2) | ↑ | `run_step1_via_compiler` → `run_anonymous_diagnosis` | (A-1과 동일) | temp factory RW 후 DELETE | full_result |
+| 3 | 결과 저장 | ↑ | `run_diagnosis` | — | `anonymous_diagnosis_results` INSERT, `diagnosis_auth_log` UPDATE, `diagnosis_purchases` INSERT(유료) | token 반환 |
+| 4 | Binding (조건부) | `run_diagnosis` (router) | `legal_adapter.project_rules` | `inspection_sets` (중복체크) | `runtime_candidate`*, `inspection_sets` INSERT†, `runtime_candidate_*_req` | activation 없음 |
+| 4b | rules 변환 | ↑ | `convert_rules_table_to_matched_rules` | — | — | — |
+
+\* `runtime_binding_engine.project_candidate`  
+† `_create_inspection_set` — `law_name` 있을 때만, **items 없음**
+
+**점검 항목 생성 — 기획 vs 코드:**
+
+| 기획상 기대 | 실제 코드 경로 | 연결 |
+|-------------|----------------|------|
+| 진단 완료 → `auto_create_inspection_sets_from_diagnosis` | `inspection_set_auto.py` | ❌ `diagnosis_integrated`에서 **미호출** (dead: `legal_engine_svc.run_diagnose_step1_endpoint`만 호출) |
+| 진단 → `generate_items_for_set` | `inspection_sets.py` → `inspection_sets_svc.generate_items_for_set` | ❌ 진단 후 자동 호출 없음 (수동 API) |
+| Binding → `runtime_activation_service.activate_candidate` | `runtime_candidate_api` | ❌ `project_rules`는 **project만**, activate 없음 |
+| Binding → `inspection_set_items` | `runtime_activation_service._sync_inspection_set` | ❌ activate 경로 미진입 |
+
+**일정 생성 — 기획 vs 코드:**
+
+| 경로 | 코드 | 진단 후 자동? |
+|------|------|---------------|
+| `work_schedules` | `schedule_engine.generate_schedule`, `inspection_checklist` rolling | ❌ `/diagnosis/run`에서 미호출 |
+| `runtime_candidate_schedule` | `project_candidate` (schedule_suggestion 있을 때) | ❌ `legal_adapter`가 `schedule_suggestion` **미전달** |
+| 건설 현장 | `construction_svc.auto_diagnose_and_schedule` | ⚠️ `/diagnosis/run`과 **별도** (construction 등록 시) |
+
+```mermaid
+flowchart LR
+  DR[POST /diagnosis/run] --> COMP[run_anonymous_diagnosis]
+  COMP --> SAVE[anonymous_diagnosis_results]
+  DR -->|factory_id AND company_id| PR[project_rules]
+  PR --> RC[runtime_candidate INSERT]
+  PR --> IS[inspection_sets INSERT]
+  PR -.->|없음| ITEMS[inspection_set_items]
+  PR -.->|없음| WS[work_schedules]
+  PR -.->|없음| ACT[activate_candidate]
+```
+
+---
+
+### A-3. SaaS 사용: 대시보드 → 점검 → 설비 → 교육 → 문서
+
+SaaS UI는 **단일 대시보드 API가 아니라** 기능별 라우터 조합이다.
+
+#### 대시보드 / 온보딩
+
+| 화면 | Endpoint | Router | DB Read | DB Write |
+|------|----------|--------|---------|----------|
+| 온보딩 체크리스트 | `GET /onboarding/status` | `onboarding.py` | `factories`, `factory_process`, `equipment_assets`, `inspection_sets`, `inspection_set_items` | — |
+| 상황 대시보드 | `GET /situation/dashboard/overview` | `situation_dashboard_api.py` | `operational_situation_snapshot` | — |
+| 위험성평가 대시 | `GET /risk-assessments/dashboard` | `risk_assessments.py` | `risk_assessments` 등 | — |
+
+온보딩은 **진단 파이프라인과 import 없음** — 등록 여부만 COUNT.
+
+#### 점검 (관리자 / Legacy 스택)
+
+| 동작 | Endpoint | Service/Logic | DB Read | DB Write |
+|------|----------|---------------|---------|----------|
+| 점검세트 목록 | `GET /inspection-sets` | `inspection_sets_svc.get_sets_list` | `inspection_sets`, `master_building_legal_rules`(조인 시도) | — |
+| 항목 생성 | `POST /inspection-sets/{id}/generate-items` | `inspection_sets_svc.generate_items_for_set` | `inspection_sets` | `inspection_set_items` INSERT |
+| 일정 목록 | `GET /inspection/schedules/{factory_id}` | `inspection_checklist.list_schedules` | `work_schedules` + `inspection_sets` JOIN | — |
+| 일정 생성 | `POST /schedule-engine/generate/{inspection_set_id}` | `schedule_engine.generate_schedule` | `inspection_sets` | `work_schedules` INSERT |
+| 점검 시작 | `POST /inspection/start/{work_schedule_id}` | `inspection_checklist` | `work_schedules` | `work_schedules` UPDATE, `safety_inspections` INSERT |
+| 결과 기록 | `POST /inspection/result/{id}/items` | ↑ | `safety_inspections` | `safety_inspection_results` INSERT |
+
+**법령엔진 → 점검세트 (SaaS 측 유일 자동 경로):**
+
+| Trigger | Code | Connection |
+|---------|------|------------|
+| `POST /legal-engine/apply/{factory_id}` | `legal_engine_svc` → (runtime apply) | 배치 적용 |
+| `POST /legal-engine/create-inspection-sets/{factory_id}` | `run_create_inspection_sets_from_legal` | 수동 |
+| 건설 현장 등록 | `construction_svc.auto_diagnose_and_schedule` → `auto_create_inspection_sets_from_diagnosis` | ✅ 코드 있음 |
+| `run_diagnose_step1_endpoint` (dead) | `auto_create_inspection_sets_from_diagnosis` | 라우터 미연결 |
+
+#### 점검 (작업자 / Runtime 스택)
+
+| 동작 | Endpoint | DB |
+|------|----------|-----|
+| 오늘 할일 | `GET /worker/today` | `work_assignments`, `inspection_sets`, TBM, `education_*` |
+| 내 점검 | `GET /bridge/my-inspection` | `runtime_inspection_session`, `runtime_operational_work_order` |
+| 세션 시작 | `POST /bridge/inspection-sessions` | `runtime_inspection_session` INSERT |
+
+**Legacy `inspection_set_items` ↔ Runtime `runtime_checklist_item`:** `inspection_bridge.py`가 매핑 조회. **진단→Runtime 자동 sync 코드 없음.**
+
+#### 설비
+
+| 동작 | Endpoint | DB Read | DB Write |
+|------|----------|---------|----------|
+| 자산 CRUD | `/equipment-assets` | `equipment_assets` | `equipment_assets` |
+| QR → 점검세트 조회 | `GET /worker/qr-check/{equipment_id}` | `equipment_assets`, `inspection_sets`, `inspection_set_items` | — |
+| QR 체크인 제출 | `POST /equipment-checkins` | `equipment_assets`, `factories` | `equipment_checkins` INSERT; optional `work_schedules` UPDATE |
+
+`equipment_checkins` → Runtime / `safety_inspection_results` **import·호출 없음**.
+
+#### 교육
+
+| 동작 | Endpoint | DB |
+|------|----------|-----|
+| 마스터·설정 | `GET/POST /education/*` | `education_master`, `company_education_setting`, `education_setting` |
+| 이수 기록 | `POST /education/history` 등 | `education_history` |
+
+진단·Compiler와 **연결 코드 없음**.
+
+#### 문서
+
+| 역할 | Endpoint | 테이블 |
+|------|----------|--------|
+| 관리자 서식 | `GET /engine/forms` | `document_form_master`, `form_templates` |
+| 소비자 Runtime 문서 | `GET/POST /document-engine/documents` | `runtime_document_data`, `runtime_form_schema` |
+| Legacy 파일 | `GET/POST /documents` | `documents` (write frozen → 410) |
+| 브릿지 | `GET /bridge/documents` | `document_engine_svc` → `runtime_document_data` |
+| PDF/TBM | `GET /document-forms/{id}/preview` | `generated_document`, `document_form_master` (watch_engine) |
+
+**3계층 분리:** `document_form_master` (정의) → `runtime_form_schema` (Runtime 스키마) → `runtime_document_data` (인스턴스). **자동 매핑 import 없음.**
+
+---
+
+### A-4. 점검 실행: QR → 체크리스트 → 완료 → 증적
+
+코드상 **두 개의 실행 파이프라인**이 병존한다.
+
+#### 파이프라인 4a — Legacy (`work_schedules` 중심)
+
+```mermaid
+flowchart LR
+  QR[GET /worker/qr-check] --> ITEMS[inspection_set_items READ]
+  QR -.->|체크인 미사용| EC[POST /equipment-checkins]
+  WA[work_assignments / worker/today] --> WS[work_schedules]
+  WS --> START[POST /inspection/start]
+  START --> SI[safety_inspections]
+  SI --> RES[POST /inspection/result/items]
+  RES --> SIR[safety_inspection_results]
+  RES --> WS2[work_schedules completed]
+```
+
+| Step | Router | DB Write | → 증적 |
+|------|--------|----------|--------|
+| QR 조회 | `worker_home` | — | items 표시만 |
+| 체크인 | `equipment_checkins` | `equipment_checkins` | `photo_urls` JSON 필드만; **evidence 테이블 없음** |
+| 체크리스트 수행 | `inspection_checklist` | `safety_inspection_results` | `photo_url` 컬럼 |
+| 완료 | `inspection_checklist.complete` | `work_schedules` + 다음 회차 INSERT | — |
+
+**`runtime_compliance_evidence` / `evidence_bridge` 호출 없음.**
+
+#### 파이프라인 4b — Runtime (`my_inspection_bridge`)
+
+```mermaid
+flowchart LR
+  WO[runtime_operational_work_order] --> SES[POST /bridge/inspection-sessions]
+  SES --> RIS[runtime_inspection_session]
+  RIS --> CL[POST /bridge/inspection-checklist]
+  CL --> RCE[runtime_checklist_execution]
+  RIS --> EV[POST /bridge/inspection-evidence]
+  EV --> RIE[runtime_inspection_evidence]
+  RIS --> SUB[POST /bridge/inspection-submit]
+  SUB --> RISUB[runtime_inspection_submission]
+```
+
+| Step | Router | DB | 다음 |
+|------|--------|-----|------|
+| 세션 시작 | `my_inspection_bridge` | `runtime_inspection_session` INSERT, `runtime_operational_work_order` UPDATE | checklist |
+| 항목 수행 | ↑ | `runtime_checklist_execution` INSERT | evidence |
+| 증빙 업로드 | ↑ | `runtime_inspection_evidence` INSERT | submit |
+| 제출 | ↑ | `runtime_inspection_submission` INSERT, session → SUBMITTED | review queue (코드 주석) |
+
+**끊김:**
+- `runtime_inspection_evidence` → `runtime_compliance_evidence` (**`evidence_bridge` 미호출**)
+- `equipment_checkins` → Runtime session (**경로 없음**)
+- `inspection_set_items` → `runtime_checklist_execution` (**자동 sync 없음**)
+- Submit 후 `evidence_binding_engine` / compliance promotion **import 없음**
+
+#### 파이프라인 4c — Compliance Evidence (독립)
+
+`evidence_bridge.py`: `POST /bridge/upload-evidence` → `runtime_compliance_evidence`  
+**점검 완료·체크인·Legacy 결과 기록 어디에서도 호출되지 않음** (grep 기준 호출처 = 라우터 자체 + verification 스크립트).
+
+---
+
+## B. 엔진 간 연결 매트릭스
+
+화살표: `소스 → 타겟`. **import/호출**과 **소비자 경로에서 실제 실행**을 분리 표기.
+
+| From → To | 호출 코드 존재 | 소비자 경로 실행 | 경로 요약 |
+|-----------|:-------------:|:----------------:|-----------|
+| **진단(Compiler temp)** → **점검세트** | ❌ | ❌ | `auto_create` / `generate_items` 미연결 |
+| **진단(Compiler temp)** → **점검항목** | ❌ | ❌ | — |
+| **진단(/diagnosis/run)** → **Binding** | ✅ `diagnosis_integrated` → `project_rules` | ⚠️ `factory_id`+`company_id` 있을 때만 | `runtime_candidate` + `inspection_sets` |
+| **Binding** → **Activation** | ✅ `runtime_candidate_api` → `activate_candidate` | ❌ 진단 후 자동 없음 | 수동 API |
+| **Activation** → **inspection_set_items** | ✅ `runtime_activation_service._sync_inspection_set` | ❌ activate 미진입 | — |
+| **진단** → **일정(work_schedules)** | ✅ `schedule_engine`, `construction_svc` | ❌ `/diagnosis/run` 후 없음 | 건설 등록·수동 API만 |
+| **진단** → **일정(runtime_schedule)** | ✅ `runtime_schedule_service` | ❌ 진단 후 자동 없음 | — |
+| **진단** → **문서(runtime_document_data)** | ❌ | ❌ | — |
+| **진단** → **문서(generated_document)** | ✅ `watch_engine.document` hook | ✅ 무료 진단 POST (non-blocking) | `document_form_master` 기반 |
+| **진단-engine** → **saas-setup** | ✅ `saas_setup_service.extract` | ❌ Nexas 진단이 session 생성 안 함 | 별도 `POST /diagnosis-engine/evaluate` 필요 |
+| **saas-setup register** → **Runtime** | ⚠️ `register_to_runtime` | ⚠️ `saas_registration_log` INSERT만 | 주석: "실제 Runtime 등록은 기존 시스템" |
+| **legal-engine/apply** → **inspection_sets** | ✅ `run_create_inspection_sets_from_legal` | ✅ SaaS 수동/배치 | `/legal-engine/create-inspection-sets` |
+| **설비(QR)** → **점검항목** | ✅ `worker_home` GET | ✅ 조회만 | write 없음 |
+| **설비(checkin)** → **점검기록** | ✅ `equipment_checkins` POST | ⚠️ API만 존재 | downstream 없음 |
+| **설비** → **증적(compliance)** | ❌ | ❌ | — |
+| **점검(Runtime submit)** → **증적(compliance)** | ❌ | ❌ | `runtime_inspection_evidence`에만 머무름 |
+| **점검(Legacy result)** → **증적(compliance)** | ❌ | ❌ | `safety_inspection_results.photo_url` |
+| **Compiler API** → **소비자 진단** | ✅ 공유 `fetch_compiler_candidates` | ✅ | `/api/v1/compiler`와 anonymous **동일 svc**, 다른 orchestration |
+
+---
+
+## C. 기획서 vs 실제 코드 — `SESSION_2026_05_11_FULL_PIPELINE.md` 대조
+
+기획 문서: 레포 루트 `SESSION_2026_05_11_FULL_PIPELINE.md` (v5.40, 2026-05-11)
+
+### C-1. 일치 구간
+
+| 기획 | 코드 | 일치 |
+|------|------|------|
+| Compiler Core 14단계 배치 파이프라인 | `scripts/run_*`, `constraint_*`, `task_candidate` … 테이블 | ✅ 배치·테이블 존재 |
+| `POST /api/v1/compiler/evaluate-facility` | `routers/compiler_core.py` → `fetch_compiler_candidates` | ✅ |
+| `POST /api/v1/diagnosis-engine/evaluate` | `routers/diagnosis_engine.py` → `DiagnosisService.evaluate` | ✅ |
+| 진단은 Candidate만, 반복설정 확정 안 함 | `diagnosis_service.py` docstring·구현 | ✅ |
+| `POST /api/v1/saas-setup/extract\|approve\|register` | `routers/saas_setup.py` → `SaaSSetupService` | ✅ |
+| Legacy Runtime Layer 55+ 라우터 유지 | `router_registry/*` | ✅ |
+| Candidate→Truth 승격 금지 철학 | Binding `project_candidate` status=`projected` | ✅ (설계 의도) |
+
+### C-2. 갈라진 지점 (Fork)
+
+| # | 기획서 서술 | 실제 소비자 코드 | 갈라짐 |
+|---|-------------|------------------|--------|
+| **F-01** | §4-2: 소비자 진단 → `POST /diagnosis-engine/evaluate` | Nexas: `POST /anonymous-diagnosis`, `POST /diagnosis/run` → **`run_anonymous_diagnosis`** | **진단 진입 API 불일치**. `diagnosis_session` 미생성 |
+| **F-02** | §4-2: 진단 후 `saas-setup/extract` | anonymous/integrated는 `anonymous_diagnosis_results`만 저장 | **extract 체인 단절** |
+| **F-03** | §4-2: `register` → Runtime 등록 | `register_to_runtime` = `saas_registration_log` INSERT | **Runtime 실등록 코드 없음** |
+| **F-04** | Compiler → Applicability/Task 평가 | Consumer: on-demand temp `facility_applicability` + global `task_candidate` READ | **평가 방식 분기** (배치 vs temp) |
+| **F-05** | Phase 2 merge 후 통합 진단 | `diagnosis_integrated` → `run_step1_via_compiler` (2026-06) | 기획서 **미반영** (v5.10 `legal_v510_svc` 경로와 별도) |
+| **F-06** | v5.10 `to_candidate_contract` + evidence | Compiler `_compiler_result_to_step1_format` | **Adapter/Builder 우회** |
+| **F-07** | 진단 → 점검세트 자동생성 (BE-1) | `auto_create` = dead endpoint + construction만 | **Nexas 진단 미연결** |
+| **F-08** | Runtime이 Compiler consume | Comment in `compiler_core.py`; 실제 Legacy는 `inspection_schedule`·`legal_engine` 혼용 | **부분 소비** |
+| **F-09** | 단일 증적 계층 | `runtime_inspection_evidence` ≠ `runtime_compliance_evidence` | **증적 이중 스택, 미연결** |
+| **F-10** | 문서 엔진 통합 | `document_form_master` / `runtime_document_data` / `generated_document` 3갈래 | **소비자 read 경로 분리** |
+
+### C-3. 기획 다이어그램 vs 2026-06 소비자 실경로
+
+**기획 (SESSION §4-2):**
+```
+입력 → diagnosis-engine/evaluate → Compiler → diagnosis_session
+     → saas-setup/extract → approve → register → Runtime
+```
+
+**실제 Nexas 무료:**
+```
+입력 → anonymous-diagnosis → anonymous_factory_service (temp) → anonymous_diagnosis_results
+     → transform / recommend-plan → (끝)
+```
+
+**실제 Nexas 유료:**
+```
+인증 → disclaimer → diagnosis/run → anonymous_factory_service (temp)
+     → anonymous_diagnosis_results
+     → [optional] project_rules → runtime_candidate + inspection_sets
+     → (점검항목·일정·saas-setup 없음)
+```
+
+**실제 SaaS 운영 (가입 후):**
+```
+onboarding/status ← 등록 데이터 COUNT
+legal-engine/apply OR 수동 inspection-sets API
+inspection_checklist ↔ work_schedules (Legacy)
+OR bridge/my-inspection (Runtime)
+```
+
+---
+
+## D. 핵심 단절점 (코드 근거만)
+
+1. **진단 3종 API** — `anonymous-diagnosis`, `diagnosis/run`, `diagnosis-engine/evaluate`가 **서로 다른 orchestration·저장 테이블**을 사용한다.
+2. **Phase 2 Compiler temp** — 진단 결과가 **영구 factory·session에 남지 않아** 기획된 SaaS setup·auto_create·일정 생성과 **구조적으로 맞물리지 않는다**.
+3. **Binding without Activation** — `project_rules`는 candidate·inspection_set **투영**만; `activate_candidate`·`generate_items`·`schedule_engine`은 **다음 단계 코드 없음**.
+4. **점검 실행 이중화** — Legacy(`safety_inspection_*`)와 Runtime(`runtime_inspection_*`)이 **병렬**; QR·체크인은 **셋째 경로**로 고립.
+5. **증적 3종** — `safety_inspection_results.photo_url`, `runtime_inspection_evidence`, `runtime_compliance_evidence` — **상호 promotion/import 없음**.
+
+---
+
+## E. 파일 인덱스 (추적에 사용한 주요 경로)
+
+| 영역 | 파일 |
+|------|------|
+| 무료 진단 | `routers/anonymous_diagnosis.py` |
+| 유료 진단 | `routers/diagnosis_integrated.py`, `services/diagnosis_integrated_svc.py` |
+| Compiler 소비자 | `services/anonymous_factory_service.py`, `services/compiler_core_svc.py` |
+| Compiler API | `routers/compiler_core.py` |
+| 기획 진단 서비스 | `routers/diagnosis_engine.py`, `services/diagnosis_service.py` |
+| SaaS setup | `routers/saas_setup.py`, `services/saas_setup_service.py` |
+| Binding | `services/legal_adapter.py`, `services/runtime_binding_engine.py` |
+| Activation | `services/runtime_activation_service.py`, `routers/runtime_candidate_api.py` |
+| 점검 Legacy | `routers/inspection_sets.py`, `routers/inspection_checklist.py`, `routers/schedule_engine.py` |
+| 점검 Runtime | `routers/my_inspection_bridge.py` |
+| 설비·QR | `routers/equipment_assets.py`, `routers/equipment_checkins.py`, `routers/worker_home.py` |
+| 문서 | `routers/engine_document.py`, `routers/document_engine_api.py`, `watch_engine/document/__init__.py` |
+| Transform | `routers/diagnosis_transform.py` |
+| 기획서 | `SESSION_2026_05_11_FULL_PIPELINE.md` |
+
+---
+
+*분석만 수행. 코드 수정 없음.*

--- a/docs/LEGAL_DIAGNOSIS_LAYER_PROBLEMS.md
+++ b/docs/LEGAL_DIAGNOSIS_LAYER_PROBLEMS.md
@@ -1,0 +1,339 @@
+# Legal Diagnosis — Layer Interface Problems (Stage 2)
+
+**Repo:** `taiengineering/tai-api`  
+**Date:** 2026-06-08  
+**Scope:** 6-layer 소비자 법령진단 Compiler Core 경로 (`run_anonymous_diagnosis`) — **인터페이스 문제만 기록, 수정안 없음**  
+**Reference:** `docs/LEGAL_DIAGNOSIS_LAYER_SURVEY.md` (1단계 조사)  
+**DB:** Supabase `vwlahtguyggrhvslabax` (MCP `execute_sql`)
+
+**Pipeline:**
+```
+[1] DiagnoseStep1Body
+  → [2] create_temp_factory + evaluate_single_factory (factories row)
+  → [3] FIELD_MAP × draft_slot.binding_field
+  → [4] fetch_compiler_candidates → _compiler_result_to_step1_format
+  → [5] diagnosis_transform._extract_obligations
+  → [6] _partial_from_full / _build_partial
+```
+
+---
+
+## Executive Summary
+
+| 구간 | 핵심 문제 | 최고 심각도 |
+|------|-----------|-------------|
+| [1→2] | `facility_ctx`에만 존재하는 입력이 `factories`에 미저장 → Layer 3 평가가 DB row 기준 | **CRITICAL** |
+| [2→3] | `binding_field IS NULL` 슬롯 1,917건 평가 제외; `fac_col=None` 3키는 영구 `MISSING_DATA` | **HIGH** |
+| [3→4] | 익명 임시 factory는 `task_candidate` 없음 → applicability fallback만 사용; task_type 명명 불일치 | **CRITICAL** |
+| [4→5] | `obligations` wrapper(`items[]`) 미전개 → Transform 제목·evidence 전부 손실 | **HIGH** |
+| [5→6] | 동일 `full_result`라도 진입 경로별 `partial_result` 스키마 불일치 | **MEDIUM** |
+
+---
+
+## [1→2] DiagnoseStep1Body (33필드) vs `create_temp_factory` (15 DB 컬럼)
+
+### 1.2.1 스키마 대응
+
+**`DiagnoseStep1Body` 필드 수:** 33 (`factory_id`, `sector`, `input` + 본문 30개) — `schemas/legal_engine.py`
+
+**`create_temp_factory` INSERT 컬럼 (15 + 메타):**
+
+| # | DB 컬럼 | 값 출처 (`facility_ctx` / body) |
+|---|---------|--------------------------------|
+| 1 | `name` | `[ANON]{sector}-{ts}` |
+| 2 | `sector` | `body.sector` |
+| 3 | `site_type` | **`sector_raw`** (섹터 코드, 예: `BUILDING`) |
+| 4 | `is_active` | `false` |
+| 5 | `status_code` | `ANON_TEMP` |
+| 6 | `employee_count` | `worker_count` 또는 `employee_count` |
+| 7 | `building_area` | `building_area` / `total_floor_area` |
+| 8 | `electrical_capacity_kw` | `electrical_capacity_kw` / `electric_capacity` |
+| 9 | `transformer_capacity_kva` | `transformer_capacity_kva` |
+| 10 | `gas_capacity_m3` | `gas_capacity_m3` |
+| 11 | `gas_capacity_kg` | `gas_capacity_kg` |
+| 12 | `construction_amount` | `construction_amount` |
+| 13 | `ksic_code` | `ksic_code` |
+| 14 | `construction_type` | `construction_type` |
+| 15 | `subcontractor_worker_count` | `subcontractor_worker_count` / `subcon_workers` |
+
+**Layer 3 평가 입력:** `evaluate_single_factory`는 **`factories` SELECT `*`** 만 사용 (`anonymous_factory_service.py:173–176`). `facility_ctx`는 Layer 4 `result_data.facility_context`에만 남고 평가 루프에는 미사용.
+
+### 1.2.2 누락 필드 목록 및 평가 영향
+
+| 입력 필드 / `facility_ctx` 키 | `factories` 저장 | 평가 영향 | 근거 |
+|------------------------------|------------------|-----------|------|
+| `factory_id` | N/A (신규 UUID) | 없음 | 임시 factory 의도적 신규 생성 |
+| `input` (`region`, `site_kind`, `scale`, `anonymous_flow` 등) | **미저장** | **간접** | tier/UX 메타; FIELD_MAP 직접 키 아님 |
+| `building_use_type` → `building_use_code` | **미저장** | **있음** | `facility_type` scope는 `site_type` 컬럼 참조인데 `site_type=sector`로 덮어씀 → 건물 용도 무시 |
+| `floor_count` | **미저장** | 없음 (현 FIELD_MAP) | draft_slot에 해당 `binding_field` 없음 |
+| `elevator_count` | **미저장** | 없음 (현 FIELD_MAP) | 승강기 조건 슬롯 없음 |
+| `boiler_capacity_kw` / `has_boiler` | **미저장** | 없음 (현 FIELD_MAP) | 보일러 전용 binding 없음 |
+| `annual_energy_toe` | **미저장** | 없음 (현 FIELD_MAP) | 에너지 binding 없음 |
+| `has_high_pressure_gas` | **미저장** (kg만 간접) | **있음** | `gas_capacity_kg`만 저장; 불리언만 제출 시 kg=0이면 가스 관련 numeric/scope 약화 |
+| `has_hazardous_material` | **미저장** | 없음 (현 FIELD_MAP) | |
+| `has_chemical_substance` | **미저장** | 없음 (현 FIELD_MAP) | |
+| `facility_type` (SPECIAL) → `building_use_code` | **미저장** (`site_type=sector`) | **있음** | `facility_type` scope → `site_type` 컬럼인데 섹터 코드만 존재 |
+| `direct_workers` | **미저장** (합산만) | **있음** | `employee_count`에 direct+subcon 합만 저장; direct 단독 임계 미반영 가능 |
+| `has_tunnel_bridge`, `has_blasting`, `has_crane`, `has_high_work` | **미저장** | 없음 (현 FIELD_MAP) | 건설 위험공종 boolean binding 없음 |
+| `employee_count` / `worker_count` / `floor_area` / `electric_capacity` 등 | **저장됨** | **있음** | `employee_count`, `area_size`, `power_capacity` DIRECT 비교 가능 |
+| `contract_amount_eok` → `construction_amount` | **저장됨** | **있음** | `monetary_value` → `AMBIGUOUS`만 (MATCH 불가) |
+| `ksic_major` → `ksic_code` | **저장됨** | **있음** | `process_type` scope → `POSSIBLE_CANDIDATE` (값 비교 없음) |
+| `gas_capacity_m3` / `gas_capacity_kg` | **저장됨** | **있음** | `storage_capacity` → `AMBIGUOUS`; kg는 FIELD_MAP 미연결 |
+| `transformer_capacity_kva` | **저장됨** | **있음** | `voltage_level` → `AMBIGUOUS` (전압≠kVA) |
+| `construction_type` | **저장됨** | **간접** | FIELD_MAP 키 아님; 건설 summary만 |
+| `subcontractor_worker_count` | **저장됨** | **간접** | 별도 binding 없음; `employee_count`와 분리 평가 불가 |
+
+### 1.2.3 구조적 문제 (번호)
+
+| ID | 심각도 | 문제 |
+|----|--------|------|
+| **P-1-01** | **CRITICAL** | Layer 2 평가(`evaluate_single_factory`)가 `facility_ctx`가 아닌 **15컬럼 `factories` row**만 사용 — ctx에만 있는 입력은 평가에 반영되지 않음 |
+| **P-1-02** | **HIGH** | `site_type`에 `building_use_type` / `facility_type` 대신 **`sector` 코드** 저장 → `FIELD_MAP["facility_type"]` → `site_type` scope가 용도·시설유형과 무관 |
+| **P-1-03** | **MEDIUM** | `input` dict 전체 미영속 — 익명 프리셋(`region`, `scale`)이 재평가·감사 추적 불가 |
+| **P-1-04** | **MEDIUM** | boolean 위험요인(`has_*`) 다수 미저장 — 해당 조건을 쓰는 draft가 추가되면 소비자 입력과 평가 데이터 불일치 |
+
+---
+
+## [2→3] FIELD_MAP (10키) vs `draft_slot` 실제 `binding_field`
+
+### 2.3.1 스키마 명칭 차이
+
+조사 쿼리 문구: `field_name`, `slot_kind = 'IF_NUMERIC'`.  
+**실제 DB/코드:** `draft_slot.binding_field`, `draft_slot.section IN ('IF_NUMERIC','IF_SCOPE')` (`_load_draft_slot_groups`).
+
+### 2.3.2 DB 실측 (Supabase `vwlahtguyggrhvslabax`)
+
+**동등 쿼리:**
+```sql
+SELECT section, binding_field, COUNT(*) AS cnt
+FROM draft_slot
+WHERE section IN ('IF_NUMERIC','IF_SCOPE')
+GROUP BY section, binding_field
+ORDER BY section, cnt DESC;
+```
+
+| section | binding_field | cnt | FIELD_MAP |
+|---------|---------------|-----|-----------|
+| IF_NUMERIC | *(null)* | **1,702** | — (로더 제외) |
+| IF_NUMERIC | `distance_value` | 415 | ✓ (`fac_col=None`) |
+| IF_NUMERIC | `employee_count` | 164 | ✓ DIRECT |
+| IF_NUMERIC | `voltage_level` | 142 | ✓ AMBIGUOUS |
+| IF_NUMERIC | `concentration_level` | 110 | ✓ (`fac_col=None`) |
+| IF_NUMERIC | `storage_capacity` | 23 | ✓ AMBIGUOUS |
+| IF_NUMERIC | `power_capacity` | 15 | ✓ DIRECT |
+| IF_NUMERIC | `area_size` | 12 | ✓ DIRECT |
+| IF_NUMERIC | `monetary_value` | 6 | ✓ AMBIGUOUS |
+| IF_SCOPE | `equipment_type` | 260 | ✓ (`fac_col=None`) |
+| IF_SCOPE | `facility_type` | 220 | ✓ AMBIGUOUS |
+| IF_SCOPE | *(null)* | **215** | — (로더 제외) |
+| IF_SCOPE | `process_type` | 33 | ✓ AMBIGUOUS |
+
+- **IF_NUMERIC/IF_SCOPE 슬롯 합계:** 3,317  
+- **`binding_field IS NULL`:** 1,917 (57.8%) — `_load_draft_slot_groups`에서 **`.not_.is_("binding_field", "null")`** 로 **평가 대상에서 제외**  
+- **FIELD_MAP에 없는 non-null `binding_field`:** **0건** (DB 기준 “맵 밖 field_name” 없음)
+
+### 2.3.3 FIELD_MAP 10키별 평가 가능성
+
+| binding_field | fac_col | quality | 평가 결과 | MATCH/POSSIBLE persist |
+|---------------|---------|---------|-----------|------------------------|
+| `employee_count` | `employee_count` | DIRECT | `DIRECT_COMPARE` | 가능 |
+| `area_size` | `building_area` | DIRECT | `DIRECT_COMPARE` | 가능 |
+| `power_capacity` | `electrical_capacity_kw` | DIRECT | `DIRECT_COMPARE` | 가능 |
+| `voltage_level` | `transformer_capacity_kva` | AMBIGUOUS | 항상 `AMBIGUOUS` | **불가** (`_PERSIST_STATUSES`에 없음) |
+| `storage_capacity` | `gas_capacity_m3` | AMBIGUOUS | 항상 `AMBIGUOUS` | **불가** |
+| `monetary_value` | `construction_amount` | AMBIGUOUS | 항상 `AMBIGUOUS` | **불가** |
+| `facility_type` | `site_type` | AMBIGUOUS (scope) | 값 존재 시 `POSSIBLE_CANDIDATE` | 가능 (의미 왜곡 — P-1-02) |
+| `process_type` | `ksic_code` | AMBIGUOUS (scope) | `POSSIBLE_CANDIDATE` | 가능 (코드 존재만 확인) |
+| `concentration_level` | `None` | MISSING | `MISSING_DATA` / `NO_FACILITY_COLUMN` | **불가** |
+| `distance_value` | `None` | MISSING | 동일 | **불가** |
+| `equipment_type` | `None` | EQUIPMENT_JOIN | scope도 `NO_FACILITY_COLUMN` | **불가** |
+
+**영향 큰 슬롯 수 (fac_col=None):** `distance_value` 415 + `concentration_level` 110 + `equipment_type` 260 = **785건** — 코드상 구조적으로 `MATCH_CANDIDATE`/`POSSIBLE_CANDIDATE` 도달 불가.
+
+### 2.3.4 구조적 문제 (번호)
+
+| ID | 심각도 | 문제 |
+|----|--------|------|
+| **P-2-01** | **HIGH** | 1,917개 슬롯(`binding_field` null)이 평가 파이프라인에 **진입하지 않음** — 해당 draft는 numeric/scope 체크 없이 후보에서 빠질 수 있음 |
+| **P-2-02** | **HIGH** | FIELD_MAP에 있으나 `fac_col=None`인 3키(`concentration_level`, `distance_value`, `equipment_type`) — **785 슬롯**이 영구 `MISSING_DATA` |
+| **P-2-03** | **HIGH** | `AMBIGUOUS` quality 4키는 numeric 비교 없음 → draft 전체가 `AMBIGUOUS`이면 persist 제외; `POSSIBLE_CANDIDATE`만 scope로 얻는 draft에 편향 |
+| **P-2-04** | **LOW** | 문서/쿼리 `field_name`·`slot_kind` vs 실제 `binding_field`·`section` 불일치 — 운영 SQL 오류 위험 |
+
+---
+
+## [3→4] task 경로 vs applicability fallback 경로
+
+### 3.4.1 경로 선택 로직
+
+```python
+rules_from_tasks = [_task_to_rule_row(t, sector_raw) for t in tasks]
+if not rules_from_tasks and applicability:
+    # applicability → generic rule rows
+```
+
+`tasks` = `fetch_compiler_candidates` → `task_candidate` WHERE `factory_id = fid`.
+
+**DB:** `task_candidate` **3,388행**, **distinct factory_id = 29**. 익명 진단은 매 요청 **신규 UUID** 임시 factory → **`task_candidates` ≈ 항상 `[]`**.
+
+→ 소비자 Compiler 경로는 사실상 **applicability fallback만** Layer 4 rule 생성에 사용.
+
+### 3.4.2 출력 필드 차이표
+
+| 필드 | Task 경로 `_task_to_rule_row` | Applicability fallback |
+|------|------------------------------|------------------------|
+| `rule_id` | `task.id` | `applicability.id` 또는 `draft_id` |
+| `rule_type` | `task_type` (예: `INSPECTION_TASK_CANDIDATE`) | **없음** |
+| `law_name` | `obligation_family` 또는 `"Compiler Candidate"` | **`"Applicability Candidate"`** (고정) |
+| `law_article` | `""` | `""` |
+| `obligation_summary` | `{task_type}: {source_action_family}` | **`"Applicability: {status}"`** |
+| `remarks` / `description` | title 문자열 | **`draft={draft_id}`** |
+| `category` | bucket label (선임/점검/…) | **`"조치"`** (고정) |
+| `obligation_type` | `APPOINT`/`INSPECT`/… 또는 **`ACTION`** (아래 P-3-03) | **`ACTION`** |
+| `sector` | `sector_raw` | `sector_raw` |
+| `diagnosis_stage` | `1` | **없음** |
+| `schedule_type` | `ON_DEMAND` | **없음** |
+| `penalty_summary` | `""` | **없음** |
+| `appointment_required` | bucket 기반 | **없음** |
+| `inspection_required` | bucket 기반 | **없음** |
+| `action_required` | bucket 기반 | **`True`만** |
+| `report_required` | bucket 기반 | **없음** |
+| `notify_required` | bucket 기반 | **없음** |
+| 법령·조문·패널티 연결 | `obligation_family` 일부 | **없음** (status 문자열만) |
+
+### 3.4.3 task_type 명명 불일치 (task 경로가 있어도)
+
+**DB `task_type` 분포 (상위):** `REPORT_TASK_CANDIDATE`(988), `INSTALL_TASK_CANDIDATE`(769), `APPOINTMENT_TASK_CANDIDATE`(764), `INSPECTION_TASK_CANDIDATE`(144), …
+
+**`_TASK_TYPE_TO_BUCKET` 키:** `APPOINTMENT`, `INSPECTION`, `REPORT`, … (**`_TASK_CANDIDATE` 접미사 없음**)
+
+→ `task_type.upper()`가 맵에 없으면 **전부 `("action", "조치")` bucket**.
+
+**`obligation_type` 허용 목록:** `APPOINT`, `INSPECT`, `REPORT`, `NOTIFY`, `ACTION` — DB 값 `*_TASK_CANDIDATE`와 **불일치** → **항상 `ACTION`**.
+
+### 3.4.4 구조적 문제 (번호)
+
+| ID | 심각도 | 문제 |
+|----|--------|------|
+| **P-3-01** | **CRITICAL** | 익명 임시 `factory_id`에 `task_candidate` 없음 → Layer 4 출력이 **applicability fallback 형태**로 고정 |
+| **P-3-02** | **HIGH** | Fallback row는 법령명·의무 유형·bucket 플래그·일정 메타 **대부분 누락** — UI/Transform이 기대하는 rule row 스키마와 불일치 |
+| **P-3-03** | **HIGH** | `_TASK_TYPE_TO_BUCKET` / `obligation_type`이 실제 DB `*_TASK_CANDIDATE` enum과 **미매칭** — task 경로 복구 시에도 bucket·`inspection_required` 오분류 |
+| **P-3-04** | **MEDIUM** | `rules_from_tasks` 비어 있을 때만 applicability 사용 — task와 applicability **병합 없음**; 이중 정보 소실 |
+
+---
+
+## [4→5] `obligations` wrapper와 Transform 처리
+
+### 4.5.1 Layer 4 `obligations` 구조
+
+`_compiler_result_to_step1_format` (`anonymous_factory_service.py:332–339`):
+
+```python
+obligations.append({
+    "category": key,      # "appointment" | "inspection" | ...
+    "label": label,       # "선임" | "점검" | ...
+    "items": triggered[key],  # List[rule_row dict]
+})
+```
+
+동시에 `key_obligations`는 **`List[str]`** (요약 문자열 20개까지).
+
+### 4.5.2 `_extract_obligations` 동작
+
+1. 키 우선순위: `obligations` → `key_obligations` → … — **`obligations`가 non-empty이면 즉시 선택**  
+2. `raw_list`의 각 원소를 **flat obligation**으로 1:1 변환  
+3. wrapper dict에는 `title`/`name`/`item` 없음 → **`title = "의무사항"`**  
+4. `evidence` = `obj.get("evidence")` or `legal_basis` — wrapper에 없음 → **`[]`**  
+5. **`items[]` 전개 없음** — nested `rule_row`의 `obligation_summary`, `law_name`, flags 미사용  
+6. `key_obligations`(문자열 리스트)는 `obligations` wrapper가 있으면 **도달하지 않음**
+
+### 4.5.3 evidence / evidence_chain
+
+- Layer 4 `rule_row`에도 `evidence` / `evidence_chain` 필드 **없음**  
+- `compiler_core` 블록에 raw candidates는 있으나 Transform **미참조**  
+- Transform 출력: 모든 obligation `evidence: []` 고정에 가까움
+
+### 4.5.4 구조적 문제 (번호)
+
+| ID | 심각도 | 문제 |
+|----|--------|------|
+| **P-4-01** | **HIGH** | Transform이 `obligations[].items[]` wrapper를 **범주 1건**으로 처리 — 실제 의무 건수·제목·법령명 소실 |
+| **P-4-02** | **HIGH** | `key_obligations`(가독 문자열)가 wrapper 존재로 **우선순위에서 밀림** — 의도한 요약도 Transform에 반영 안 됨 |
+| **P-4-03** | **HIGH** | `evidence` / `evidence_chain` **전 구간 미연결** — Layer 5 obligation evidence 항상 빈 배열 |
+| **P-4-04** | **MEDIUM** | `rules_table` / `rules`에는 flat rule_row 있으나 Transform은 `obligations` 키만 사용 — **동일 full_result 내 데이터 이중 구조·불일치** |
+
+---
+
+## [5→6] `_partial_from_full` vs `_build_partial`
+
+### 5.6.1 코드 위치
+
+- 익명: `routers/anonymous_diagnosis.py` → `_partial_from_full`
+- 통합: `services/diagnosis_helpers.py` → `_build_partial`
+
+### 5.6.2 동일 `full_result` 기준 필드 비교
+
+| 키 | `_partial_from_full` | `_build_partial` | 비고 |
+|----|----------------------|------------------|------|
+| `risk_level` | ✓ | ✓ | 동일 |
+| `summary` | ✓ | ✓ | 동일 |
+| `applicable_count` | ✓ | ✓ | 동일 |
+| `sector` | ✓ | ✓ | 동일 |
+| `key_obligations` | ✓ `[:6]` | ✓ `[:6]` | Compiler 경로에서 **문자열 리스트** |
+| `law_badges` | ✓ `[:18]` | ✓ `[:18]` | 동일 |
+| `evaluated_at` | ✓ | **없음** | 통합 partial에 시각 없음 |
+| `rules_preview` | ✓ `rules[:12]` | **없음** | 익명만 rule 미리보기 |
+| `construction_summary` | ✓ (CONSTRUCTION 시) | **없음** | 건설 섹터 partial 불균형 |
+| `message` | ✓ (로그인 유도 문구) | **없음** | UX 메타만 익명 |
+
+**공유되지 않는 full 필드 (양쪽 partial 모두 누락):** `obligations`, `rules_table`, `compiler_core`, `facility_context`, `risk_reason`, bucket arrays (`appointment_required` 등).
+
+### 5.6.3 구조적 문제 (번호)
+
+| ID | 심각도 | 문제 |
+|----|--------|------|
+| **P-5-01** | **MEDIUM** | 동일 diagnosis 엔진 출력인데 **진입 API별 partial 스키마 상이** — 클라이언트 공통 모델 불가 |
+| **P-5-02** | **MEDIUM** | `rules_preview`·`construction_summary`·`evaluated_at` 익명 전용 — 통합 로그인 사용자는 동일 정보 partial에서 **접근 불가** |
+| **P-5-03** | **LOW** | `key_obligations` 타입이 경로별로 `List[str]`(Compiler) vs legacy 구조 혼재 가능 — partial만으로 의미 해석 불명확 |
+
+---
+
+## Cross-Layer Problem Index
+
+| ID | 구간 | 심각도 | 한 줄 요약 |
+|----|------|--------|------------|
+| P-1-01 | 1→2 | CRITICAL | 평가는 15컬럼 factory row만 사용 |
+| P-1-02 | 1→2 | HIGH | `site_type`≠건물/시설 용도 |
+| P-1-03 | 1→2 | MEDIUM | `input` dict 미영속 |
+| P-1-04 | 1→2 | MEDIUM | `has_*` boolean 미저장 |
+| P-2-01 | 2→3 | HIGH | null `binding_field` 1,917 슬롯 제외 |
+| P-2-02 | 2→3 | HIGH | fac_col=None 3키 → 785 슬롯 영구 MISSING |
+| P-2-03 | 2→3 | HIGH | AMBIGUOUS-only draft persist 불가 |
+| P-2-04 | 2→3 | LOW | DB 컬럼명 문서 불일치 |
+| P-3-01 | 3→4 | CRITICAL | 익명 경로 task_candidate 공백 → fallback only |
+| P-3-02 | 3→4 | HIGH | Fallback rule row 메타 대량 누락 |
+| P-3-03 | 3→4 | HIGH | `*_TASK_CANDIDATE` vs bucket 맵 불일치 |
+| P-3-04 | 3→4 | MEDIUM | task·applicability 비병합 |
+| P-4-01 | 4→5 | HIGH | obligations wrapper 미전개 |
+| P-4-02 | 4→5 | HIGH | key_obligations 우선순위 차단 |
+| P-4-03 | 4→5 | HIGH | evidence 전 구간 빈 배열 |
+| P-4-04 | 4→5 | MEDIUM | rules vs obligations 이중 구조 |
+| P-5-01 | 5→6 | MEDIUM | partial 스키마 API별 분기 |
+| P-5-02 | 5→6 | MEDIUM | rules_preview 등 익명 편향 |
+| P-5-03 | 5→6 | LOW | key_obligations 타입 혼재 |
+
+---
+
+## Source Files
+
+| Layer | File |
+|-------|------|
+| 1 | `schemas/legal_engine.py` |
+| 2 | `services/anonymous_factory_service.py`, `services/legal_context.py` |
+| 3 | `services/facility_applicability_eval.py` |
+| 4 | `services/compiler_core_svc.py`, `services/anonymous_factory_service.py` |
+| 5 | `routers/diagnosis_transform.py`, `routers/anonymous_diagnosis.py` |
+| 6 | `routers/anonymous_diagnosis.py`, `services/diagnosis_helpers.py` |
+
+---
+
+*Stage 2 complete. 수정·패치 없음. Stage 3(연결 설계)는 별도 워크오더.*

--- a/docs/LEGAL_DIAGNOSIS_LAYER_SURVEY.md
+++ b/docs/LEGAL_DIAGNOSIS_LAYER_SURVEY.md
@@ -1,0 +1,710 @@
+# Legal Diagnosis — 6-Layer Interface Survey
+
+**Repo:** `taiengineering/tai-api`  
+**Date:** 2026-06-08  
+**Scope:** 소비자 법령진단 **Compiler Core 경로** (`run_anonymous_diagnosis`) — 코드에서 확인한 필드·타입·구조만 기록. 추측 없음.  
+**Primary files:** `schemas/legal_engine.py`, `services/anonymous_factory_service.py`, `services/facility_applicability_eval.py`, `services/compiler_core_svc.py`, `services/legal_context.py`, `services/legal_rules.py`, `routers/diagnosis_transform.py`, `routers/anonymous_diagnosis.py`, `services/diagnosis_integrated_svc.py`
+
+**Orchestration entry (공통):**
+```
+run_step1_via_compiler(supabase, DiagnoseStep1Body)
+  → run_anonymous_diagnosis(supabase, body, allowed_sectors)
+  → Dict[str, Any]   # step1 result_data
+  → wrapped: {"status": "success", "data": result_data}
+```
+
+---
+
+## Layer [1] 소비자 입력
+
+### 1.1 `DiagnoseStep1Body` (`schemas/legal_engine.py`)
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `factory_id` | `Optional[str]` | `None` | Compiler 소비자 경로: 익명은 `None`; `/diagnosis/run`은 optional |
+| `sector` | `str` | (required) | `.strip().upper()` 후 검증 |
+| `input` | `Optional[Dict[str, Any]]` | `{}` | 자유 키·값 dict |
+| `building_use_type` | `Optional[str]` | `None` | BUILDING |
+| `employee_count` | `Optional[int]` | `None` | |
+| `floor_area` | `Optional[float]` | `None` | |
+| `worker_count` | `Optional[int]` | `None` | |
+| `total_floor_area` | `Optional[float]` | `None` | |
+| `electric_capacity` | `Optional[float]` | `None` | |
+| `floor_count` | `Optional[int]` | `None` | |
+| `contract_amount_eok` | `Optional[float]` | `None` | 억원 단위 (Field description) |
+| `ksic_major` | `Optional[str]` | `None` | MANUFACTURING |
+| `facility_type` | `Optional[str]` | `None` | SPECIAL_FACILITY |
+| `elevator_count` | `Optional[int]` | `None` | |
+| `gas_capacity_kg` | `Optional[float]` | `None` | |
+| `gas_capacity_m3` | `Optional[float]` | `None` | |
+| `boiler_capacity_kw` | `Optional[float]` | `None` | |
+| `annual_energy_toe` | `Optional[float]` | `None` | |
+| `has_high_pressure_gas` | `Optional[bool]` | `None` | |
+| `has_boiler` | `Optional[bool]` | `None` | |
+| `has_hazardous_material` | `Optional[bool]` | `None` | |
+| `has_chemical_substance` | `Optional[bool]` | `None` | |
+| `construction_type` | `Optional[str]` | `None` | CONSTRUCTION |
+| `direct_workers` | `Optional[int]` | `None` | CONSTRUCTION |
+| `subcon_workers` | `Optional[int]` | `None` | CONSTRUCTION |
+| `electrical_capacity_kw` | `Optional[float]` | `None` | CONSTRUCTION |
+| `has_tunnel_bridge` | `Optional[bool]` | `None` | CONSTRUCTION |
+| `has_blasting` | `Optional[bool]` | `None` | CONSTRUCTION |
+| `has_crane` | `Optional[bool]` | `None` | CONSTRUCTION |
+| `has_high_work` | `Optional[bool]` | `None` | CONSTRUCTION |
+
+### 1.2 섹터별 진입 (코드에서 조립되는 필드)
+
+**Allowed sectors** (`anonymous_factory_service.run_anonymous_diagnosis`, `anonymous_diagnosis.py`):
+`BUILDING`, `MANUFACTURING`, `CONSTRUCTION`, `SPECIAL_FACILITY`, `SPECIAL`
+
+#### A) `POST /anonymous-diagnosis` — `AnonymousDiagnosisCreate` → `DiagnoseStep1Body`
+
+`AnonymousDiagnosisCreate` (`routers/anonymous_diagnosis.py`):
+
+| Field | Type | Constraint |
+|-------|------|------------|
+| `site_kind` | `str` | `construction \| manufacturing \| building \| other` |
+| `scale` | `str` | `small \| medium \| large` |
+| `workers` | `int` | `ge=1, le=50000` |
+| `region` | `str` | default `""` |
+
+`SECTOR_BY_KIND`: `construction→CONSTRUCTION`, `manufacturing→MANUFACTURING`, `building→BUILDING`, `other→SPECIAL_FACILITY`
+
+`SCALE_PRESETS` keys: `small`, `medium`, `large` — each has `floor_area`, `total_floor_area`, `contract_amount_eok`, `employee_hint` (float/int)
+
+| Sector | `DiagnoseStep1Body` fields set | `input` dict keys |
+|--------|-------------------------------|-------------------|
+| `CONSTRUCTION` | `factory_id=None`, `construction_type="건축"`, `contract_amount_eok=preset`, `direct_workers=workers`, `subcon_workers=0` | `region`, `site_kind`, `scale`, `anonymous_flow=True` |
+| `MANUFACTURING` | `worker_count`, `employee_count`, `floor_area`, `total_floor_area`, `ksic_major=""` | same + above |
+| `BUILDING` | `building_use_type="사무실"`, `floor_area`, `total_floor_area`, `worker_count`, `employee_count`, `floor_count=5` | same |
+| `SPECIAL_FACILITY` | `facility_type="기타시설"`, `floor_area`, `total_floor_area`, `worker_count`, `employee_count` | same |
+
+#### B) `POST /diagnosis/run` — `DiagnosisRunBody` → `DiagnoseStep1Body`
+
+`DiagnosisRunBody` (`schemas/diagnosis_integrated.py`) — Nexas 필드. `nexas_run_body_from_request()`가 `form_data` 병합.
+
+`diagnosis_integrated_svc.run_diagnosis`가 `normalize_sector_db(body.sector)` 후 `engine_sector`:
+- `INDUSTRIAL` → `MANUFACTURING`
+- else → `sector` 그대로
+
+| `engine_sector` | `DiagnoseStep1Body` 조립 필드 |
+|-----------------|------------------------------|
+| `CONSTRUCTION` | `factory_id`, `construction_type`, `contract_amount_eok`, `direct_workers`, `subcon_workers`, `input` |
+| `BUILDING` | `factory_id`, `building_use_type`, `floor_area`, `total_floor_area`, `worker_count`, `employee_count`, `floor_count`, `electric_capacity`, `elevator_count`, `has_high_pressure_gas`←`has_gas`, `has_hazardous_material`←`has_chemical` |
+| else (MANUFACTURING 등) | `factory_id`, `worker_count`, `employee_count`, `floor_area`, `total_floor_area`, `ksic_major`, `electric_capacity`, `has_boiler`, `has_hazardous_material`, `has_high_pressure_gas`, `has_chemical_substance` |
+
+공통 `input` dict: `region`, `anonymous_flow=True`, `tier_code`, optional `factory_id`, `company_id`
+
+### 1.3 `_merge_body_input(body)` 출력
+
+`Dict[str, Any]`: `body.input` 복사 후, top-level `DiagnoseStep1Body` 필드 중 `input`에 없고 `not None`인 값을 아래 키로 주입:
+
+`building_use_type`, `employee_count`, `floor_area`, `worker_count`, `total_floor_area`, `electric_capacity`, `floor_count`, `contract_amount_eok`, `ksic_major`, `facility_type`, `elevator_count`, `gas_capacity_kg`, `gas_capacity_m3`, `boiler_capacity_kw`, `annual_energy_toe`, `has_high_pressure_gas`, `has_boiler`, `has_hazardous_material`, `has_chemical_substance`, `construction_type`, `direct_workers`, `subcon_workers`, `electrical_capacity_kw`, `has_tunnel_bridge`, `has_blasting`, `has_crane`, `has_high_work`
+
+---
+
+## Layer [2] 엔진 입력부
+
+### 2.1 `create_temp_factory(supabase, body: DiagnoseStep1Body) -> str`
+
+**Returns:** `factories.id` (str)
+
+**Pipeline inside:**
+1. `sector_raw = body.sector.strip().upper()`
+2. `inp = _merge_body_input(body)`
+3. `ctx = _input_to_facility_context(sector_raw, inp)` — Layer 1→2 facility context (아래 § Interface 1→2)
+4. `factories` INSERT row:
+
+| `factories` column | Source expression | Python cast |
+|--------------------|-------------------|-------------|
+| `name` | `f"[ANON]{sector_raw}-{ts}"[:200]` | `str` |
+| `sector` | `sector_raw` | `str` |
+| `site_type` | `sector_raw` | `str` |
+| `is_active` | `False` | `bool` |
+| `status_code` | `"ANON_TEMP"` | `str` |
+| `employee_count` | `ctx.worker_count or ctx.employee_count or 0` | `int` |
+| `building_area` | `ctx.building_area or ctx.total_floor_area or 0` | `float` |
+| `electrical_capacity_kw` | `ctx.electrical_capacity_kw or ctx.electric_capacity or 0` | `float` |
+| `transformer_capacity_kva` | `ctx.transformer_capacity_kva or 0` | `float` |
+| `gas_capacity_m3` | `ctx.gas_capacity_m3 or 0` | `float` |
+| `gas_capacity_kg` | `ctx.gas_capacity_kg or 0` | `float` |
+| `construction_amount` | `ctx.construction_amount or 0` | `float` |
+| `ksic_code` | `ctx.ksic_code or ""` | `str` |
+| `construction_type` | `ctx.construction_type or ""` | `str` |
+| `subcontractor_worker_count` | `ctx.subcontractor_worker_count or ctx.subcon_workers or 0` | `int` |
+| `created_at` | `datetime.now(timezone.utc).isoformat()` | `str` (ISO) |
+| `updated_at` | same | `str` (ISO) |
+
+**Not written to `factories` from ctx:** `floor_count`, boolean flags (`has_*`), `elevator_count`, `building_use_code`, etc. — `FIELD_MAP` 비연결 컬럼은 applicability 평가 시 `FACILITY_VALUE_NULL` / `MISSING_DATA` 가능.
+
+### 2.2 `evaluate_single_factory(supabase, factory_id: str) -> Dict[str, int]`
+
+**인자:** `factory_id: str` only (추가 kwargs 없음)
+
+**Returns:**
+```python
+{"drafts_evaluated": int, "applicability_inserted": int}
+```
+
+**Reads:**
+- `factories` SELECT `*` WHERE `id = factory_id`
+- `draft_slot` SELECT (`draft_id`, `part_id`, `section`, `binding_field`, `operator`, `value`, `unit`, `family_name`) WHERE `binding_field IS NOT NULL` AND `section IN ('IF_NUMERIC','IF_SCOPE')` — paginated 1000/page
+
+**Writes (`facility_applicability` INSERT), per draft where overall ∈ `MATCH_CANDIDATE`, `POSSIBLE_CANDIDATE`:**
+
+| Column | Value |
+|--------|-------|
+| `factory_id` | `factory_id` |
+| `draft_id` | `draft_id` |
+| `part_id` | `part_id` (str) |
+| `applicability_status` | `overall` (str) |
+| `match_details` | `{"checks": len(check_results)}` |
+
+**Calls:** `evaluate_draft_for_facility(facility, draft_id, numeric_slots, scope_slots)` per draft.
+
+### 2.3 `fetch_compiler_candidates(supabase, factory_id)` (Layer 2 후속 read)
+
+**인자:** `factory_id: str`, optional `applicability_statuses` default `("MATCH_CANDIDATE", "POSSIBLE_CANDIDATE")`
+
+**Reads (factory_id scoped unless noted):**
+
+| Table | SELECT columns |
+|-------|----------------|
+| `facility_applicability` | `id, draft_id, applicability_status, part_id, match_details` |
+| `task_candidate` | `id, task_type, source_action_family, obligation_family, applicability_status, status` |
+| `schedule_candidate` | `id, schedule_type, source_family, source_relation_type, task_type, status` |
+| `penalty_obligation_relation` | `id, penalty_candidate_id, rule_candidate_id, obligation_family, via_reference, status` (limit 200, **not** factory-filtered) |
+| `compliance_review_queue` | `id, issue_type, detail, status` |
+| `compliance_package` | `*` |
+
+### 2.4 Cleanup
+
+`cleanup_temp_factory(supabase, factory_id)`:
+- DELETE `facility_applicability` WHERE `factory_id`
+- DELETE `factories` WHERE `id`
+
+---
+
+## Layer [3] 법령엔진 내부 (Applicability + Compiler read)
+
+소비자 경로의 “내부 엔진”은 `services/facility_applicability_eval.py` + pre-materialized Compiler 테이블 read.
+
+### 3.1 `FIELD_MAP`
+
+`Dict[str, Tuple[Optional[str], str]]` — `binding_field → (factories column, match quality)`
+
+| `binding_field` | factories column | quality |
+|-----------------|------------------|---------|
+| `employee_count` | `employee_count` | `DIRECT` |
+| `area_size` | `building_area` | `DIRECT` |
+| `power_capacity` | `electrical_capacity_kw` | `DIRECT` |
+| `voltage_level` | `transformer_capacity_kva` | `AMBIGUOUS` |
+| `storage_capacity` | `gas_capacity_m3` | `AMBIGUOUS` |
+| `equipment_type` | `None` | `EQUIPMENT_JOIN` |
+| `facility_type` | `site_type` | `AMBIGUOUS` |
+| `process_type` | `ksic_code` | `AMBIGUOUS` |
+| `monetary_value` | `construction_amount` | `AMBIGUOUS` |
+| `concentration_level` | `None` | `MISSING` |
+| `distance_value` | `None` | `MISSING` |
+
+### 3.2 `compare_numeric(operator, draft_val, facility_val) -> str`
+
+| Condition | Return token |
+|-----------|--------------|
+| `draft_val is None` or `facility_val is None` | `MISSING_DATA` |
+| non-numeric cast | `MISSING_DATA` |
+| `op == ">="` and `fv >= dv` | `MATCH_CANDIDATE` |
+| `op == ">="` and else | `NOT_MATCHED` |
+| `op == "<="` and `fv <= dv` | `MATCH_CANDIDATE` |
+| `op == "<="` and else | `NOT_MATCHED` |
+| `op == ">"` and `fv > dv` | `MATCH_CANDIDATE` |
+| `op == ">"` and else | `NOT_MATCHED` |
+| `op == "<"` and `fv < dv` | `MATCH_CANDIDATE` |
+| `op == "<"` and else | `NOT_MATCHED` |
+| other operator | `AMBIGUOUS` |
+
+### 3.3 `aggregate_applicability_status(results: Set[str]) -> str`
+
+| `results` set condition | `applicability_status` |
+|-------------------------|------------------------|
+| empty | `MISSING_DATA` |
+| has `MATCH_CANDIDATE`, no `NOT_MATCHED` | `MATCH_CANDIDATE` |
+| has both `MATCH_CANDIDATE` and `NOT_MATCHED` | `AMBIGUOUS` |
+| has `POSSIBLE_CANDIDATE` | `POSSIBLE_CANDIDATE` |
+| has `AMBIGUOUS` | `AMBIGUOUS` |
+| exactly `{"NOT_MATCHED"}` | `NOT_MATCHED` |
+| else | `MISSING_DATA` |
+
+**Persist filter** (`anonymous_factory_service._PERSIST_STATUSES`): only `MATCH_CANDIDATE`, `POSSIBLE_CANDIDATE` inserted.
+
+### 3.4 `CheckResult` tuple (8 elements)
+
+```python
+CheckResult = Tuple[str, str, Optional[str], Optional[str], Any, Any, str, str]
+# (check_type, binding_field, fac_col, operator, draft_value, fac_val, result_token, reason_code)
+```
+
+`result_token` (index 6): `MATCH_CANDIDATE`, `NOT_MATCHED`, `MISSING_DATA`, `AMBIGUOUS`, `POSSIBLE_CANDIDATE`
+
+### 3.5 `evaluate_draft_for_facility` return
+
+```python
+Optional[Tuple[str, str, List[CheckResult]]]
+# (overall_status, part_id, check_results)
+```
+
+Returns `None` if `not check_results` or `part_id is None`.
+
+### 3.6 `fetch_compiler_candidates` return dict
+
+```python
+{
+    "factory_id": str,
+    "compiler_version": "v3.0-deterministic",
+    "warning": "All results are CANDIDATES. Not legal conclusions.",
+    "applicability_candidates": list[dict],  # facility_applicability rows
+    "task_candidates": list[dict],
+    "schedule_candidates": list[dict],
+    "penalty_relations": list[dict],
+    "penalty_candidates": list[dict],  # same slice as penalty_relations
+    "review_queue": list[dict],
+    "residuals": list[dict],  # same as review_queue.data
+    "compliance_package": dict | None,
+}
+```
+
+---
+
+## Layer [4] 검증엔진 — `_compiler_result_to_step1_format`
+
+**Input:** `compiler: Dict` (Layer 3 output), `sector_raw: str`, `facility_ctx: Dict`, `evaluated_at: str` (ISO)
+
+### 4.1 `_TASK_TYPE_TO_BUCKET`
+
+`task_type.upper()` → `(bucket_key, category_label)`:
+
+| `task_type` | bucket | label |
+|-------------|--------|-------|
+| `APPOINTMENT`, `DESIGNATE` | `appointment` | `선임` |
+| `REPORT`, `SUBMIT` | `report` | `신고` |
+| `NOTIFY` | `notify` | `보고` |
+| `INSPECTION`, `INSPECT`, `MEASURE` | `inspection` | `점검` |
+| `INSTALL`, `MAINTAIN`, `EDUCATION`, `RECORD`, `PRESERVATION` | `action` | `조치` |
+| (other) | `action` | `조치` |
+
+### 4.2 `_task_to_rule_row(task, sector_raw) -> dict`
+
+**Input `task` keys read:** `task_type`, `source_action_family`, `obligation_family`, `id`
+
+**Output dict keys (before `_bucket` pop):**
+
+| Key | Source |
+|-----|--------|
+| `rule_id` | `str(task["id"] or "")` |
+| `rule_type` | `task_type` upper, default `ACTION` |
+| `law_name` | `obligation_family` or `"Compiler Candidate"` |
+| `law_article` | `""` |
+| `obligation_summary`, `remarks`, `description` | title string |
+| `category` | bucket label (한글) |
+| `obligation_type` | `task_type` if in `APPOINT,INSPECT,REPORT,NOTIFY,ACTION` else `ACTION` |
+| `sector` | `sector_raw` |
+| `diagnosis_stage` | `1` |
+| `schedule_type` | `"ON_DEMAND"` |
+| `penalty_summary` | `""` |
+| `appointment_required` | `bool` |
+| `inspection_required` | `bool` |
+| `action_required` | `bool` |
+| `report_required` | `bool` |
+| `notify_required` | `bool` |
+| `_bucket` | internal bucket key |
+
+### 4.3 Applicability fallback rows
+
+If `rules_from_tasks` empty and `applicability` non-empty, per applicability row `a`:
+
+| Key | Value |
+|-----|-------|
+| `rule_id` | `str(a["id"] or a["draft_id"] or "")` |
+| `law_name` | `"Applicability Candidate"` |
+| `obligation_summary` | `f"Applicability: {a['applicability_status']}"` |
+| `obligation_type` | `"ACTION"` |
+| `action_required` | `True` |
+| `_bucket` | `"action"` |
+
+### 4.4 `rules_table` item shape
+
+```python
+{"category": "<한글 label>", **rule_row}  # rule_row without _bucket
+```
+
+Labels order: `appointment→선임`, `inspection→점검`, `action→조치`, `report→신고`, `notify→보고`
+
+### 4.5 `risk_level(applicable_count: int, appointment_n: int) -> str`
+
+| Condition | Return |
+|-----------|--------|
+| `applicable_count >= 12` or `appointment_n >= 4` | `"HIGH"` |
+| `applicable_count >= 5` or `appointment_n >= 1` | `"MEDIUM"` |
+| else | `"LOW"` |
+
+Where:
+- `applicable_count = sum(len(triggered[k]) for k in appointment, inspection, notify, report, action)`
+- `appointment_n = len(triggered["appointment"])`
+
+### 4.6 `obligations` (group wrapper)
+
+```python
+[
+  {"category": "appointment"|"inspection"|"action"|"report"|"notify",
+   "label": "<한글>",
+   "items": [<rule_row dict>, ...]},
+  ...
+]
+```
+
+### 4.7 `key_obligations`
+
+`List[str]` — first 20 unique `obligation_summary` or `remarks` strings from `rules_from_tasks`.
+
+### 4.8 Full `result_data` top-level keys (`_compiler_result_to_step1_format` return)
+
+| Key | Type / shape |
+|-----|----------------|
+| `sector` | `str` |
+| `sector_groups` | `List[str]` from `get_sector_groups(normalize_sector_db(sector_raw))` |
+| `step` | `int` `1` |
+| `engine_version` | `"v3.0-compiler-core-anonymous"` |
+| `rule_version` | `"compiler_core:facility_applicability:v1"` |
+| `evaluated_at` | `str` ISO |
+| `facility_context` | `Dict` (Layer 1→2 ctx) |
+| `risk_level` | `"HIGH"\|"MEDIUM"\|"LOW"` |
+| `risk_reason` | `str` |
+| `applicable_law_categories` | `List[str]` sorted unique `law_name` |
+| `appointment_required_flag` | `bool` |
+| `key_obligations` | `List[str]` |
+| `law_badges` | `List[str]` (= law_names) |
+| `obligations` | group wrapper list (§4.6) |
+| `rules_table` | `List[dict]` |
+| `rules` | same as `rules_table` |
+| `appointment_required` | `List[dict]` |
+| `inspection_required` | `List[dict]` |
+| `action_required` | `List[dict]` |
+| `report_required` | `List[dict]` (report + notify combined) |
+| `not_applicable` | `[]` |
+| `not_applicable_total` | `0` |
+| `total_rules_checked` | `int` |
+| `applicable_count` | `int` |
+| `article_mapping_stats` | `{total_rules, mapped_rules:0, coverage_pct:0.0}` |
+| `inspection_schedule_ready` | `{periodic_count:0, before_work_count:0, on_demand_count, periodic:[], before_work:[]}` |
+| `summary` | `{total, appointment, inspection, action, report, notify, form_linked:0}` |
+| `compiler_core` | `{compiler_version, warning, applicability_count, task_count, schedule_count, applicability_candidates, task_candidates, schedule_candidates}` |
+| `construction_summary` | `Dict` — **only if** `sector_raw == "CONSTRUCTION"` (`get_construction_summary(facility_ctx)`) |
+
+### 4.9 `construction_summary` keys (`get_construction_summary`)
+
+`site_type`, `contract_amount`, `contract_amount_eok`, `total_workers`, `direct_workers`, `subcon_workers`, `safety_manager_required`, `safety_manager_basis`, `threshold_used`, `key_thresholds_met` (dict of bool thresholds)
+
+---
+
+## Layer [5] 정제 (Transform + 저장)
+
+### 5.1 저장 — `anonymous_diagnosis_results` INSERT
+
+#### 무료 `POST /anonymous-diagnosis`
+
+| Column | Value |
+|--------|-------|
+| `public_token` | `uuid4` str |
+| `input_data` | `{site_kind, scale, workers, region, sector}` |
+| `partial_result` | `_partial_from_full(full_result)` |
+| `full_result` | Layer 4 `result_data` |
+| `created_at` | ISO |
+| `expires_at` | now + 7 days ISO |
+| `claimed_user_id` | `None` |
+| `status` | `"ACTIVE"` |
+| `source_type` | `"site_free"` |
+| `engine_version` | `ANONYMOUS_COMPILER_ENGINE_VERSION` |
+| `rule_version` | `RULE_VERSION_COMPILER` |
+
+#### 유료 `diagnosis_integrated_svc.run_diagnosis`
+
+| Column | Value |
+|--------|-------|
+| `public_token` | `uuid4` |
+| `input_data` | `{sector, tier_code, floor_area, contract_amount_eok, workers, factory_id?, company_id?}` |
+| `partial_result` | `_build_partial(full_result)` |
+| `full_result` | Layer 4 `result_data` |
+| `expires_at` | 7 days if free else `None` |
+| `status` | `"ACTIVE"` |
+| `source_type` | `"free_diag"` or `"paid_diag"` |
+| `engine_version` | param `engine_version` |
+| `ci_hash`, `auth_log_id`, `disclaimer_log_id`, `tier_code`, `paid_amount`, `payment_ref` | from auth flow |
+
+### 5.2 `_partial_from_full` vs `_build_partial`
+
+| Key | `_partial_from_full` (anonymous) | `_build_partial` (integrated) |
+|-----|----------------------------------|-------------------------------|
+| `risk_level` | ✓ | ✓ |
+| `summary` | ✓ | ✓ |
+| `applicable_count` | ✓ | ✓ |
+| `sector` | ✓ | ✓ |
+| `key_obligations` | `[:6]` | `[:6]` |
+| `law_badges` | `[:18]` | `[:18]` |
+| `evaluated_at` | ✓ | — |
+| `rules_preview` | `rules[:12]` | — |
+| `construction_summary` | ✓ | — |
+| `message` | fixed str | — |
+
+### 5.3 Transform (`routers/diagnosis_transform.py`)
+
+Read-only on `full_result` JSONB. No DB write.
+
+#### `_extract_obligations(rd) -> list[dict]`
+
+**Input scan order:** `obligations` → `key_obligations` → `mandatory_obligations` → `critical_obligations` (first non-empty list wins)
+
+Fallback: `{cat_key}_items` or `{cat_label}_항목` for `CATEGORY_MAP` keys.
+
+**Output item:**
+```python
+{
+  "id": str,
+  "category": str,           # normalized via CATEGORY_MAP
+  "title": str,
+  "risk_level": str,         # upper, default "MEDIUM"
+  "description": str,
+  "evidence": list,          # from obj["evidence"] or obj["legal_basis"]; str→[str]
+  "action_url": Optional,
+  "auto_schedulable": bool,
+}
+```
+
+**Compiler `obligations` group wrapper:** first matching key is `obligations` (list of `{category, label, items}`). Transform iterates wrapper dicts — `title` defaults to `"의무사항"`, `evidence` → `[]` unless wrapper dict has `evidence` key.
+
+**Compiler `key_obligations`:** `List[str]` — if `obligations` empty, strings become `{category:"서류", title:str, evidence:[]}`.
+
+#### `_extract_headline(rd, rule_count) -> dict`
+
+```python
+{"summary": str, "severity": str}  # severity: CRITICAL|HIGH|MEDIUM|LOW
+```
+
+#### `_extract_exposure(rd, rule_count) -> dict`
+
+```python
+{"penalty_max_krw": int, "rule_count": int}
+```
+
+#### `_extract_roi(rd) -> Optional[dict]`
+
+```python
+{"penalty_max_krw": int, "subscription_annual_krw": int, "roi_ratio": float, "breakeven_days": int}
+```
+or `None` if `penalty == 0`
+
+#### `_extract_inspection_schedule(rd) -> list[dict]`
+
+```python
+[{"month": int 1-12, "count": int, "items": list[str]}, ...]  # 12 months, missing filled count=0
+```
+
+Reads keys: `inspection_schedule`, `inspection_schedule_ready`, `inspection_schedule_summary` — Compiler `inspection_schedule_ready` is **object not list** → Transform returns 12 empty months.
+
+#### `_extract_warnings(rd) -> list[dict]`
+
+```python
+[{"level": str, "message": str}, ...]
+```
+
+### 5.4 Nexas 정제 `build_nexas_run_response` (`/diagnosis/run` only)
+
+`rules_table_to_obligations(full)` → flat list:
+```python
+{"title", "name", "obligation_name", "law_reference", "law", "category", "who", "what", "when"}
+```
+
+Response wrapper adds `data.obligations`, `data.results`, `data.items`, `data.paid_preview` (obligations[5:]), top-level `result` = full `result_data`.
+
+---
+
+## Layer [6] 출력 — GET 응답 JSON
+
+### 6.1 `POST /anonymous-diagnosis` (즉시)
+
+```python
+{
+  "status": "success",
+  "publicToken": str,
+  "partialResult": dict,      # _partial_from_full
+  "hasFullResult": True,
+  "expiresAt": str,
+}
+```
+
+### 6.2 `GET /anonymous-diagnosis/{token}`
+
+```python
+{
+  "status": "success",
+  "data": {
+    "publicToken": str,
+    "partialResult": dict,
+    "fullResult": dict | None,   # None unless canViewFull
+    "canViewFull": bool,
+    "claimed": bool,
+    "expiresAt": str | None,
+  }
+}
+```
+
+`canViewFull`: `tai_legacy_public=1` OR (Bearer + `claimed_user_id == user.id`)
+
+### 6.3 `GET /anonymous-diagnosis/{token}/transform`
+
+```python
+{
+  "status": "success",
+  "transform_version": str,      # TRANSFORM_VERSION "1.0.1"
+  "source": "anonymous_token",
+  "token": str,
+  "sector": str,                 # normalize_sector_db applied
+  "schema_version": "2026.04",
+  "expires_at": str | None,
+  "rule_count": int,
+  "headline": {"summary": str, "severity": str},
+  "obligations": [ObligationModel-shaped dicts],
+  "warnings": [{"level", "message"}],
+  "exposure": {"penalty_max_krw", "rule_count"},
+  "inspection_schedule": [{"month", "count", "items"}],
+  "roi": dict | None,
+  "risk_summary": dict,
+  "applicable_laws": list,
+  "next_actions": list,
+  "key_obligations": list[:10],
+  "law_badges": list[:20],
+  "input_data": {"site_kind", "scale", "workers", "region"},
+}
+```
+
+### 6.4 `GET /anonymous-diagnosis/{token}/recommend-plan`
+
+```python
+{
+  "status": "success",
+  "version": str,
+  "source": "anonymous_token",
+  "token": str,
+  "sector": str,
+  "input_summary": {"severity", "obl_count", "workers"},
+  "recommended": {
+    "plan_code", "plan_name", "monthly_krw", "is_custom", "pricing_note"
+  },
+  "reasons": list,
+  "alternatives": list,
+  "comparison": dict,
+  "cta": {"primary", "secondary", "signup"},
+}
+```
+
+### 6.5 `POST /diagnosis/run` (Nexas)
+
+`build_nexas_run_response` → §5.4 + top-level `public_token`, `diagnosis_id`, `tier_code`, `is_free`, `result`.
+
+---
+
+## Layer 간 인터페이스
+
+### Layer 1 → Layer 2
+
+```
+DiagnoseStep1Body
+  → _merge_body_input() → inp: Dict[str, Any]
+  → _input_to_facility_context(sector_raw, inp) → facility_ctx: Dict[str, Any]
+  → create_temp_factory: facility_ctx → factories row (subset, §2.1)
+```
+
+**`_input_to_facility_context` sector branches** (`services/legal_context.py`):
+
+| Sector | Notable `ctx` keys populated |
+|--------|------------------------------|
+| `BUILDING` | `building_use_code`, `total_floor_area`, `building_area`, `floor_count`, `worker_count`, `electric_capacity`, `electrical_capacity_kw`, `has_high_pressure_gas`, `gas_capacity_*`, `has_hazardous_material`, `elevator_count`, `annual_energy_toe`, `has_boiler`, `boiler_capacity_kw` |
+| `MANUFACTURING` | `ksic_code`, `worker_count`, `electric_capacity`, `electrical_capacity_kw`, `has_*` flags, `gas_*`, `building_area`, `total_floor_area`, `is_factory_registered` |
+| `CONSTRUCTION` | `construction_amount`, `contract_amount` (= eok×1e8), `construction_type`, `worker_count`, `employee_count`, `direct_workers`, `subcon_workers`, `subcontractor_worker_count`, `has_tunnel_bridge`, `has_blasting`, `has_crane`, `has_high_work`, `electrical_capacity_kw`, `transformer_capacity_kva`, `safety_manager_threshold` |
+| `SPECIAL_FACILITY` / `SPECIAL` | `building_use_code`←`facility_type`, `total_floor_area`, `building_area`, `hospital_beds`, `student_count`, `worker_count` |
+
+`INDUSTRIAL` input sector → internally treated as `MANUFACTURING` in `_input_to_facility_context`.
+
+**Gap:** `facility_ctx` keys not mapped to `factories` columns (§2.1) are unavailable to `FIELD_MAP` during `evaluate_single_factory`.
+
+### Layer 2 → Layer 3
+
+```
+factories row (dict) + draft_slot groups
+  → evaluate_draft_for_facility(facility, draft_id, numeric_slots, scope_slots)
+  → (overall_status, part_id, check_results) | None
+  → facility_applicability INSERT (filtered statuses)
+
+factory_id
+  → fetch_compiler_candidates
+  → compiler dict (§3.6)
+```
+
+**`task_candidate` row** (as returned by SELECT): keys `id`, `task_type`, `source_action_family`, `obligation_family`, `applicability_status`, `status` — **no `factory_id` filter mismatch in code**; query uses `.eq("factory_id", fid)`.
+
+### Layer 3 → Layer 4
+
+```
+compiler: Dict
+  + sector_raw: str
+  + facility_ctx: Dict
+  + evaluated_at: str
+  → _compiler_result_to_step1_format
+  → result_data: Dict (§4.8)
+```
+
+Primary list driving rules: `compiler["task_candidates"]`; fallback: `compiler["applicability_candidates"]`.
+
+### Layer 4 → Layer 5
+
+```
+result_data (Dict)
+  → _partial_from_full / _build_partial → partial_result
+  → anonymous_diagnosis_results.full_result (JSONB)
+
+result_data
+  → diagnosis_transform._extract_* (read full_result)
+  → UI-facing sections (no schema mutation of stored JSON)
+```
+
+### Layer 5 → Layer 6
+
+```
+anonymous_diagnosis_results row
+  → GET handlers read partial_result / full_result
+  → optional transform/recommend-plan projection
+```
+
+---
+
+## 부록: `_input_to_facility_context` 기본 `ctx` 초기값
+
+All sectors start with zeros/empty for:
+
+`worker_count`, `total_floor_area`, `electric_capacity`, `building_use_code`, `ksic_code`, `floor_count`, `construction_amount`, `contract_amount`, `is_hazardous_material`, `is_multi_use`, `is_factory_registered`, `has_high_pressure_gas`, `has_hazardous_material`, `has_chemical_substance`, `has_boiler`, `has_tunnel_bridge`, `hospital_beds`, `student_count`, `gas_capacity_kg`, `gas_capacity_m3`, `boiler_capacity_kw`, `elevator_count`, `annual_energy_toe`
+
+---
+
+## 부록: 별도 진입 경로 (본 6-Layer Orchestration 아님)
+
+코드에 존재하나 `run_anonymous_diagnosis` 체인에 **포함되지 않음**:
+
+| Entry | Service | Output storage |
+|-------|---------|----------------|
+| `POST /legal-engine/diagnose/step1` | `legal_v510_svc.run_diagnose_step1_v510` | `factory_diagnosis_results` |
+| `POST /api/v1/diagnosis-engine/evaluate` | `DiagnosisService.evaluate` | `diagnosis_session`, `diagnosis_candidate`, … |
+
+본 문서 Layer [1]–[6]는 **`run_anonymous_diagnosis` / `run_step1_via_compiler`** 기준.
+
+---
+
+*Analysis only. No code changes.*

--- a/docs/LEGAL_ENGINE_AUDIT.md
+++ b/docs/LEGAL_ENGINE_AUDIT.md
@@ -1,0 +1,267 @@
+# 법령엔진 전체 감사 (LEGAL_ENGINE_AUDIT)
+
+> 레포: `taiengineering/tai-api`  
+> 기준 커밋: `main` (rollback PR #104 이후)  
+> 감사일: 2026-06-07  
+> 원칙: **분석만. 코드/DB 수정 없음.**  
+> DB 건수: Supabase `vwlahtguyggrhvslabax` MCP `execute_sql` 실측
+
+---
+
+## 요약
+
+소비자 진단(`/anonymous-diagnosis`, `/diagnosis/run`)은 **환경변수와 무관하게** `runtime_metadata_resolution` → `fetch_runtime_rules_as_v1` → `evaluate_facility_conditions_db` 경로를 **직접** 탄다. 해당 카탈로그 테이블의 `condition_value`는 **3,395건 중 7건(0.2%)만 채워짐** — 조건 없는 룰은 `evaluate_facility_conditions_db`에서 **입력과 무관하게 자동 적용**된다.
+
+반면 등록 API `/legal-engine/diagnose/step1`은 `fetch_diagnosis_rules`(ENV 분기) + `_check_rule_conditions`를 쓴다. **같은 제품의 step1이 경로마다 다른 룰 소스·다른 평가 함수를 사용**한다.
+
+`master_building_legal_rules` 테이블은 **DB에 존재하지 않음**(`to_regclass` → `null`). 그러나 `legal_runtime.py`, `construction_svc.py`, `public_admin.py`, `engine_qa.py` 등 **다수 경로가 여전히 이 테이블을 조회**한다.
+
+---
+
+## 1. 데이터 소스 목록
+
+| 테이블 | 용도 | 건수 (실측) | 진단용? | 읽는 파일 |
+|--------|------|-------------|---------|-----------|
+| `runtime_metadata_resolution` | 법령 카탈로그(메타데이터) | 3,395 | **소비자 step1에서 진단 소스로 사용** (주석과 모순) | `legal_runtime_fetch.py`, `diagnosis_runtime_step1.py`, `legal_engine_svc.py`(debug) |
+| `master_building_legal_rules_legacy_contaminated` | v1 진단 룰 (legacy) | 2,002 (조건코드 1,806 / 조건값 1,571) | 진단용 (의도된 v1 소스) | `legal_diagnosis_rules.py:118` (`fetch_rules_v1`) |
+| `master_building_legal_rules` | v1 진단 룰 (구명칭) | **테이블 없음** | DEAD | `legal_runtime.py:208,286`, `construction_svc.py:64`, `public_admin.py:167`, `engine_qa.py:231`, `contract_kmong.py:85`, `health.py:44`, `law_rule_generator.py` 등 |
+| `master_rule_v2` | 차세대 룰 | **0** | DEAD (플래그 켜도 빈 결과) | `legal_diagnosis_rules.py:142` |
+| `master_rule_v2_relation` | v2 관계 | (미개별 조회) | v2 부속 | `legal_diagnosis_rules.py:62` |
+| `master_rule_scope` / `master_rule_scope_mapping` / `master_rule_scope_threshold` | v2 스코프 | (미개별 조회) | v2 부속 | `legal_diagnosis_rules.py:79–101` |
+| `rule_article_mapping` | rule_id → 조문 본문 | 2,677 | 조문 enrichment | `legal_article_loader.py:73`, `legal_step1_builder.py` |
+| `rule_candidate` | 후보 룰 | 34,456 | 카탈로그/슬롯 조인 | `legal_runtime_fetch.py:105`, `diagnosis_runtime_step1.py:242` |
+| `rule_candidate_slot` | who/when/what 슬롯 | 146,595 | 카탈로그 enrichment | `diagnosis_runtime_step1.py` |
+| `facility_applicability` | 공장별 적용 draft | (미개별 조회) | factory 서브셋 필터 | `legal_runtime_fetch.py:54` |
+| `executable_draft` | draft → rule_candidate | 10,725 | factory 서브셋 필터 | `legal_runtime_fetch.py:81` |
+| `task_candidate` | 공장 task draft | — | factory 서브셋 폴백 | `legal_runtime_fetch.py:68` |
+| `law_article` | 조문 본문 | — | enrichment | `legal_article_loader.py:98`, `diagnosis_runtime_step1.py:219` |
+| `law_version` | 법령 버전 | — | enrichment | `diagnosis_runtime_step1.py` |
+| `kcsc_process_master` / `kcsc_work_master` | 건설 공정/작업 | — | step2/3 | `legal_engine_svc.py:66,154` |
+| `factory_diagnosis_results` | 진단 결과 저장 | — | 저장 | `legal_v510_svc.py`, `legal_rules.py`, `legal_runtime.py` |
+| `anonymous_diagnosis_results` | 익명/유료 진단 저장 | 6 | 저장 | `anonymous_diagnosis.py`, `diagnosis_integrated_svc.py` |
+| `factories` / `quotes` | 시설/견적 | — | apply 엔진 | `legal_runtime.py`, `legal_evaluator.py` |
+
+### A-3. 카탈로그 vs 진단
+
+| 소스 | 코드상 라벨 | 실제 역할 |
+|------|-------------|-----------|
+| `runtime_metadata_resolution` | `legal_runtime_fetch.py:1-3` **CATALOG ONLY** | 소비자 진단 **실제 소스** |
+| `master_building_legal_rules_legacy_contaminated` | `fetch_diagnosis_rules` 기본 경로 | v510/legacy step1 **의도 소스** (ENV 기본) |
+| `master_rule_v2` | `TAI_USE_V2_ENGINE` | 미구축 (0건) |
+
+### A-4. `legacy_contaminated` 사용
+
+- `legal_diagnosis_rules.fetch_rules_v1` → `master_building_legal_rules_legacy_contaminated` (```118:130:services/legal_diagnosis_rules.py```)
+- `diagnosis_rule_source_label()` 기본 반환값은 `master_building_legal_rules:v1` 이지만 실제 읽는 테이블은 `_legacy_contaminated` (```29:35:services/legal_diagnosis_rules.py```)
+
+### A-5. ENV 분기 (`fetch_diagnosis_rules`만 해당)
+
+| `TAI_USE_RUNTIME_ENGINE` | `TAI_USE_V2_ENGINE` | 읽는 테이블 |
+|--------------------------|---------------------|-------------|
+| `true` | (무시) | `runtime_metadata_resolution` |
+| `false` | `true` | `master_rule_v2` (+ relation/scope) |
+| `false` | `false` (기본) | `master_building_legal_rules_legacy_contaminated` |
+
+**주의:** 소비자 경로(`run_diagnose_step1_runtime`)는 `fetch_diagnosis_rules`를 **호출하지 않음** → ENV **무시**.
+
+### `runtime_metadata_resolution` 조건 필드 실측
+
+| 지표 | 값 |
+|------|-----|
+| 전체 행 | 3,395 |
+| `condition_value` 비어있지 않음 | **7 (0.2%)** |
+| `condition_status = RESOLVED` | 2,886 |
+| `condition_status = UNRESOLVED` | 441 |
+| `condition_status = PARTIAL` | 68 |
+
+`condition_status`가 RESOLVED여도 `condition_value`가 비어 있는 경우가 대다수 → **상태 필드 신뢰 불가**.
+
+`rule_article_mapping`과 `runtime_metadata_resolution.id` 조인: **0건** (metadata UUID는 mapping `rule_id`와 불일치).
+
+---
+
+## 2. 진입 경로 목록
+
+| API | Registry | 함수 체인 | 룰 소스 | ENV 분기 |
+|-----|----------|-----------|---------|----------|
+| `POST /anonymous-diagnosis` | `router_registry/public.py` → `anonymous_diagnosis` | `create_anonymous_diagnosis` → `_run_step1_via_service` → `run_diagnose_step1_runtime` → `fetch_runtime_rules_as_v1` → `evaluate_facility_conditions_db` | `runtime_metadata_resolution` | **없음** |
+| `POST /diagnosis/run` | `router_registry/diagnosis.py` → `diagnosis_integrated` | `run_diagnosis` → `_run_step1_via_service` → (동일) | `runtime_metadata_resolution` | **없음** |
+| `POST /legal-engine/diagnose/step1` | `router_registry/legal_engine.py` → `legal_engine` | `run_diagnose_step1_v510` → `fetch_diagnosis_rules` → `_evaluate_conditions`(`_check_rule_conditions`) | ENV 의존 (기본: `legacy_contaminated`) | **있음** |
+| `POST /legal-engine/diagnose/step2` | `legal_engine` | `run_diagnose_step2` → `fetch_diagnosis_rules` → `_evaluate_condition` | ENV 의존 | **있음** |
+| `POST /legal-engine/diagnose/step3` | `legal_engine` | `run_diagnose_step3` → `fetch_diagnosis_rules` → `_evaluate_condition` | ENV 의존 | **있음** |
+| `POST /legal-engine/apply/{factory_id}` | `legal_engine` | `run_apply_engine` → `master_building_legal_rules` 직접 조회 | **존재하지 않는 테이블** | 없음 |
+| `POST /legal-engine/apply-quote/{quote_id}` | `legal_engine` | `run_apply_quote` → `master_building_legal_rules` | **존재하지 않는 테이블** | 없음 |
+| `POST /admin/public-diagnosis-requests/{id}/run-diagnosis` | `public_admin` | `_input_to_facility_context` → `master_building_legal_rules` → `evaluate_facility_conditions_db` | **존재하지 않는 테이블** | 없음 |
+| 건설 모듈 `construction_svc.run_diagnosis` | `router_registry/construction` | `master_building_legal_rules` → `evaluate_facility_conditions_db` | **존재하지 않는 테이블** | 없음 |
+| `engine_qa` 테스트 실행 | `legal_engine` | `master_building_legal_rules` → `evaluate_facility_conditions_db` | **존재하지 않는 테이블** | 없음 |
+
+### B-5. 룰 소스 일치 여부
+
+| 경로 그룹 | 룰 소스 | 평가 함수 |
+|-----------|---------|-----------|
+| 소비자 (anonymous + diagnosis/run) | `runtime_metadata_resolution` | `evaluate_facility_conditions_db` |
+| v510 step1 (legal-engine) | `fetch_diagnosis_rules` (기본 legacy) | `_check_rule_conditions` |
+| apply/quote/public-admin/construction/QA | `master_building_legal_rules` (없음) | `_evaluate_conditions` 또는 `evaluate_facility_conditions_db` |
+
+**결론: 경로마다 룰 소스·평가기가 모두 다름.**
+
+### B-6. ENV 조합 (`fetch_diagnosis_rules` 경로만)
+
+| # | RUNTIME | V2 | 결과 |
+|---|---------|-----|------|
+| 1 | `false` | `false` | legacy_contaminated 2,002건, 조건값 78% |
+| 2 | `true` | * | runtime 3,395건, 조건값 0.2% |
+| 3 | `false` | `true` | master_rule_v2 **0건** → 빈 진단 |
+| 4 | `true` | `true` | RUNTIME 우선 → runtime (V2 무시) |
+
+소비자 경로는 항상 #2와 동일 소스이나, 평가 함수는 v510의 `_check_rule_conditions`가 아니라 `evaluate_facility_conditions_db`를 사용 → **#2와도 결과 불일치**.
+
+### 미등록 라우터
+
+`routers/legal_engine_v510.py` — `POST /legal-engine/diagnose/step1` **중복 정의**이나 `router_registry`에 **미등록** → 런타임 미노출.
+
+---
+
+## 3. 조건 평가 함수 비교
+
+| 함수 | alias? | 스키마 | 호출자 | 결과 차이 |
+|------|--------|--------|--------|-------------|
+| `_db_rule_matches_facility` | **있음** (`CONDITION_CODE_TO_CONTEXT_KEY`, `legal_rules.py:18-38`) | `condition_code` + `condition_value` | `evaluate_facility_conditions_db` → 소비자 step1, contract_kmong, construction_svc, public_admin, engine_qa | 기준 |
+| `_check_rule_conditions` | **없음** — `context[condition_code]` 직접 조회 (`legal_rules.py:64-100`) | `condition_code` + `condition_value` | `legal_v510_svc` step1 (`_evaluate_conditions`), step2 (`_evaluate_step2_rule`), `legal_runtime` apply | **alias 미적용** — `employee_count` 룰 + `worker_count`만 있는 context → False |
+| `_evaluate_condition` | **없음** — `condition_1_field` 등 별도 필드 (`legal_rules.py:237-278`) | v1 extended 필드 | `legal_engine_svc` step2/3, `legal_runtime` process/equipment | **스키마 자체가 다름** — legacy/v2 adapted 룰과 projection 룰에서 필드 부재 시 **무조건 True** (필드 없으면 `return True`, `:239-240`) |
+
+### C-4 / C-5. 구체적 불일치 사례
+
+**사례 1 — alias (`employee_count` vs `worker_count`)**
+
+- 룰: `condition_code=employee_count`, `condition_value=50`
+- context: `{worker_count: 60}` (employee_count 키 없음)
+- `_db_rule_matches_facility`: alias → **True**
+- `_check_rule_conditions`: `context.get("employee_count")` → None → **False**
+
+**사례 2 — 조건 없는 룰 (runtime projection)**
+
+- `project_metadata_to_v1` 기본: `condition_code=""`, `condition_value=None` (`rule_candidate_projection.py:115-116`)
+- `_apply_runtime_condition`은 DB `condition_value` 텍스트 파싱 — **7건만 해당**
+- `evaluate_facility_conditions_db`: `not cc or cv is None` → **비건설 섹터는 무조건 applicable** (`legal_rules.py:174-191`)
+- `_check_rule_conditions`: `not cc` → **True** (동일하게 무조건 통과)
+- **입력 변경해도 applicable_count 거의 불변** (3,388+ 룰)
+
+**사례 3 — step2/3 `_evaluate_condition`**
+
+- projection 룰에 `condition_1_field` 없음 → `check()`가 필드 부재 시 **True** 반환
+- step2/3에서 **전 룰 매칭** 가능
+
+**사례 4 — v510 미사용 평가기**
+
+- `legal_v510_helpers._evaluate_facility_conditions_db_v510` 정의됨 (`legal_v510_helpers.py:146-169`)
+- `legal_v510_svc.run_diagnose_step1_v510`는 `_evaluate_conditions`(→ `_check_rule_conditions`) 사용 (`legal_v510_svc.py:130-132`) — **v510 전용 평가기 미사용**
+
+**사례 5 — 건설 임계값**
+
+- `legal_context` / `legal_rules.get_construction_summary`: `get_construction_amount_threshold` — 건축 150억, 토목 120억 (`legal_helpers.py:30-35,96-97`)
+- `legal_v510_helpers._get_construction_summary`: `BUILDING`/`SPECIALTY` → 150억, 그 외 120억 하드코드 (`legal_v510_helpers.py:104-105`) — `건축`/`토목` 한글 키와 **불일치 가능**
+
+### 입력 정규화 경로 차이 (D-2)
+
+| 경로 | 입력 변환 |
+|------|-----------|
+| 소비자 | `_input_to_facility_context` only |
+| v510 step1 | `_input_to_facility_context_v510` + `normalize_input` (`input_normalizer._ensure_condition_code_keys`) |
+
+v510만 `electric_capacity` ↔ `electrical_capacity_kw` 등 **condition_code 키 보장** (`input_normalizer.py:89-111`). 소비자 경로에는 없음.
+
+---
+
+## 4. 발견 목록
+
+| 번호 | 심각도 | 위치 | 설명 | 증상 |
+|------|--------|------|------|------|
+| F-001 | **CRITICAL** | DB `runtime_metadata_resolution`; `legal_runtime_fetch.py:48-49` | `condition_value` 3,395건 중 **7건(0.2%)**만 존재. projection 후 대부분 `condition_code=""` | 입력(면적·인원·공사금) 변경해도 applicable 룰 수 거의 동일 |
+| F-002 | **CRITICAL** | `legal_runtime_fetch.py:1-3`; `diagnosis_runtime_step1.py:413-418` | **CATALOG ONLY — NOT DIAGNOSIS SOURCE** 주석(2026-05-31)과 달리 소비자 진단이 직접 사용 | 아키텍처 의도와 운영 실태 불일치; 카탈로그 품질이 곧 서비스 품질 |
+| F-003 | **HIGH** | DB `master_rule_v2`; `legal_diagnosis_rules.py:142-174` | 차세대 룰 **0건**. `TAI_USE_V2_ENGINE=true` 시 빈 룰셋 | v2 플래그 활성화 시 진단 결과 0건 |
+| F-004 | **CRITICAL** | `diagnosis_runtime_step1.py:413-418`; `anonymous_diagnosis.py:79-83`; `diagnosis_integrated.py:75-79` | 소비자 경로가 `fetch_diagnosis_rules`·ENV **완전 우회**, 항상 `fetch_runtime_rules_as_v1` | Railway에서 ENV 바꿔도 무료/유료 진단 결과 동일 소스 |
+| F-005 | **CRITICAL** | DB `to_regclass('master_building_legal_rules')` = null; `legal_runtime.py:208,286`, `construction_svc.py:64`, `public_admin.py:167`, `engine_qa.py:231` | **삭제된 테이블**을 apply/건설/관리자/QA가 조회 | 해당 API 호출 시 빈 룰 또는 DB 오류; apply 엔진 무력화 |
+| F-006 | **HIGH** | DB: RESOLVED 2,886건 vs `condition_value` 7건 | `condition_status=RESOLVED`와 실제 조건값 공백 **불일치** | 메타데이터 파이프라인 품질 지표 신뢰 불가 |
+| F-007 | **HIGH** | `diagnosis_runtime_step1.py:456` vs `legal_v510_svc.py:130-132` | 소비자=`evaluate_facility_conditions_db`, v510=`_check_rule_conditions` — **등록 step1과 소비자 step1 평가기 상이** | 동일 입력·섹터라도 API별 applicable 수·목록 상이 |
+| F-008 | **HIGH** | `legal_rules.py:64-100,149-164,237-278` | 3개 평가 함수 — alias·스키마·무조건통과 규칙 **전부 다름** | step1/2/3·apply·소비자 간 교차 검증 불가 |
+| F-009 | **HIGH** | `rule_candidate_projection.py:94`; `legal_article_loader.py:73`; DB 조인 0건 | runtime `rule_id` = metadata UUID, `rule_article_mapping.rule_id`와 **0건 매칭** | step1 조문 본문 enrichment 실패; `article_mapping_stats` 부정확 |
+| F-010 | **MEDIUM** | `legal_diagnosis_rules.py:35,118` | 라벨 `master_building_legal_rules:v1` vs 실제 `*_legacy_contaminated` | `rule_version`·감사 추적 혼란 |
+| F-011 | **MEDIUM** | `routers/legal_engine_v510.py` | `/legal-engine/diagnose/step1` 중복 라우터 **미등록** | dead code; 문서/테스트와 프로덕션 경로 혼동 |
+| F-012 | **MEDIUM** | `legal_v510_helpers.py:146-169` vs `legal_v510_svc.py:132` | `_evaluate_facility_conditions_db_v510` **정의만 있고 미호출** | v510 전용 건설 필터 로직 미적용 |
+| F-013 | **MEDIUM** | `legal_diagnosis_rules.py:146-152`; `legal_runtime_fetch.py:117-120`; `legal_runtime.py:144,268-273` 등 | `except Exception: pass/continue` 다수 — DB·조회 실패 **삼킴** | 빈 enrichment·저장 실패가 silent; 사용자는 성공 응답 |
+| F-014 | **LOW** | `legal_engine_svc.py:74,174,353,360`; `legal_runtime.py:93,128,269,273,300`; `legal_article_loader.py:80,110` 등 | 프로덕션 경로에 `print()` 디버그 잔존 | 로그 오염; 구조화 로깅 미사용 |
+| F-015 | **LOW** | `services/legal_v510_svc.py.bak` | `.bak` 파일 존재 | 유지보수 혼란 |
+| F-016 | **LOW** | `legal_engine_svc.py:326-334` | `run_diagnose_step1_endpoint` — **호출처 없음** | dead code |
+| F-017 | **MEDIUM** | `legal_v510_helpers.py:104-105` vs `legal_helpers.py:30-35` | 건설 금액 임계값 — v510 helper 하드코드 vs `get_construction_amount_threshold` | `construction_summary.safety_manager_required` API별 상이 |
+| F-018 | **MEDIUM** | `legal_runtime_fetch.py:20`; `legal_diagnosis_rules.py:22` | Railway 프로덕션 ENV 값 **미확인** (MCP/Railway 접근 불가). 코드 기본값 둘 다 `false` | 운영에서 실제 분기 상태 불명; verification 스크립트는 `TAI_USE_RUNTIME_ENGINE=false` 강제 |
+| F-019 | **HIGH** | `evaluate_facility_conditions_db` `legal_rules.py:174-191` | 조건 없는 룰 = **class C auto-applicable** (비건설 전 섹터 무조건 통과) | runtime 3,395건 중 ~99.8%가 입력 무관 적용; “진단”이 “카탈로그 나열”에 가까움 |
+| F-020 | **MEDIUM** | `anonymous_diagnosis.py:64-67` vs `legal_context.py:103-104` | sector 정규화: anonymous는 MANUFACTURING→INDUSTRIAL **저장 변환**, 엔진은 INDUSTRIAL→MANUFACTURING **판정 변환** | 저장 sector와 엔진 sector 이중 변환; 추적 시 혼란 |
+
+---
+
+## 5. 권장 수정 순서
+
+> **수정은 본 감사 범위 외.** 의존성·리스크 기준 우선순위만 제시.
+
+1. **F-004 + F-001 + F-002 + F-019 (소비자 경로 룰 소스)**  
+   소비자 진단이 어떤 테이블을 써야 하는지 단일 결정. `legacy_contaminated`(조건 78%) vs runtime(0.2%) vs v2(0건) 중 선택 전까지 **서비스 품질 보장 불가**.
+
+2. **F-005 (ghost table `master_building_legal_rules`)**  
+   apply/건설/QA/health 전역을 `legacy_contaminated` 또는 통합 뷰로 정렬. 현재는 런타임 오류 또는 0건.
+
+3. **F-007 + F-008 (평가기 단일화)**  
+   step1 전 경로에서 하나의 평가 함수 + alias 정책 확정. `input_normalizer` 적용 범위 통일.
+
+4. **F-003 (master_rule_v2)**  
+   v2 플래그를 켜기 전 데이터 적재 또는 플래그 비활성화 문서화.
+
+5. **F-009 (rule_id / article mapping)**  
+   runtime UUID ↔ mapping 키 체계 정합. enrichment 경로 재설계.
+
+6. **F-006 (metadata 품질)**  
+   `condition_status`와 `condition_value` 정합성. RESOLVED인데 값 없는 2,886건 재처리.
+
+7. **F-010, F-011, F-012, F-015, F-016 (정리)**  
+   라벨 정정, 미등록 라우터/.bak/dead function 제거.
+
+8. **F-013, F-014 (운영 품질)**  
+   예외 삼킴 → 로깅/실패 전파; `print` → structured log.
+
+9. **F-018 (ENV)**  
+   Railway 실측 후 `TAI_USE_*` 조합 문서화 및 소비자 경로와의 관계 명시.
+
+---
+
+## 부록: ENV 플래그 전체
+
+| 변수 | 읽는 위치 | 기본값 | True 시 | False 시 |
+|------|-----------|--------|---------|----------|
+| `TAI_USE_RUNTIME_ENGINE` | `legal_runtime_fetch.py:20`, `legal_diagnosis_rules.py:13` | `false` | `fetch_diagnosis_rules` → runtime | legacy_contaminated (V2 false일 때) |
+| `TAI_USE_V2_ENGINE` | `legal_diagnosis_rules.py:22` | `false` | RUNTIME false일 때 v2 | legacy_contaminated |
+
+**소비자 경로:** 위 플래그 **미참조**.
+
+**Railway 실제 값:** 본 감사 시점 MCP로 **확인 불가** (코드 기본값 `false`/`false` → v510 기본은 `legacy_contaminated`).
+
+---
+
+## 부록: 감사 대상 파일 체크리스트
+
+| 파일 | 감사 완료 | 비고 |
+|------|-----------|------|
+| `diagnosis_runtime_step1.py` | ✓ | 소비자 메인 |
+| `diagnosis_integrated_svc.py` | ✓ | persist only |
+| `legal_runtime_fetch.py` | ✓ | CATALOG 주석 |
+| `rule_candidate_projection.py` | ✓ | 조건 projection |
+| `legal_diagnosis_rules.py` | ✓ | ENV 분기 |
+| `legal_rules.py` | ✓ | 3 evaluators |
+| `legal_v510_svc.py` | ✓ | v510 step1/2 |
+| `legal_engine_svc.py` | ✓ | step2/3, apply |
+| `legal_runtime.py` | ✓ | ghost table |
+| `legal_context.py` | ✓ | facility_ctx |
+| `input_normalizer.py` | ✓ | v510 only |
+| `legal_evaluator.py` | ✓ | 결과 조회·inspection_sets |
+| `legal_v510_svc.py.bak` | ✓ | E-2 |
+
+관련 선행 문서: `docs/PIPELINE_TRACE.md`, `docs/WORKORDER_LEGAL_ENGINE_AUDIT.md`

--- a/docs/PIPELINE_TRACE.md
+++ b/docs/PIPELINE_TRACE.md
@@ -1,0 +1,347 @@
+# PIPELINE_TRACE — 법령진단 소비자 파이프라인 (tai-api)
+
+> 기준 커밋: main `cb5af3f` (rollback 후)  
+> 분석일: 2026-06-08  
+> 작업지시: `docs/WORKORDER_PIPELINE_TRACE.md`
+
+---
+
+## 1. Executive summary
+
+| 항목 | 무료 익명 (`/anonymous-diagnosis`) | 유료 통합 (`/diagnosis/run`) | 등록 API (`legal_engine` / v510) |
+|---|---|---|---|
+| Step1 함수 | `run_diagnose_step1_runtime` | `run_diagnose_step1_runtime` | `run_diagnose_step1_v510` → `fetch_diagnosis_rules` |
+| Rule 소스 | **`runtime_metadata_resolution`** (직접) | 동일 | **env 분기** (runtime / v2 / legacy) |
+| `master_building_legal_rules` | **미사용** | **미사용** | env off 시 `legacy_contaminated` |
+| `master_rule_v2` | **미사용** | **미사용** | `TAI_USE_V2_ENGINE=true` 시 |
+| `_archive/` import | **없음** | **없음** | **없음** |
+| 결과 저장 | `anonymous_diagnosis_results` | `anonymous_diagnosis_results` (+ auth/disclaimer 테이블) | 응답만 (경로별 상이) |
+
+**핵심:** 프로덕션 무료·유료 Nexas 소비자 경로는 **환경변수와 무관하게** `runtime_metadata_resolution`만 읽는다.  
+`fetch_diagnosis_rules()`의 env 분기는 **v510/legacy API·검증 스크립트** 경로에만 적용.
+
+---
+
+## 2. 파이프라인 다이어그램 (무료 익명 — primary consumer)
+
+```mermaid
+flowchart TD
+  A[POST /anonymous-diagnosis] --> B[anonymous_diagnosis.create_anonymous_diagnosis]
+  B --> C[_build_step1_body]
+  C --> D[DiagnoseStep1Body]
+  D --> E[_run_step1_via_service]
+  E --> F[run_diagnose_step1_runtime]
+  F --> G[fetch_runtime_rules_as_v1]
+  G --> H[(runtime_metadata_resolution)]
+  G --> I[project_metadata_batch]
+  I --> J[_input_to_facility_context]
+  J --> K[evaluate_facility_conditions_db]
+  K --> L[build_step1_result_data]
+  L --> M[_enrich_result_data_slots]
+  M --> N[(rule_candidate_slot / law_article ...)]
+  L --> O[_partial_from_full]
+  O --> P[(anonymous_diagnosis_results INSERT)]
+  P --> Q[JSON response publicToken + partialResult]
+```
+
+---
+
+## 3. 단계별 추적 (무료 익명)
+
+### Step 0 — HTTP 진입
+
+| | |
+|---|---|
+| **Endpoint** | `POST /anonymous-diagnosis` |
+| **File** | `routers/anonymous_diagnosis.py` |
+| **Handler** | `create_anonymous_diagnosis(body: AnonymousDiagnosisCreate)` |
+| **Registry** | `router_registry/public.py` → `routers.anonymous_diagnosis` |
+| **Input** | `{ site_kind, scale, workers, region? }` |
+| **Output** | `{ status, publicToken, partialResult, hasFullResult, expiresAt }` |
+
+### Step 1 — 요청 → DiagnoseStep1Body 변환
+
+| | |
+|---|---|
+| **Function** | `_build_step1_body(body)` |
+| **File** | `routers/anonymous_diagnosis.py` |
+| **Mapping** | `site_kind` → `sector` (`SECTOR_BY_KIND`) |
+| | `scale` → `SCALE_PRESETS` (floor_area, total_floor_area, contract_amount_eok) |
+| | `workers` → `worker_count` + `employee_count` (BUILDING/MANUFACTURING) |
+| | `workers` → `direct_workers` (CONSTRUCTION) |
+| **Output type** | `schemas.legal_engine.DiagnoseStep1Body` |
+
+**sector 매핑**
+
+| site_kind | DiagnoseStep1Body.sector | 표시 정규화 (`_SECTOR_NORMALIZE`) |
+|---|---|---|
+| construction | CONSTRUCTION | — |
+| manufacturing | MANUFACTURING | → INDUSTRIAL (watch/trace용) |
+| building | BUILDING | — |
+| other | SPECIAL_FACILITY | → BUILDING |
+
+### Step 2 — Step1 엔진 실행
+
+| | |
+|---|---|
+| **Function** | `_run_step1_via_service` → `run_diagnose_step1_runtime` |
+| **File** | `services/diagnosis_runtime_step1.py` |
+| **Input** | `DiagnoseStep1Body`, `allowed_sectors` |
+| **Sub-steps** | see §4 |
+
+### Step 3 — 결과 축약 + 영속화
+
+| | |
+|---|---|
+| **Function** | `_partial_from_full(full_result)` |
+| **Input** | step1 `result_data` (full) |
+| **Output** | `partial_result` (rules_preview ≤12, key_obligations ≤6) |
+| **DB** | `anonymous_diagnosis_results` INSERT |
+| **Columns** | `public_token`, `input_data`, `partial_result`, `full_result`, `engine_version`, `rule_version`, `expires_at`, `status`, `source_type` |
+
+**저장 메타**
+
+- `engine_version`: `v3.0-runtime-compiler` (`RUNTIME_ENGINE_VERSION`)
+- `rule_version`: `runtime_metadata_resolution:v1`
+
+---
+
+## 4. Step1 내부 단계 (`run_diagnose_step1_runtime`)
+
+### 4.1 Rule fetch (소스 확정)
+
+| | |
+|---|---|
+| **Function** | `fetch_runtime_rules_as_v1` |
+| **File** | `services/legal_runtime_fetch.py` |
+| **호출 방식** | `run_diagnose_step1_runtime`에서 **직접 호출** (`fetch_diagnosis_rules` 우회) |
+| **env 영향** | **없음** (`TAI_USE_RUNTIME_ENGINE` 미참조) |
+
+**DB read chain**
+
+| 순서 | Table | 함수 | 용도 |
+|---|---|---|---|
+| 1 | `runtime_metadata_resolution` | `fetch_runtime_metadata_rows` | 전체 metadata 페이지네이션 (`*`) |
+| 2a | `facility_applicability` | `_factory_rule_candidate_ids` | factory_id 있을 때 draft 서브셋 |
+| 2b | `task_candidate` | ↑ | fallback draft |
+| 2c | `executable_draft` | ↑ | `rule_candidate_id` |
+| 2d | `rule_candidate` | `_metadata_for_factory` | `article_id` |
+| 2e | `law_article` | ↑ | law_name + article_no 매칭 |
+| 3 | — | `project_metadata_batch` | v1 호환 dict 투영 |
+| 4 | — | `filter_runtime_for_sector` | sector 필터 |
+| 5 | — | `diagnosis_stage==1` 필터 | stage1만 |
+
+**미사용 (이 경로)**
+
+- `master_building_legal_rules`
+- `master_building_legal_rules_legacy_contaminated`
+- `master_rule_v2`
+
+### 4.2 Projection
+
+| | |
+|---|---|
+| **Function** | `project_metadata_to_v1` / `project_metadata_batch` |
+| **File** | `services/rule_candidate_projection.py` |
+| **Input** | `runtime_metadata_resolution` row |
+| **Output** | v1 호환 rule dict (`rule_id` = metadata `id`, `obligation_summary`, flags, `condition_code`/`condition_value`, …) |
+| **condition 파생** | `_apply_runtime_condition` — `condition_value` 텍스트에서 `employee_count`/`building_area`/… 추출 |
+
+### 4.3 Facility context
+
+| | |
+|---|---|
+| **Function** | `_input_to_facility_context(sector_raw, inp)` |
+| **File** | `services/legal_context.py` |
+| **Input** | `DiagnoseStep1Body` flat fields + `body.input` dict 병합 |
+| **Output** | `facility_ctx` (`worker_count`, `total_floor_area`, `construction_amount`, …) |
+
+**필드 병합** (`run_diagnose_step1_runtime` 420–452행): body top-level 필드가 `inp`에 없으면 주입.
+
+### 4.4 Rule matching
+
+| | |
+|---|---|
+| **Function** | `evaluate_facility_conditions_db(facility_ctx, all_rules, sector_raw)` |
+| **File** | `services/legal_rules.py` |
+| **Logic** | `condition_code` 없음 → sector/law 휴리스틱 적용 |
+| | `condition_code` 있음 → `_db_rule_matches_facility` |
+| **매핑** | `CONDITION_CODE_TO_CONTEXT_KEY`: `employee_count` → **`worker_count`** |
+
+### 4.5 Result build
+
+| | |
+|---|---|
+| **Function** | `build_step1_result_data` |
+| **File** | `services/legal_step1_builder.py` |
+| **Input** | applicable / not_applicable lists |
+| **Helpers** | `_classify_rules_db`, `format_rule_result_db`, `risk_level`, `get_construction_summary` |
+| **Article enrich** | `fetch_article_contexts` → `rule_article_mapping`, `law_article` |
+| **Output keys** | `rules_table`, `appointment_required`, `inspection_required`, `key_obligations`, `risk_level`, `applicable_count`, `law_badges`, `construction_summary`, … |
+
+### 4.6 Slot enrichment (post-build)
+
+| | |
+|---|---|
+| **Function** | `_enrich_result_data_slots` → `enrich_rules_with_candidate_slots` |
+| **File** | `services/diagnosis_runtime_step1.py` |
+| **DB** | `runtime_metadata_resolution` (who/when/how), `law_master`, `law_version`, `law_article`, `rule_candidate`, `rule_candidate_slot` |
+| **목적** | rules_table에 `who`/`what`/`when` 주입 |
+
+---
+
+## 5. 유료 통합 경로 (`POST /diagnosis/run`)
+
+| | |
+|---|---|
+| **Router** | `routers/diagnosis_integrated.py` → `run_diagnosis` |
+| **Adapter** | `nexas_run_body_from_request` → `DiagnosisRunBody` → `DiagnoseStep1Body` |
+| **Step1** | `_run_step1_via_service` → **`run_diagnose_step1_runtime`** (무료와 동일) |
+| **Persist** | `services/diagnosis_integrated_svc.run_diagnosis` → `anonymous_diagnosis_results` |
+| **부가 DB** | `diagnosis_auth_log`, `diagnosis_disclaimer_log`, `diagnosis_purchases`, `inicis_auth_requests`, `factories` (binding) |
+
+Rule 소스·matcher·builder: **§4와 동일**.
+
+---
+
+## 6. 대체 경로 (등록 API — 소비자 외 / 레거시)
+
+| Endpoint | Step1 | Rule fetch |
+|---|---|---|
+| `routers/legal_engine.py` | `run_diagnose_step1_v510` | `fetch_diagnosis_rules` |
+| `routers/legal_engine_v510.py` | 동일 | 동일 |
+| `services/legal_engine_svc.run_diagnose_step1` | legacy wrapper | `fetch_diagnosis_rules` |
+
+### `fetch_diagnosis_rules` 분기 (`services/legal_diagnosis_rules.py`)
+
+| env | 소스 table | 함수 |
+|---|---|---|
+| `TAI_USE_RUNTIME_ENGINE=true` | `runtime_metadata_resolution` | `fetch_runtime_rules_as_v1` |
+| `TAI_USE_V2_ENGINE=true` | `master_rule_v2` (+ relation/scope tables) | `fetch_rules_v2_as_v1` |
+| **default (둘 다 false)** | **`master_building_legal_rules_legacy_contaminated`** | `fetch_rules_v1` |
+
+> 주의: fallback 라벨은 `master_building_legal_rules:v1`이지만 **실제 쿼리 테이블은 `*_legacy_contaminated`**.
+
+**지원 테이블 (v2 경로만):** `master_rule_v2`, `master_rule_v2_relation`, `master_rule_scope_mapping`, `master_rule_scope`, `master_rule_scope_threshold`
+
+---
+
+## 7. 필수 확인 4항
+
+### 7.1 `legacy_contaminated` 참조
+
+| 경로 | 참조 여부 |
+|---|---|
+| `POST /anonymous-diagnosis` | **없음** |
+| `POST /diagnosis/run` | **없음** |
+| `fetch_diagnosis_rules` (env default) | **있음** — `master_building_legal_rules_legacy_contaminated` |
+| `verification/*` (audit scripts) | **있음** — 검증 전용 |
+
+### 7.2 `_archive/` import
+
+```
+grep -r "from _archive\|import _archive" tai-api/**/*.py → 0건 (진단 경로)
+```
+
+격리 라우터는 `routers/` 밖 `_archive/routers_20260608/`에만 존재. **진단 파이프라인 import 없음.**
+
+### 7.3 Rule table — 실제 읽는 소스
+
+| Consumer path | 읽는 소스 |
+|---|---|
+| **무료·유료 Nexas (primary)** | `runtime_metadata_resolution` only |
+| v510 API (env runtime) | `runtime_metadata_resolution` |
+| v510 API (env v2) | `master_rule_v2` |
+| v510 API (env default) | `master_building_legal_rules_legacy_contaminated` |
+| `master_building_legal_rules` (비 contaminated) | inspection_sets, law_collector, health probe 등 **타 도메인** — **진단 step1 소비자 경로 아님** |
+
+### 7.4 인터페이스 불일치 (필드명·타입)
+
+| 구간 | 불일치 | 영향 |
+|---|---|---|
+| API → Step1Body | `workers` → `worker_count` + `employee_count` | 의도적 이중 설정; matcher는 `worker_count` 사용 |
+| sector 표준 | 입력 `MANUFACTURING` vs 저장 표시 `INDUSTRIAL` (`_SECTOR_NORMALIZE`) | DB `input_data.sector`는 full_result 기준 |
+| sector 표준 | `legal_context`: `INDUSTRIAL` → `MANUFACTURING` 정규화 | 유료 API `INDUSTRIAL` 진입 시 context 정상화 |
+| Rule `rule_id` | runtime path: metadata UUID | `rule_article_mapping` 조인 실패 가능 (본문 enrich skip) |
+| condition_code | projection: `employee_count` | matcher: `CONDITION_CODE_TO_CONTEXT_KEY` → `worker_count` | **의도적 브릿지** — anonymous는 양쪽 동일값 설정으로 OK |
+| condition 누락 | runtime row에 `condition_value` 없으면 `condition_code=""` | `evaluate_facility_conditions_db` class C (무조건 적용) |
+| `uploads` vs registry | N/A | 진단 경로 무관 |
+
+**이전 검증에서 확인된 함정 (T-W / T-F01):**  
+`worker_count`·`total_floor_area` 입력 변경이 **class C rule (condition 없음) 3394건**에는 영향 없음.  
+조건부 rule은 runtime projection의 `employee_count` 1건뿐 — 입력이 `worker_count`로 매핑되면 매칭됨.
+
+---
+
+## 8. DB 테이블 — 진단 소비자 경로 전체
+
+| Table | 단계 | Read/Write |
+|---|---|---|
+| `runtime_metadata_resolution` | rule fetch, slot fallback | R |
+| `facility_applicability` | factory subset | R |
+| `task_candidate` | factory subset | R |
+| `executable_draft` | factory subset | R |
+| `rule_candidate` | factory/article/slot chain | R |
+| `law_master` | slot enrich | R |
+| `law_version` | slot enrich | R |
+| `law_article` | factory narrow / slot enrich / article loader | R |
+| `rule_candidate_slot` | slot enrich | R |
+| `rule_article_mapping` | article context | R |
+| `anonymous_diagnosis_results` | persist | W |
+| `diagnosis_auth_log` | 유료 auth | R/W |
+| `diagnosis_disclaimer_log` | 유료 disclaimer | R/W |
+| `diagnosis_purchases` | 유료 결제 | W |
+| `factories` | 유료 company binding | R |
+
+---
+
+## 9. 함수 인덱스 (호출 순)
+
+```
+create_anonymous_diagnosis
+  └ _build_step1_body
+  └ _run_step1_via_service
+       └ run_diagnose_step1_runtime          [diagnosis_runtime_step1.py]
+            ├ fetch_runtime_rules_as_v1      [legal_runtime_fetch.py]
+            │    ├ fetch_runtime_metadata_rows
+            │    ├ _metadata_for_factory (optional)
+            │    ├ project_metadata_batch    [rule_candidate_projection.py]
+            │    └ filter_runtime_for_sector
+            ├ normalize_sector_db / get_sector_groups
+            ├ _input_to_facility_context     [legal_context.py]
+            ├ evaluate_facility_conditions_db [legal_rules.py]
+            ├ build_step1_result_data        [legal_step1_builder.py]
+            │    └ fetch_article_contexts    [legal_article_loader.py]
+            └ _enrich_result_data_slots
+                 └ enrich_rules_with_candidate_slots
+  └ _partial_from_full
+  └ anonymous_diagnosis_results.insert
+```
+
+---
+
+## 10. 결론 · 다음 세션 공유 포인트
+
+1. **소비자 파이프라인(무료·유료)은 단일 소스:** `runtime_metadata_resolution` — env 무관, hardcoded runtime path.
+2. **`master_building_legal_rules` / `legacy_contaminated` / `master_rule_v2`는 v510·legacy API 분기에서만** — Nexas 소비자와 분리됨.
+3. **`_archive/` 격리 코드는 진단 import 없음** — 라우터 격리가 엔진에 영향 없음.
+4. **인터페이스 리스크:** `rule_id`(metadata UUID) ↔ `rule_article_mapping` 불일치로 조문 본문 enrich가 частич skip될 수 있음.
+5. **등록/폐기 결정은 별도** — 본 문서는 추적만, 변경 없음.
+
+---
+
+## Appendix — 관련 파일
+
+| 역할 | Path |
+|---|---|
+| 무료 router | `routers/anonymous_diagnosis.py` |
+| 유료 router | `routers/diagnosis_integrated.py` |
+| Runtime step1 | `services/diagnosis_runtime_step1.py` |
+| Rule fetch | `services/legal_runtime_fetch.py` |
+| Projection | `services/rule_candidate_projection.py` |
+| Env 분기 (비소비자) | `services/legal_diagnosis_rules.py` |
+| Context | `services/legal_context.py` |
+| Matcher | `services/legal_rules.py` |
+| Builder | `services/legal_step1_builder.py` |
+| Article loader | `services/legal_article_loader.py` |
+| v510 path | `services/legal_v510_svc.py`, `routers/legal_engine.py` |

--- a/routers/anonymous_diagnosis.py
+++ b/routers/anonymous_diagnosis.py
@@ -23,6 +23,7 @@ from schemas.legal_engine import DiagnoseStep1Body
 from services.anonymous_factory_service import (
     ANONYMOUS_COMPILER_ENGINE_VERSION,
     RULE_VERSION_COMPILER,
+    prepare_step1_body_for_compiler,
     run_anonymous_diagnosis,
 )
 from services.legal_helpers import _now_iso
@@ -76,6 +77,7 @@ def _now() -> datetime:
 
 
 def _run_step1_via_service(supabase, step1_body: DiagnoseStep1Body) -> Dict[str, Any]:
+    step1_body = prepare_step1_body_for_compiler(step1_body)
     result_data = run_anonymous_diagnosis(
         supabase,
         step1_body,

--- a/services/anonymous_factory_service.py
+++ b/services/anonymous_factory_service.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, FrozenSet, List, Optional, Tuple
 from schemas.legal_engine import DiagnoseStep1Body
 from services.compiler_core_svc import COMPILER_VERSION, fetch_compiler_candidates
 from services.facility_applicability_eval import evaluate_draft_for_facility
+from services.input_normalizer import normalize_input
 from services.legal_context import _input_to_facility_context
 from services.legal_helpers import get_sector_groups
 from services.legal_rules import get_construction_summary, normalize_sector_db, risk_level
@@ -80,16 +81,66 @@ def _merge_body_input(body: DiagnoseStep1Body) -> Dict[str, Any]:
     return inp
 
 
+def normalize_consumer_inp(body: DiagnoseStep1Body) -> Dict[str, Any]:
+    """
+    Consumer path: merge body fields → normalize_input → legal_context-ready dict.
+
+    Defends legal_context float() parsing from unit strings (e.g. 800kVA, 78억).
+    """
+    base = _merge_body_input(body)
+    sector = body.sector.strip().upper()
+    norm = normalize_input({**base, "sector": sector})
+    merged = {**base, **norm}
+    if sector == "CONSTRUCTION":
+        won = norm.get("contract_amount") or norm.get("construction_amount")
+        if won is not None:
+            merged["contract_amount_eok"] = float(won) / 100_000_000.0
+    return merged
+
+
+def prepare_step1_body_for_compiler(body: DiagnoseStep1Body) -> DiagnoseStep1Body:
+    """Persist normalized values into body.input before compiler step1."""
+    norm = normalize_consumer_inp(body)
+    payload_input = dict(body.input or {})
+    for key, val in norm.items():
+        if key == "sector":
+            continue
+        payload_input[key] = val
+    return body.model_copy(update={"input": payload_input})
+
+
+def _resolve_site_type(sector_raw: str, inp: Dict[str, Any], ctx: Dict[str, Any]) -> str:
+    """Layer 1→2: site_type = facility/building use (not sector enum)."""
+    use = str(
+        inp.get("building_use_type")
+        or inp.get("facility_type")
+        or ctx.get("building_use_code")
+        or ""
+    ).strip()
+    if use:
+        return use
+    if sector_raw == "CONSTRUCTION":
+        return str(ctx.get("construction_type") or "").strip()
+    if sector_raw == "MANUFACTURING":
+        return str(ctx.get("ksic_code") or "").strip()
+    return ""
+
+
 def create_temp_factory(supabase, body: DiagnoseStep1Body) -> str:
     """Consumer input → short-lived factories row (is_active=false)."""
     sector_raw = body.sector.strip().upper()
-    inp = _merge_body_input(body)
+    inp = normalize_consumer_inp(body)
     ctx = _input_to_facility_context(sector_raw, inp)
     ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    building_use_code = str(
+        inp.get("building_use_type") or inp.get("facility_type") or ctx.get("building_use_code") or ""
+    ).strip()
+    site_type = _resolve_site_type(sector_raw, inp, ctx)
+    sector_db = normalize_sector_db(sector_raw)
     row: Dict[str, Any] = {
         "name": f"[ANON]{sector_raw}-{ts}"[:200],
-        "sector": sector_raw,
-        "site_type": sector_raw,
+        "sector": sector_db,
+        "site_type": site_type or None,
         "is_active": False,
         "status_code": "ANON_TEMP",
         "employee_count": int(ctx.get("worker_count") or ctx.get("employee_count") or 0),
@@ -98,17 +149,40 @@ def create_temp_factory(supabase, body: DiagnoseStep1Body) -> str:
             ctx.get("electrical_capacity_kw") or ctx.get("electric_capacity") or 0
         ),
         "transformer_capacity_kva": float(ctx.get("transformer_capacity_kva") or 0),
-        "gas_capacity_m3": float(ctx.get("gas_capacity_m3") or 0),
         "gas_capacity_kg": float(ctx.get("gas_capacity_kg") or 0),
         "construction_amount": float(ctx.get("construction_amount") or 0),
-        "ksic_code": str(ctx.get("ksic_code") or ""),
-        "construction_type": str(ctx.get("construction_type") or ""),
         "subcontractor_worker_count": int(
             ctx.get("subcontractor_worker_count") or ctx.get("subcon_workers") or 0
         ),
         "created_at": datetime.now(timezone.utc).isoformat(),
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }
+    ksic = str(ctx.get("ksic_code") or "").strip()
+    if ksic:
+        row["ksic_code"] = ksic
+    construction_type = str(ctx.get("construction_type") or "").strip()
+    if construction_type:
+        row["construction_type"] = construction_type
+    if building_use_code:
+        row["building_use_code"] = building_use_code
+    floor_count = int(ctx.get("floor_count") or 0)
+    if floor_count > 0:
+        row["floor_count"] = floor_count
+    gas_m3 = float(ctx.get("gas_capacity_m3") or 0)
+    if gas_m3 > 0:
+        row["gas_capacity_m3"] = gas_m3
+    boiler_kw = float(ctx.get("boiler_capacity_kw") or 0)
+    if boiler_kw > 0:
+        row["boiler_capacity_kw"] = boiler_kw
+    elevator_count = int(ctx.get("elevator_count") or 0)
+    if elevator_count > 0:
+        row["elevator_count"] = elevator_count
+    annual_toe = float(ctx.get("annual_energy_toe") or 0)
+    if annual_toe > 0:
+        row["annual_energy_toe"] = annual_toe
+    is_haz = ctx.get("is_hazardous_material")
+    if is_haz is not None:
+        row["is_hazardous_material"] = bool(is_haz)
     res = supabase.table("factories").insert(row).execute()
     if not res.data:
         raise RuntimeError("임시 시설(factories) 생성 실패")
@@ -414,7 +488,7 @@ def run_anonymous_diagnosis(
             "sector는 BUILDING, MANUFACTURING, CONSTRUCTION, SPECIAL_FACILITY 중 하나여야 합니다."
         )
 
-    inp = _merge_body_input(body)
+    inp = normalize_consumer_inp(body)
     facility_ctx = _input_to_facility_context(sector_raw, inp)
     evaluated_at = datetime.now(timezone.utc).isoformat()
 

--- a/services/diagnosis_integrated_svc.py
+++ b/services/diagnosis_integrated_svc.py
@@ -20,9 +20,10 @@ _COMPILER_ALLOWED_SECTORS = frozenset(
 
 def run_step1_via_compiler(supabase, step1_body: DiagnoseStep1Body, allowed_sectors=None) -> Dict[str, Any]:
     """Consumer step1 via Compiler Core temp-factory path (Phase 2)."""
-    from services.anonymous_factory_service import run_anonymous_diagnosis
+    from services.anonymous_factory_service import prepare_step1_body_for_compiler, run_anonymous_diagnosis
 
     sectors = allowed_sectors or _COMPILER_ALLOWED_SECTORS
+    step1_body = prepare_step1_body_for_compiler(step1_body)
     result_data = run_anonymous_diagnosis(supabase, step1_body, sectors)
     return {"status": "success", "data": result_data}
 

--- a/services/input_normalizer.py
+++ b/services/input_normalizer.py
@@ -1,14 +1,15 @@
 """
-services/input_normalizer.py — Input Normalizer v1.1.0
+services/input_normalizer.py — Input Normalizer v1.2.0
 
 역할:
 - 별칭 통합 (workers → worker_count 등)
 - 타입 변환 ("10" → 10)
 - 빈값 처리 ("" → None)
 - 단위 문자 제거 ("500㎡" → 500)
+- 단위 환산 (전력→kW, 금액→원, 거리→m) — 단위 문자열이 있을 때만
 - condition_code 양방향 키 보장 (electric_capacity, FLOOR_AREA 등)
 
-허용: 별칭 통합, 타입 정규화, 빈값 처리
+허용: 별칭 통합, 타입 정규화, 빈값 처리, 명시 단위 환산
 금지: 판단, 추정, 기본값 자동 생성
 """
 from __future__ import annotations
@@ -50,9 +51,110 @@ ALIAS_MAP: Dict[str, str] = {
 # 단위 제거 패턴
 _UNIT_PATTERN = re.compile(r"[\u33a1kKwWm\u00b3\ud1a4\uc5b5\uc6d0\uba85\uce35\ub300]+$")
 
+_POWER_KEYS = frozenset({
+    "electrical_capacity_kw",
+    "electric_capacity",
+    "electric_capacity_kw",
+    "power_capacity",
+    "transformer_capacity_kva",
+})
+_AMOUNT_KEYS = frozenset({
+    "contract_amount",
+    "construction_amount",
+    "contract_amount_won",
+})
+_DISTANCE_KEYS = frozenset({
+    "distance_value",
+    "distance",
+    "distance_m",
+    "TUNNEL_LENGTH",
+})
+
+_EOK = 100_000_000.0
+_MANWON = 10_000.0
+
 
 def _strip_units(value: str) -> str:
     return _UNIT_PATTERN.sub("", value.strip()).strip()
+
+
+def _parse_numeric_prefix(value: str) -> Optional[float]:
+    """문자열 앞부분 숫자만 추출 (단위 환산용)."""
+    cleaned = value.strip().replace(",", "")
+    match = re.match(r"^[-+]?\d+(?:\.\d+)?", cleaned)
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _convert_to_standard_unit(key: str, raw_value: Any) -> Any:
+    """
+    표준 단위 환산.
+    - 전력 → kW (W: /1000, kVA: kW 근사 1:1)
+    - 금액 → 원 (억: ×1억, 만원/만: ×1만, contract_amount_eok 키: ×1억)
+    - 거리 → m (mm: /1000, cm: /100)
+    - 단위 문자열이 없고 이미 숫자면 환산하지 않음 (추정 금지)
+    """
+    if raw_value is None:
+        return raw_value
+
+    if key == "contract_amount_eok":
+        num = float(raw_value) if isinstance(raw_value, (int, float)) else _parse_numeric_prefix(str(raw_value))
+        if num is not None:
+            return num * _EOK
+        return raw_value
+
+    if isinstance(raw_value, (int, float)):
+        return raw_value
+
+    if not isinstance(raw_value, str):
+        return raw_value
+
+    text = raw_value.strip()
+    if not text:
+        return raw_value
+
+    if key in _POWER_KEYS:
+        lower = text.lower().replace(" ", "")
+        num = _parse_numeric_prefix(lower)
+        if num is None:
+            return raw_value
+        if "kva" in lower:
+            return num
+        if "kw" in lower:
+            return num
+        if lower.endswith("w") and not lower.endswith("kw"):
+            return num / 1000.0
+        return raw_value
+
+    if key in _AMOUNT_KEYS:
+        compact = text.replace(" ", "")
+        num = _parse_numeric_prefix(compact)
+        if num is None:
+            return raw_value
+        if "억원" in compact or "억" in compact:
+            return num * _EOK
+        if "만원" in compact or compact.endswith("만"):
+            return num * _MANWON
+        return raw_value
+
+    if key in _DISTANCE_KEYS:
+        lower = text.lower().replace(" ", "")
+        num = _parse_numeric_prefix(lower)
+        if num is None:
+            return raw_value
+        if lower.endswith("mm"):
+            return num / 1000.0
+        if lower.endswith("cm"):
+            return num / 100.0
+        if lower.endswith("m") and not lower.endswith("mm") and not lower.endswith("cm"):
+            return num
+        return raw_value
+
+    return raw_value
 
 
 def _to_number(value: Any) -> Optional[float]:
@@ -122,6 +224,9 @@ def normalize_input(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     for key, value in payload.items():
         normalized_key = ALIAS_MAP.get(key, key)
+        value = _convert_to_standard_unit(key, value)
+        if normalized_key != key:
+            value = _convert_to_standard_unit(normalized_key, value)
         normalized_value = _normalize_value(normalized_key, value)
         if normalized_value is None:
             continue  # 빈값은 포함하지 않음

--- a/services/legal_rules.py
+++ b/services/legal_rules.py
@@ -44,6 +44,8 @@ def normalize_sector_db(sector: str) -> str:
     u = sector.strip().upper()
     if u == "INDUSTRY":
         return "INDUSTRIAL"
+    if u == "MANUFACTURING":
+        return "INDUSTRIAL"
     if u == "SPECIAL":
         return "SPECIAL_FACILITY"
     return u

--- a/tests/test_anonymous_factory_service.py
+++ b/tests/test_anonymous_factory_service.py
@@ -9,6 +9,7 @@ from services.anonymous_factory_service import (
     _compiler_result_to_step1_format,
     cleanup_temp_factory,
     create_temp_factory,
+    normalize_consumer_inp,
     run_anonymous_diagnosis,
 )
 
@@ -51,6 +52,34 @@ def test_compiler_result_to_step1_format_shape():
     assert out["engine_version"] == "v3.0-compiler-core-anonymous"
 
 
+def test_normalize_consumer_inp_unit_strings():
+    body = DiagnoseStep1Body(
+        sector="CONSTRUCTION",
+        input={"electrical_capacity_kw": "800kVA", "construction_amount": "78억"},
+        direct_workers=50,
+        subcon_workers=0,
+        construction_type="건축",
+    )
+    inp = normalize_consumer_inp(body)
+    assert inp["electrical_capacity_kw"] == 800
+    assert inp["contract_amount_eok"] == 78.0
+    assert inp["construction_amount"] == 7_800_000_000
+
+
+def test_normalize_consumer_inp_numeric_regression():
+    body = DiagnoseStep1Body(
+        sector="CONSTRUCTION",
+        contract_amount_eok=78.0,
+        direct_workers=50,
+        subcon_workers=0,
+        construction_type="건축",
+        electrical_capacity_kw=800.0,
+    )
+    inp = normalize_consumer_inp(body)
+    assert inp["contract_amount_eok"] == 78.0
+    assert inp["electrical_capacity_kw"] == 800.0
+
+
 def test_create_temp_factory_maps_building_fields():
     sb = MagicMock()
     sb.table.return_value.insert.return_value.execute.return_value = _FakeResponse(
@@ -71,6 +100,56 @@ def test_create_temp_factory_maps_building_fields():
     assert insert_call["name"].startswith("[ANON]BUILDING")
     assert insert_call["employee_count"] == 25
     assert insert_call["building_area"] == 1200.0
+    assert insert_call["sector"] == "BUILDING"
+    assert insert_call["site_type"] == "사무실"
+    assert insert_call["building_use_code"] == "사무실"
+
+
+def test_create_temp_factory_manufacturing_sector_db_industrial():
+    sb = MagicMock()
+    sb.table.return_value.insert.return_value.execute.return_value = _FakeResponse(
+        [{"id": "fac-mfg-1"}]
+    )
+    body = DiagnoseStep1Body(
+        sector="MANUFACTURING",
+        worker_count=300,
+        employee_count=300,
+        floor_area=5000.0,
+        total_floor_area=5000.0,
+        ksic_major="C10",
+    )
+    create_temp_factory(sb, body)
+    row = sb.table.return_value.insert.call_args[0][0]
+    assert row["sector"] == "INDUSTRIAL"
+    assert row["employee_count"] == 300
+
+
+def test_create_temp_factory_hospital_building_fields():
+    sb = MagicMock()
+    sb.table.return_value.insert.return_value.execute.return_value = _FakeResponse(
+        [{"id": "fac-uuid-2"}]
+    )
+    body = DiagnoseStep1Body(
+        sector="BUILDING",
+        building_use_type="병원",
+        floor_count=5,
+        floor_area=3000.0,
+        total_floor_area=3000.0,
+        worker_count=50,
+        employee_count=50,
+        has_hazardous_material=True,
+        gas_capacity_m3=120.0,
+    )
+    fid = create_temp_factory(sb, body)
+    assert fid == "fac-uuid-2"
+    row = sb.table.return_value.insert.call_args[0][0]
+    assert row["site_type"] == "병원"
+    assert row["building_use_code"] == "병원"
+    assert row["floor_count"] == 5
+    assert row["employee_count"] == 50
+    assert row["gas_capacity_m3"] == 120.0
+    assert row["is_hazardous_material"] is True
+    assert row["site_type"] != row["sector"]
 
 
 def test_cleanup_temp_factory_deletes_rows():

--- a/tests/test_legal_rules.py
+++ b/tests/test_legal_rules.py
@@ -25,6 +25,8 @@ def test_resolve_obligation_and_risk_level():
     assert risk_level(6, 0) == "MEDIUM"
     assert risk_level(2, 0) == "LOW"
     assert normalize_sector_db(" building ") == "BUILDING"
+    assert normalize_sector_db("MANUFACTURING") == "INDUSTRIAL"
+    assert normalize_sector_db("INDUSTRY") == "INDUSTRIAL"
 
 
 def test_evaluate_facility_conditions_db_filters():


### PR DESCRIPTION
# 법령진단 입력 표준화 (STEP 1/A/B')

## 배경

법령진단 6개 레이어 표준화 중 입력 경계(Layer 1→2) 표준화.
조사 → 문제점 파악 → 표준 정의 → 실행 → 검증 순서로 진행.

## 변경 내용

### STEP 1: 소비자 입력 → factories 저장
- `create_temp_factory`에 building_use_code, floor_count 등 누락 필드 추가
- site_type 의미 왜곡 수정 (sector 코드 → 용도 문자열)

### STEP A: normalizer 소비자 경로 연결
- `normalize_consumer_inp`, `prepare_step1_body_for_compiler` 추가
- 단위 문자열 입력("800kVA", "78억")이 파이프라인을 깨뜨리지 않게 방어
- legal_context 앞에 normalize 배치

### STEP B': sector 어휘 표준 + 세 섹터 입력 필드 표준화
- `normalize_sector_db`에 MANUFACTURING→INDUSTRIAL 매핑 추가
- 저장 경계(create_temp_factory)에서만 변환: DB=INDUSTRIAL / 엔진=MANUFACTURING
- 세 섹터 공통 누락 필드 INSERT 추가

## 표준 확정

```
sector 어휘:
  입력/저장/DB: BUILDING / INDUSTRIAL / CONSTRUCTION / SPECIAL_FACILITY
  엔진/룰: BUILDING / MANUFACTURING / CONSTRUCTION / SPECIAL_FACILITY
  변환 지점: 저장 시 normalize_sector_db (단일 경계)

입력 필드: ctx가 만드는 필드는 factories에 모두 저장 (유실 없음)
```

## 검증

| 섹터 | INSERT | sector(DB) | MATCH | 결과 |
|------|--------|-----------|-------|------|
| BUILDING 병원 5층 50명 | OK | BUILDING | 114 | 정상 |
| INDUSTRIAL 제조 300명 | OK | INDUSTRIAL | 113 | 정상 (이전 ERROR→해소) |
| CONSTRUCTION 78억 120명 | OK | CONSTRUCTION | 114 | 정상 |

- 핵심 성과: INDUSTRIAL 진단 factories_sector_check ERROR 해소
- 회귀 없음: BUILDING/CONSTRUCTION MATCH 이전과 동일
- 테스트 12/12 통과
- **facility_applicability_eval.py 미변경 (엔진 보존)**

## 범위 외 (관찰 기록)

- 단위 정합 매칭: draft_slot 단위 정규화 필요 → 엔진/배치 영역, 별도 과제
- 출력 표준화(STEP 3/4/5): obligations flat, evidence, partial 통합 → 후속

## 문서
- docs/LEGAL_DIAGNOSIS_LAYER_STANDARD.md (표준 정의)
- docs/LEGAL_DIAGNOSIS_LAYER_SURVEY.md, LAYER_PROBLEMS.md (조사/문제)
- docs/ENGINE_CONNECTION_AUDIT.md, ENGINE_PIPELINE_MAP.md (감사)