### PR TITLE
feat: Layer 4→5 연결 표준화 (obligations 형태 일치)

### DIFF
--- a/routers/diagnosis_transform.py
+++ b/routers/diagnosis_transform.py
@@ -137,6 +137,51 @@ def _normalize_category(raw: str) -> str:
     return CATEGORY_MAP.get((raw or "").lower().strip(), "서류")
 
 
+def _evidence_text_list(item: dict) -> list[str]:
+    """TAI 내부 evidence: text 배열만 (Check 계약 변환은 별도 어댑터)."""
+    ev = item.get("evidence") or item.get("legal_basis") or []
+    if isinstance(ev, str):
+        return [ev] if ev.strip() else []
+    if not isinstance(ev, list):
+        return []
+    return [str(x) for x in ev if x]
+
+
+def _obligation_from_item(item: dict, *, group_category: str = "") -> dict:
+    cat = _normalize_category(group_category or item.get("category") or item.get("type") or "")
+    title = (
+        item.get("obligation_summary")
+        or item.get("title")
+        or item.get("name")
+        or item.get("item")
+    )
+    law_name = str(item.get("law_name") or "").strip()
+    rule_type = str(item.get("rule_type") or "").strip()
+    evidence = _evidence_text_list(item)
+    if not evidence and law_name:
+        law_art = str(item.get("law_article") or "").strip()
+        ref = " ".join(p for p in (law_name, law_art) if p)
+        if ref:
+            evidence = [ref]
+    return {
+        "id": str(item.get("rule_id") or item.get("id") or uuid.uuid4()),
+        "category": cat,
+        "title": str(title or "의무사항"),
+        "law_name": law_name,
+        "rule_type": rule_type,
+        "risk_level": (item.get("risk_level") or item.get("severity") or "MEDIUM").upper(),
+        "description": str(item.get("description") or item.get("remarks") or item.get("detail") or ""),
+        "evidence": evidence,
+        "action_url": item.get("action_url"),
+        "auto_schedulable": bool(item.get("auto_schedulable") or item.get("schedulable") or False),
+    }
+
+
+def _is_obligation_wrapper(obj: dict) -> bool:
+    items = obj.get("items")
+    return isinstance(items, list) and bool(items)
+
+
 def _extract_obligations(rd: dict) -> list[dict]:
     raw_list: list = []
     for key in ("obligations", "key_obligations", "mandatory_obligations", "critical_obligations"):
@@ -162,26 +207,31 @@ def _extract_obligations(rd: dict) -> list[dict]:
         if isinstance(obj, str):
             result.append({
                 "id": str(uuid.uuid4()), "category": "서류",
-                "title": obj, "risk_level": "MEDIUM",
+                "title": obj, "law_name": "", "rule_type": "",
+                "risk_level": "MEDIUM",
                 "description": obj, "evidence": [],
             })
             continue
         if not isinstance(obj, dict):
             continue
-        cat = _normalize_category(obj.get("category") or obj.get("type") or "")
-        ev = obj.get("evidence") or obj.get("legal_basis") or []
-        if isinstance(ev, str):
-            ev = [ev]
-        result.append({
-            "id": str(obj.get("id") or uuid.uuid4()),
-            "category": cat,
-            "title": str(obj.get("title") or obj.get("name") or obj.get("item") or "의무사항"),
-            "risk_level": (obj.get("risk_level") or obj.get("severity") or "MEDIUM").upper(),
-            "description": str(obj.get("description") or obj.get("detail") or ""),
-            "evidence": list(ev),
-            "action_url": obj.get("action_url"),
-            "auto_schedulable": bool(obj.get("auto_schedulable") or obj.get("schedulable") or False),
-        })
+        if _is_obligation_wrapper(obj):
+            group_cat = str(obj.get("category") or obj.get("label") or "")
+            for item in obj["items"]:
+                if isinstance(item, str):
+                    result.append({
+                        "id": str(uuid.uuid4()),
+                        "category": _normalize_category(group_cat),
+                        "title": item,
+                        "law_name": "",
+                        "rule_type": "",
+                        "risk_level": "MEDIUM",
+                        "description": item,
+                        "evidence": [],
+                    })
+                elif isinstance(item, dict):
+                    result.append(_obligation_from_item(item, group_category=group_cat))
+            continue
+        result.append(_obligation_from_item(obj))
 
     result.sort(key=lambda o: RISK_ORDER.get(o.get("risk_level", ""), 0), reverse=True)
     return result

--- a/tests/test_diagnosis_transform.py
+++ b/tests/test_diagnosis_transform.py
@@ -1,0 +1,102 @@
+"""Tests for diagnosis_transform (BE-08) — Layer 4→5 obligations standardization."""
+
+from routers.diagnosis_transform import _extract_obligations
+
+
+def _sample_rule_row(**overrides):
+    base = {
+        "rule_id": "r1",
+        "rule_type": "APPOINTMENT_TASK_CANDIDATE",
+        "law_name": "산업안전보건법",
+        "law_article": "제17조",
+        "obligation_summary": "안전관리자 선임",
+        "description": "안전관리자 선임",
+        "category": "선임",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_extract_obligations_expands_wrapper_items():
+    rd = {
+        "obligations": [
+            {
+                "category": "appointment",
+                "label": "선임",
+                "items": [
+                    _sample_rule_row(rule_id="r1"),
+                    _sample_rule_row(
+                        rule_id="r2",
+                        obligation_summary="보건관리자 선임",
+                        law_name="화재의 예방 및 안전관리에 관한 법률",
+                    ),
+                ],
+            },
+            {
+                "category": "inspection",
+                "label": "점검",
+                "items": [_sample_rule_row(rule_id="r3", rule_type="INSPECTION_TASK_CANDIDATE", obligation_summary="정기점검")],
+            },
+        ],
+        "applicable_count": 3,
+    }
+    out = _extract_obligations(rd)
+    assert len(out) == 3
+    assert all("items" not in o for o in out)
+    assert out[0]["title"] == "안전관리자 선임"
+    assert out[0]["law_name"] == "산업안전보건법"
+    assert out[0]["rule_type"] == "APPOINTMENT_TASK_CANDIDATE"
+    assert out[0]["category"] == "선임"
+    assert out[0]["evidence"] == ["산업안전보건법 제17조"]
+    assert out[2]["title"] == "정기점검"
+    assert out[2]["category"] == "점검"
+
+
+def test_extract_obligations_wrapper_item_count_preserved():
+    items = [_sample_rule_row(rule_id=f"r{i}") for i in range(5)]
+    rd = {"obligations": [{"category": "action", "label": "조치", "items": items}]}
+    out = _extract_obligations(rd)
+    assert len(out) == len(items)
+
+
+def test_extract_obligations_flat_dict_backward_compat():
+    rd = {
+        "obligations": [
+            {
+                "id": "flat-1",
+                "category": "report",
+                "title": "신고 의무",
+                "description": "상세",
+                "evidence": ["법령 근거"],
+                "risk_level": "HIGH",
+            }
+        ]
+    }
+    out = _extract_obligations(rd)
+    assert len(out) == 1
+    assert out[0]["title"] == "신고 의무"
+    assert out[0]["evidence"] == ["법령 근거"]
+    assert out[0]["category"] == "신고"
+
+
+def test_extract_obligations_key_obligations_strings_when_no_wrapper():
+    rd = {"key_obligations": ["교육 실시", "점검 실시"]}
+    out = _extract_obligations(rd)
+    assert len(out) == 2
+    assert out[0]["title"] == "교육 실시"
+    assert out[0]["evidence"] == []
+
+
+def test_extract_obligations_no_generic_title_for_wrapper_items():
+    rd = {
+        "obligations": [
+            {
+                "category": "appointment",
+                "label": "선임",
+                "items": [_sample_rule_row()],
+            }
+        ]
+    }
+    out = _extract_obligations(rd)
+    assert out[0]["title"] != "의무사항"
+    assert out[0]["title"] == "안전관리자 선임"


### PR DESCRIPTION
# Layer 4→5 연결 표준화 (obligations 형태 일치)

## 문제

검증엔진은 obligations를 `{category, label, items:[rule_row...]}` wrapper로 주는데,
Transform `_extract_obligations`가 wrapper를 flat 1건으로 처리
→ title="의무사항", evidence=[], items[] 전부 무시.

## 해결 (routers/diagnosis_transform.py)

- `_is_obligation_wrapper` — items[]가 있는 group 감지
- `_obligation_from_item` — item → flat obligation 매핑
  - title ← obligation_summary / title
  - law_name, rule_type, category (group.category)
  - evidence ← TAI 내부 text 배열 (law_name+law_article fallback)
- 기존 flat dict / string 경로 유지 (backward compat)

Check 계약 변환·facility_applicability_eval.py 미수정.

## 검증

| 항목 | 결과 |
|------|------|
| flat 전개 | wrapper 244 → flat 244 (1:1) |
| title/law_name | generic 0건, 빈 law_name 0건 |
| applicable_count | 244 유지 (형태만) |
| MATCH_CANDIDATE | 114 유지 |
| 테스트 | 17 passed (transform 5 + anonymous 12) |

핵심: 건수 불변 = 평가 안 바꾸고 형태만 전개.

## 범위
- TAI 내부 obligations 형태 일치만. Check 엔진 계약 변환은 범위 밖(별도 어댑터).
- 엔진 평가 로직 미변경.

## 문서
- docs/WORKORDER_LAYER45_OBLIGATIONS.md