### PR TITLE
feat: Layer 3→4 연결 표준화 (fallback 형태 일치)

### DIFF
--- a/services/anonymous_factory_service.py
+++ b/services/anonymous_factory_service.py
@@ -44,6 +44,51 @@ _TASK_TYPE_TO_BUCKET: Dict[str, Tuple[str, str]] = {
     "PRESERVATION": ("action", "조치"),
 }
 
+_ACTION_TO_TASK: Dict[str, str] = {
+    "INSPECT_FAMILY": "INSPECTION_TASK_CANDIDATE",
+    "REPORT_FAMILY": "REPORT_TASK_CANDIDATE",
+    "TRAINING_FAMILY": "TRAINING_TASK_CANDIDATE",
+    "APPOINT_FAMILY": "APPOINTMENT_TASK_CANDIDATE",
+    "RECORD_FAMILY": "RECORD_TASK_CANDIDATE",
+    "PRESERVE_FAMILY": "PRESERVE_TASK_CANDIDATE",
+    "INSTALL_FAMILY": "INSTALL_TASK_CANDIDATE",
+    "MANAGE_FAMILY": "MANAGE_TASK_CANDIDATE",
+    "NOTIFY_FAMILY": "NOTIFY_TASK_CANDIDATE",
+    "MEASURE_FAMILY": "MEASURE_TASK_CANDIDATE",
+    "VERIFY_FAMILY": "VERIFY_TASK_CANDIDATE",
+    "DESIGNATE_FAMILY": "DESIGNATE_TASK_CANDIDATE",
+    "EXECUTE_FAMILY": "EXECUTE_TASK_CANDIDATE",
+    "PUBLISH_FAMILY": "PUBLISH_TASK_CANDIDATE",
+    "CONSULT_FAMILY": "CONSULT_TASK_CANDIDATE",
+    "PROVIDE_FAMILY": "PROVIDE_TASK_CANDIDATE",
+    "REPAIR_FAMILY": "REPAIR_TASK_CANDIDATE",
+    "REPLACE_FAMILY": "REPLACE_TASK_CANDIDATE",
+    "CANCEL_FAMILY": "CANCEL_TASK_CANDIDATE",
+    "CORRECT_FAMILY": "CORRECT_TASK_CANDIDATE",
+    "PREVENT_FAMILY": "PREVENT_TASK_CANDIDATE",
+    "PROCESS_FAMILY": "PROCESS_TASK_CANDIDATE",
+    "REQUEST_FAMILY": "REQUEST_TASK_CANDIDATE",
+}
+
+_OBLIGATION_FAMILIES = frozenset(
+    {
+        "MANDATORY_FAMILY",
+        "PERMISSIVE_FAMILY",
+        "MANDATORY_ITEM_FAMILY",
+        "PROHIBITION_FAMILY",
+    }
+)
+
+
+def _bucket_for_task_type(task_type: str) -> Tuple[str, str]:
+    tt = (task_type or "ACTION").upper()
+    if tt in _TASK_TYPE_TO_BUCKET:
+        return _TASK_TYPE_TO_BUCKET[tt]
+    for prefix, bucket in _TASK_TYPE_TO_BUCKET.items():
+        if tt.startswith(prefix):
+            return bucket
+    return ("action", "조치")
+
 
 def _merge_body_input(body: DiagnoseStep1Body) -> Dict[str, Any]:
     inp = dict(body.input or {})
@@ -304,19 +349,144 @@ def cleanup_temp_factory(supabase, factory_id: str) -> None:
         log.warning("factories cleanup failed factory_id=%s: %s", fid, exc)
 
 
-def _task_to_rule_row(task: Dict[str, Any], sector_raw: str) -> Dict[str, Any]:
-    task_type = (task.get("task_type") or "ACTION").upper()
-    bucket, cat_label = _TASK_TYPE_TO_BUCKET.get(task_type, ("action", "조치"))
-    title = f"{task.get('task_type', '')}: {task.get('source_action_family', '')}".strip(": ")
-    fam = (task.get("obligation_family") or "").strip()
-    obl_type = task_type if task_type in ("APPOINT", "INSPECT", "REPORT", "NOTIFY", "ACTION") else "ACTION"
-    flags = {
+def _load_draft_fallback_context(
+    supabase,
+    draft_ids: List[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Batch-read executable_draft, law_master, draft_slot for fallback rule rows."""
+    unique = [
+        d
+        for d in dict.fromkeys(str(x).strip() for x in draft_ids if x and str(x).strip())
+    ]
+    if not unique or supabase is None:
+        return {}
+
+    ctx: Dict[str, Dict[str, Any]] = {d: {} for d in unique}
+    articles_by_draft: Dict[str, str] = {}
+
+    for i in range(0, len(unique), _INSERT_CHUNK):
+        chunk = unique[i : i + _INSERT_CHUNK]
+        try:
+            res = (
+                supabase.table("executable_draft")
+                .select("id, article_id, rule_candidate_id, part_id")
+                .in_("id", chunk)
+                .execute()
+            )
+        except Exception as exc:
+            log.warning("executable_draft batch fetch failed: %s", exc)
+            continue
+        for row in res.data or []:
+            did = str(row.get("id") or "")
+            if not did:
+                continue
+            ctx[did]["article_id"] = row.get("article_id")
+            ctx[did]["rule_candidate_id"] = row.get("rule_candidate_id")
+            ctx[did]["part_id"] = row.get("part_id")
+            if row.get("article_id"):
+                articles_by_draft[did] = str(row["article_id"])
+
+    article_meta: Dict[str, Dict[str, Any]] = {}
+    article_ids = list(dict.fromkeys(articles_by_draft.values()))
+    for i in range(0, len(article_ids), _INSERT_CHUNK):
+        chunk = article_ids[i : i + _INSERT_CHUNK]
+        try:
+            res = (
+                supabase.table("law_article")
+                .select("id, law_id, article_no, article_title")
+                .in_("id", chunk)
+                .execute()
+            )
+        except Exception as exc:
+            log.warning("law_article batch fetch failed: %s", exc)
+            continue
+        for row in res.data or []:
+            article_meta[str(row["id"])] = row
+
+    law_ids = list(
+        dict.fromkeys(str(r.get("law_id")) for r in article_meta.values() if r.get("law_id"))
+    )
+    law_names: Dict[str, str] = {}
+    for i in range(0, len(law_ids), _INSERT_CHUNK):
+        chunk = law_ids[i : i + _INSERT_CHUNK]
+        try:
+            res = (
+                supabase.table("law_master")
+                .select("id, law_name")
+                .in_("id", chunk)
+                .execute()
+            )
+        except Exception as exc:
+            log.warning("law_master batch fetch failed: %s", exc)
+            continue
+        for row in res.data or []:
+            law_names[str(row["id"])] = (row.get("law_name") or "").strip()
+
+    for did, aid in articles_by_draft.items():
+        am = article_meta.get(aid) or {}
+        law_name = law_names.get(str(am.get("law_id") or ""), "")
+        art_no = am.get("article_no") or ""
+        art_title = (am.get("article_title") or "").strip()
+        ctx[did]["law_name"] = law_name
+        ctx[did]["law_article"] = str(art_no) if art_no else ""
+        ctx[did]["description"] = art_title or law_name
+
+    slots_by_draft: Dict[str, List[Dict[str, Any]]] = {}
+    for i in range(0, len(unique), _INSERT_CHUNK):
+        chunk = unique[i : i + _INSERT_CHUNK]
+        try:
+            res = (
+                supabase.table("draft_slot")
+                .select("draft_id, section, family_name, raw_token")
+                .in_("draft_id", chunk)
+                .eq("section", "THEN_ACTION")
+                .execute()
+            )
+        except Exception as exc:
+            log.warning("draft_slot batch fetch failed: %s", exc)
+            continue
+        for row in res.data or []:
+            did = str(row.get("draft_id") or "")
+            if did:
+                slots_by_draft.setdefault(did, []).append(row)
+
+    for did, slots in slots_by_draft.items():
+        obligation = ""
+        for slot in slots:
+            fam = slot.get("family_name") or ""
+            if fam in _OBLIGATION_FAMILIES:
+                obligation = fam
+        for slot in slots:
+            fam = slot.get("family_name") or ""
+            if fam not in _ACTION_TO_TASK:
+                continue
+            ctx[did]["task_type"] = _ACTION_TO_TASK[fam]
+            ctx[did]["source_action_family"] = fam
+            token = (slot.get("raw_token") or "").strip()
+            if token:
+                ctx[did]["description"] = token
+            break
+        ctx[did]["obligation_family"] = obligation
+
+    return ctx
+
+
+def _rule_row_flags(bucket: str) -> Dict[str, bool]:
+    return {
         "appointment_required": bucket == "appointment",
         "inspection_required": bucket == "inspection",
         "action_required": bucket == "action",
         "report_required": bucket == "report",
         "notify_required": bucket == "notify",
     }
+
+
+def _task_to_rule_row(task: Dict[str, Any], sector_raw: str) -> Dict[str, Any]:
+    task_type = (task.get("task_type") or "ACTION").upper()
+    bucket, cat_label = _bucket_for_task_type(task_type)
+    title = f"{task.get('task_type', '')}: {task.get('source_action_family', '')}".strip(": ")
+    fam = (task.get("obligation_family") or "").strip()
+    obl_type = task_type if task_type in ("APPOINT", "INSPECT", "REPORT", "NOTIFY", "ACTION") else "ACTION"
     return {
         "rule_id": str(task.get("id") or ""),
         "rule_type": task_type,
@@ -331,7 +501,41 @@ def _task_to_rule_row(task: Dict[str, Any], sector_raw: str) -> Dict[str, Any]:
         "diagnosis_stage": 1,
         "schedule_type": "ON_DEMAND",
         "penalty_summary": "",
-        **flags,
+        **_rule_row_flags(bucket),
+        "_bucket": bucket,
+    }
+
+
+def _applicability_to_rule_row(
+    applicability: Dict[str, Any],
+    sector_raw: str,
+    draft_ctx: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    draft_id = str(applicability.get("draft_id") or "")
+    meta = draft_ctx.get(draft_id) or {}
+    task_type = (meta.get("task_type") or "ACTION").upper()
+    bucket, cat_label = _bucket_for_task_type(task_type)
+    source_fam = meta.get("source_action_family") or ""
+    fam = (meta.get("obligation_family") or "").strip()
+    law_name = (meta.get("law_name") or "").strip() or fam or "Compiler Candidate"
+    desc = (meta.get("description") or "").strip()
+    title = f"{task_type}: {source_fam}".strip(": ") if source_fam else (desc or law_name)
+    obl_type = task_type if task_type in ("APPOINT", "INSPECT", "REPORT", "NOTIFY", "ACTION") else "ACTION"
+    return {
+        "rule_id": str(applicability.get("id") or draft_id),
+        "rule_type": task_type,
+        "law_name": law_name,
+        "law_article": meta.get("law_article") or "",
+        "obligation_summary": title or fam or "의무 후보",
+        "remarks": title,
+        "description": desc or title or fam,
+        "category": cat_label,
+        "obligation_type": obl_type,
+        "sector": sector_raw,
+        "diagnosis_stage": 1,
+        "schedule_type": "ON_DEMAND",
+        "penalty_summary": "",
+        **_rule_row_flags(bucket),
         "_bucket": bucket,
     }
 
@@ -342,6 +546,7 @@ def _compiler_result_to_step1_format(
     sector_raw: str,
     facility_ctx: Dict[str, Any],
     evaluated_at: str,
+    supabase=None,
 ) -> Dict[str, Any]:
     """Compiler Core / DiagnosisService-shaped dict → legacy step1 result_data."""
     sector_db = normalize_sector_db(sector_raw)
@@ -351,23 +556,11 @@ def _compiler_result_to_step1_format(
 
     rules_from_tasks = [_task_to_rule_row(t, sector_raw) for t in tasks]
     if not rules_from_tasks and applicability:
-        for a in applicability:
-            status = a.get("applicability_status") or ""
-            rules_from_tasks.append(
-                {
-                    "rule_id": str(a.get("id") or a.get("draft_id") or ""),
-                    "law_name": "Applicability Candidate",
-                    "law_article": "",
-                    "obligation_summary": f"Applicability: {status}",
-                    "remarks": f"draft={a.get('draft_id')}",
-                    "description": f"Applicability: {status}",
-                    "category": "조치",
-                    "obligation_type": "ACTION",
-                    "sector": sector_raw,
-                    "action_required": True,
-                    "_bucket": "action",
-                }
-            )
+        draft_ids = [str(a.get("draft_id") or "") for a in applicability]
+        draft_ctx = _load_draft_fallback_context(supabase, draft_ids)
+        rules_from_tasks = [
+            _applicability_to_rule_row(a, sector_raw, draft_ctx) for a in applicability
+        ]
 
     triggered: Dict[str, List] = {
         "appointment": [],
@@ -502,6 +695,7 @@ def run_anonymous_diagnosis(
             sector_raw=sector_raw,
             facility_ctx=facility_ctx,
             evaluated_at=evaluated_at,
+            supabase=supabase,
         )
     finally:
         if factory_id:

--- a/tests/test_anonymous_factory_service.py
+++ b/tests/test_anonymous_factory_service.py
@@ -7,6 +7,7 @@ import pytest
 from schemas.legal_engine import DiagnoseStep1Body
 from services.anonymous_factory_service import (
     _compiler_result_to_step1_format,
+    _load_draft_fallback_context,
     cleanup_temp_factory,
     create_temp_factory,
     normalize_consumer_inp,
@@ -196,3 +197,115 @@ def test_run_anonymous_diagnosis_invalid_sector():
     body = DiagnoseStep1Body(sector="INVALID")
     with pytest.raises(ValueError):
         run_anonymous_diagnosis(MagicMock(), body, frozenset({"BUILDING"}))
+
+
+def _mock_supabase_for_fallback(draft_id: str, article_id: str, law_id: str):
+    sb = MagicMock()
+
+    def table(name):
+        t = MagicMock()
+        if name == "executable_draft":
+            t.select.return_value.in_.return_value.execute.return_value = _FakeResponse(
+                [{"id": draft_id, "article_id": article_id, "rule_candidate_id": "rc1", "part_id": "p1"}]
+            )
+        elif name == "law_article":
+            t.select.return_value.in_.return_value.execute.return_value = _FakeResponse(
+                [{"id": article_id, "law_id": law_id, "article_no": "12", "article_title": "시설 설치"}]
+            )
+        elif name == "law_master":
+            t.select.return_value.in_.return_value.execute.return_value = _FakeResponse(
+                [{"id": law_id, "law_name": "산업안전보건법"}]
+            )
+        elif name == "draft_slot":
+            chain = t.select.return_value.in_.return_value
+            chain.eq.return_value.execute.return_value = _FakeResponse(
+                [
+                    {
+                        "draft_id": draft_id,
+                        "section": "THEN_ACTION",
+                        "family_name": "APPOINT_FAMILY",
+                        "raw_token": "안전관리자 선임",
+                    }
+                ]
+            )
+        return t
+
+    sb.table.side_effect = table
+    return sb
+
+
+def test_compiler_result_to_step1_format_fallback_enriched():
+    draft_id = "d-fallback-1"
+    compiler = {
+        "compiler_version": "v3.0-deterministic",
+        "warning": "All results are CANDIDATES.",
+        "applicability_candidates": [
+            {"id": "a1", "applicability_status": "MATCH_CANDIDATE", "draft_id": draft_id}
+        ],
+        "task_candidates": [],
+        "schedule_candidates": [],
+    }
+    sb = _mock_supabase_for_fallback(draft_id, "art-1", "law-1")
+    out = _compiler_result_to_step1_format(
+        compiler,
+        sector_raw="BUILDING",
+        facility_ctx={"worker_count": 50, "total_floor_area": 3000},
+        evaluated_at="2026-06-08T00:00:00+00:00",
+        supabase=sb,
+    )
+    assert len(out["rules_table"]) == 1
+    row = out["rules_table"][0]
+    assert row["law_name"] == "산업안전보건법"
+    assert row["rule_type"] == "APPOINTMENT_TASK_CANDIDATE"
+    assert row["category"] == "선임"
+    assert row["appointment_required"] is True
+    assert row["action_required"] is False
+    assert row["diagnosis_stage"] == 1
+    assert row["schedule_type"] == "ON_DEMAND"
+
+
+def test_load_draft_fallback_context_empty_ids():
+    assert _load_draft_fallback_context(MagicMock(), []) == {}
+    assert _load_draft_fallback_context(None, ["d1"]) == {}
+
+
+def test_fallback_rule_row_matches_task_row_structure():
+    task_compiler = {
+        "compiler_version": "v3.0-deterministic",
+        "applicability_candidates": [],
+        "task_candidates": [
+            {
+                "id": "t1",
+                "task_type": "APPOINTMENT",
+                "source_action_family": "APPOINT_FAMILY",
+                "obligation_family": "산업안전보건법",
+            }
+        ],
+        "schedule_candidates": [],
+    }
+    task_out = _compiler_result_to_step1_format(
+        task_compiler,
+        sector_raw="BUILDING",
+        facility_ctx={},
+        evaluated_at="2026-06-08T00:00:00+00:00",
+    )
+    draft_id = "d-struct-1"
+    fallback_compiler = {
+        "compiler_version": "v3.0-deterministic",
+        "applicability_candidates": [
+            {"id": "a1", "applicability_status": "MATCH_CANDIDATE", "draft_id": draft_id}
+        ],
+        "task_candidates": [],
+        "schedule_candidates": [],
+    }
+    sb = _mock_supabase_for_fallback(draft_id, "art-1", "law-1")
+    fallback_out = _compiler_result_to_step1_format(
+        fallback_compiler,
+        sector_raw="BUILDING",
+        facility_ctx={},
+        evaluated_at="2026-06-08T00:00:00+00:00",
+        supabase=sb,
+    )
+    task_keys = set(task_out["rules_table"][0].keys())
+    fallback_keys = set(fallback_out["rules_table"][0].keys())
+    assert task_keys == fallback_keys


### PR DESCRIPTION
# Layer 3→4 연결 표준화 (fallback 형태 일치)

## 문제

익명 진단은 task_candidates가 없어 fallback을 타는데,
rules_table row에 law_name/rule_type/bucket이 비어 task 경로와 형태가 달랐음.

## 해결 (services/anonymous_factory_service.py)

- `_load_draft_fallback_context` — draft_id IN [...] 배치 조회 (N+1 방지)
  executable_draft → law_article → law_master (law_name, article_no)
  draft_slot (THEN_ACTION) → ACTION_TO_TASK → rule_type
- `_applicability_to_rule_row` — _task_to_rule_row와 동일 필드 구조
- `_bucket_for_task_type` — task/fallback 공통 bucket 매핑
- run_anonymous_diagnosis — supabase를 _compiler_result_to_step1_format에 전달

facility_applicability_eval.py / executable_draft 데이터 미수정 (READ only).

## 검증

| 항목 | 결과 |
|------|------|
| law_name 채움 | 244/244 (이전 "Applicability Candidate") |
| rule_type/category | 채워짐 (APPOINTMENT → 선임) |
| MATCH 회귀 | 114 유지 (POSSIBLE 130 + MATCH 114) |
| task ↔ fallback 필드 구조 | 동일 |
| 테스트 | 12 passed |
| CONSTRUCTION | 정상 완료 |

핵심: MATCH 건수 불변 = 평가 안 바꾸고 형태만 채움.

## 범위
- 연결 표준화 (형태 일치)만. 값 정밀도(단위)는 범위 밖 (엔진 v2 과제).
- 엔진 평가 로직 미변경.

## 문서
- docs/WORKORDER_LAYER34_FALLBACK.md
- docs/LEGAL_DIAGNOSIS_LAYER_STANDARD.md (표준3)