### PR TITLE
feat: Layer 5→6 출력 표준화 (partial 통합 + source 필드)

### DIFF
--- a/routers/anonymous_diagnosis.py
+++ b/routers/anonymous_diagnosis.py
@@ -26,6 +26,7 @@ from services.anonymous_factory_service import (
     prepare_step1_body_for_compiler,
     run_anonymous_diagnosis,
 )
+from services.diagnosis_helpers import _build_standard_output
 from services.legal_helpers import _now_iso
 from services.legal_rules import normalize_sector_db
 
@@ -87,19 +88,7 @@ def _run_step1_via_service(supabase, step1_body: DiagnoseStep1Body) -> Dict[str,
 
 
 def _partial_from_full(full: Dict[str, Any]) -> Dict[str, Any]:
-    rules = full.get("rules") or []
-    return {
-        "risk_level": full.get("risk_level"),
-        "summary": full.get("summary"),
-        "applicable_count": full.get("applicable_count"),
-        "sector": full.get("sector"),
-        "evaluated_at": full.get("evaluated_at"),
-        "key_obligations": (full.get("key_obligations") or [])[:6],
-        "rules_preview": rules[:12],
-        "law_badges": (full.get("law_badges") or [])[:18],
-        "construction_summary": full.get("construction_summary"),
-        "message": "일부 결과만 표시됩니다. 전체 법령·의무 목록은 로그인 후 확인할 수 있습니다.",
-    }
+    return _build_standard_output(full)
 
 
 SCALE_PRESETS: Dict[str, Dict[str, Any]] = {

--- a/services/anonymous_factory_service.py
+++ b/services/anonymous_factory_service.py
@@ -17,6 +17,7 @@ from services.facility_applicability_eval import evaluate_draft_for_facility
 from services.input_normalizer import normalize_input
 from services.legal_context import _input_to_facility_context
 from services.legal_helpers import get_sector_groups
+from services.diagnosis_helpers import SOURCE_DIAGNOSIS
 from services.legal_rules import get_construction_summary, normalize_sector_db, risk_level
 
 log = logging.getLogger(__name__)
@@ -501,6 +502,7 @@ def _task_to_rule_row(task: Dict[str, Any], sector_raw: str) -> Dict[str, Any]:
         "diagnosis_stage": 1,
         "schedule_type": "ON_DEMAND",
         "penalty_summary": "",
+        "source": SOURCE_DIAGNOSIS,
         **_rule_row_flags(bucket),
         "_bucket": bucket,
     }
@@ -535,6 +537,7 @@ def _applicability_to_rule_row(
         "diagnosis_stage": 1,
         "schedule_type": "ON_DEMAND",
         "penalty_summary": "",
+        "source": SOURCE_DIAGNOSIS,
         **_rule_row_flags(bucket),
         "_bucket": bucket,
     }
@@ -590,11 +593,20 @@ def _compiler_result_to_step1_format(
     appointment_n = len(triggered["appointment"])
     risk = risk_level(total_applicable, appointment_n)
 
-    key_obligations: List[str] = []
+    key_obligations: List[Dict[str, Any]] = []
+    seen_key_titles: set[str] = set()
     for x in rules_from_tasks[:20]:
         t = (x.get("obligation_summary") or x.get("remarks") or "").strip()
-        if t and t not in key_obligations:
-            key_obligations.append(t)
+        if t and t not in seen_key_titles:
+            seen_key_titles.add(t)
+            key_obligations.append(
+                {
+                    "title": t,
+                    "law_name": (x.get("law_name") or "").strip(),
+                    "rule_type": (x.get("rule_type") or "").strip(),
+                    "source": SOURCE_DIAGNOSIS,
+                }
+            )
 
     obligations: List[Dict[str, Any]] = []
     for key, label in [("appointment", "선임"), ("inspection", "점검"), ("action", "조치")]:

--- a/services/diagnosis_helpers.py
+++ b/services/diagnosis_helpers.py
@@ -1,6 +1,16 @@
 import hashlib
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Optional
+
+SOURCE_DIAGNOSIS = "DIAGNOSIS"
+
+_KEY_OBLIGATIONS_LIMIT = 6
+_LAW_BADGES_LIMIT = 18
+_RULES_PREVIEW_LIMIT = 12
+
+_PARTIAL_MESSAGE = (
+    "일부 결과만 표시됩니다. 전체 법령·의무 목록은 로그인 후 확인할 수 있습니다."
+)
 
 
 def _now() -> str:
@@ -24,12 +34,61 @@ def _auto_tier(
     return user_tier or "INDUSTRY_V2"
 
 
-def _build_partial(full: dict) -> dict:
+def _ensure_source_on_rule_row(row: Any) -> dict:
+    if not isinstance(row, dict):
+        return {"source": SOURCE_DIAGNOSIS}
+    out = dict(row)
+    out.setdefault("source", SOURCE_DIAGNOSIS)
+    return out
+
+
+def _normalize_key_obligation_item(item: Any) -> dict:
+    if isinstance(item, dict):
+        out = dict(item)
+        out.setdefault("source", SOURCE_DIAGNOSIS)
+        if not (out.get("title") or "").strip():
+            out["title"] = str(
+                out.get("obligation_summary") or out.get("name") or out.get("description") or ""
+            ).strip()
+        return out
+    text = str(item).strip()
+    return {"title": text, "source": SOURCE_DIAGNOSIS}
+
+
+def _source_rule_rows(rows: Any) -> list[dict]:
+    if not isinstance(rows, list):
+        return []
+    return [_ensure_source_on_rule_row(r) for r in rows if isinstance(r, dict)]
+
+
+def _build_standard_output(full: dict) -> dict:
+    """Layer 5→6 표준 partial 출력 (익명/통합 공통)."""
+    rules_raw = full.get("rules_table") or full.get("rules") or []
+    rules_table = _source_rule_rows(rules_raw)
+    rules_preview = rules_table[:_RULES_PREVIEW_LIMIT]
+    key_obl = [
+        _normalize_key_obligation_item(x) for x in (full.get("key_obligations") or [])
+    ][:_KEY_OBLIGATIONS_LIMIT]
+
     return {
         "risk_level": full.get("risk_level"),
         "summary": full.get("summary"),
         "applicable_count": full.get("applicable_count"),
         "sector": full.get("sector"),
-        "key_obligations": (full.get("key_obligations") or [])[:6],
-        "law_badges": (full.get("law_badges") or [])[:18],
+        "evaluated_at": full.get("evaluated_at"),
+        "engine_version": full.get("engine_version"),
+        "key_obligations": key_obl,
+        "rules_table": rules_preview,
+        "rules_preview": rules_preview,
+        "law_badges": (full.get("law_badges") or [])[:_LAW_BADGES_LIMIT],
+        "appointment_required": _source_rule_rows(full.get("appointment_required")),
+        "inspection_required": _source_rule_rows(full.get("inspection_required")),
+        "action_required": _source_rule_rows(full.get("action_required")),
+        "report_required": _source_rule_rows(full.get("report_required")),
+        "construction_summary": full.get("construction_summary"),
+        "message": _PARTIAL_MESSAGE,
     }
+
+
+def _build_partial(full: dict) -> dict:
+    return _build_standard_output(full)

--- a/tests/test_anonymous_factory_service.py
+++ b/tests/test_anonymous_factory_service.py
@@ -46,6 +46,8 @@ def test_compiler_result_to_step1_format_shape():
     assert out["rules_table"]
     assert out["rules"] == out["rules_table"]
     assert out["key_obligations"]
+    assert out["key_obligations"][0]["source"] == "DIAGNOSIS"
+    assert out["rules_table"][0]["source"] == "DIAGNOSIS"
     assert out["law_badges"]
     assert out["applicable_count"] >= 1
     assert out["summary"]["total"] >= 1

--- a/tests/test_diagnosis_helpers.py
+++ b/tests/test_diagnosis_helpers.py
@@ -1,4 +1,5 @@
 from services import diagnosis_helpers as h
+from services.diagnosis_helpers import SOURCE_DIAGNOSIS, _build_standard_output
 
 
 def test_now_iso_has_utc_offset():
@@ -31,3 +32,43 @@ def test_build_partial_truncates_lists():
     part = h._build_partial(full)
     assert len(part["key_obligations"]) == 6
     assert len(part["law_badges"]) == 18
+    assert part["key_obligations"][0]["source"] == SOURCE_DIAGNOSIS
+
+
+def test_build_standard_output_unifies_anonymous_and_integrated_fields():
+    full = {
+        "risk_level": "MEDIUM",
+        "summary": {"total": 244},
+        "applicable_count": 244,
+        "sector": "BUILDING",
+        "evaluated_at": "2026-06-08T00:00:00+00:00",
+        "engine_version": "v3.0-compiler-core-anonymous",
+        "key_obligations": [
+            {"title": "안전관리자 선임", "law_name": "산업안전보건법", "source": SOURCE_DIAGNOSIS},
+            "점검 실시",
+        ],
+        "rules_table": [
+            {"rule_id": "r1", "law_name": "산업안전보건법", "obligation_summary": "선임"},
+            {"rule_id": "r2", "law_name": "화재예방법", "obligation_summary": "점검"},
+        ],
+        "law_badges": ["산업안전보건법", "화재예방법"],
+        "appointment_required": [{"rule_id": "r1", "law_name": "산업안전보건법"}],
+        "construction_summary": {"tip": "건설 요약"},
+    }
+    out = _build_standard_output(full)
+    assert out["evaluated_at"] == "2026-06-08T00:00:00+00:00"
+    assert out["engine_version"] == "v3.0-compiler-core-anonymous"
+    assert out["rules_preview"] == out["rules_table"]
+    assert len(out["rules_table"]) == 2
+    assert all(r.get("source") == SOURCE_DIAGNOSIS for r in out["rules_table"])
+    assert out["key_obligations"][0]["title"] == "안전관리자 선임"
+    assert out["key_obligations"][1]["title"] == "점검 실시"
+    assert all(k.get("source") == SOURCE_DIAGNOSIS for k in out["key_obligations"])
+    assert out["appointment_required"][0]["source"] == SOURCE_DIAGNOSIS
+    assert out["construction_summary"] == {"tip": "건설 요약"}
+    assert out["message"]
+
+
+def test_build_partial_equals_build_standard_output():
+    full = {"sector": "BUILDING", "applicable_count": 5, "key_obligations": ["a"]}
+    assert h._build_partial(full) == _build_standard_output(full)

--- a/tests/test_diagnosis_integrated_current.py
+++ b/tests/test_diagnosis_integrated_current.py
@@ -17,20 +17,29 @@ def test_auto_tier_industry_uses_user_tier_or_default():
 
 
 def test_build_partial_includes_core_fields_and_truncation():
+    from services.diagnosis_helpers import SOURCE_DIAGNOSIS, _build_partial
+
     full = {
         "risk_level": "HIGH",
         "summary": {"total": 10},
         "applicable_count": 10,
         "sector": "BUILDING",
+        "evaluated_at": "2026-06-08T00:00:00+00:00",
+        "engine_version": "v3.0-compiler-core-anonymous",
         "key_obligations": list(range(10)),
         "law_badges": list(range(30)),
+        "rules_table": [{"rule_id": "r1", "law_name": "법A"}],
     }
-    partial = diagnosis_integrated._build_partial(full)
+    partial = _build_partial(full)
     assert partial["risk_level"] == "HIGH"
     assert partial["summary"]["total"] == 10
     assert partial["applicable_count"] == 10
+    assert partial["evaluated_at"] == "2026-06-08T00:00:00+00:00"
+    assert partial["rules_preview"]
     assert len(partial["key_obligations"]) == 6
     assert len(partial["law_badges"]) == 18
+    assert partial["key_obligations"][0]["source"] == SOURCE_DIAGNOSIS
+    assert partial["rules_table"][0]["source"] == SOURCE_DIAGNOSIS
 
 
 def test_price_table_contains_expected_core_tiers():


### PR DESCRIPTION
# Layer 5→6 출력 표준화 (partial 통합 + source 필드)

## 문제

`_partial_from_full`(익명)과 `_build_partial`(통합)이 같은 full_result라도
다른 필드를 반환 → 경로에 따라 출력 형태가 다름.

## 해결

### 작업 1: 출력 함수 통합 (services/diagnosis_helpers.py)
- `_build_standard_output(full_result)` 추가
- `_build_partial` → 위임, `_partial_from_full` → 동일 함수 호출
- evaluated_at / rules_table / engine_version / appointment·inspection·action·report_required / construction_summary·message 통일

### 작업 2: source 필드
- rules_table 각 row: `source: "DIAGNOSIS"`
- key_obligations: {title, law_name, rule_type, source} 구조
- partial 출력의 문자열 legacy 항목도 dict 정규화하며 source 보장
- MANUAL 주입은 다음 단계 (지금 안 함)

## 검증

| 항목 | 결과 |
|------|------|
| applicable_count | 244 유지 |
| MATCH_CANDIDATE | 114 유지 |
| rules_table source | 244/244 DIAGNOSIS |
| key_obligations source | 8/8 DIAGNOSIS |
| partial 일관성 | evaluated_at, rules_preview 익명/통합 동일 |
| 테스트 | 29 passed |

## 범위
- 출력 함수 통합 + source 필드(전부 DIAGNOSIS)까지.
- SaaS MANUAL 공정 주입은 다음 단계. Check 엔진 연결은 그 후.
- 엔진 평가 로직 미변경.

## 문서
- docs/WORKORDER_LAYER56_OUTPUT.md