### PR TITLE
WO-ADAPTER-LAW-ENRICHMENT-001: Trigger 경로 obligations에 법령정보 보강

### DIFF
--- a/services/obligation_adapter_service.py
+++ b/services/obligation_adapter_service.py
@@ -1,4 +1,4 @@
-"""Obligation Adapter Service — v1.2.0 (CURSOR-TASK-002)
+"""Obligation Adapter Service — v1.3.0 (WO-ADAPTER-LAW-ENRICHMENT-001)
 
 B안 어댑터: V4 verdict → result_data.obligations 스키마 변환.
 
@@ -22,6 +22,9 @@ v1.1.0: build_result_data() 추가 — factory_diagnosis_results.result_data 조
 v1.2.0: build_obligations_from_trigger_candidates() 추가 (CURSOR-TASK-002)
         Trigger 기반 semantic_clause 후보 → result_data.obligations 변환.
         기존 V4 흐름 무수정. FastAPI import 없음.
+v1.3.0: Trigger 경로 obligation에 law_name/law_article/evidence 보강
+        (WO-ADAPTER-LAW-ENRICHMENT-001). 값은 Glue(_resolve_law_for_candidates)가
+        채운 candidate 필드를 그대로 사용 — 어댑터는 조합만, 새 판단/법령 생성 없음.
 """
 from __future__ import annotations
 
@@ -63,7 +66,7 @@ def _category_from_action_type(action_type: str) -> str:
 
 
 def _category_from_trigger(trigger_code: str) -> str:
-    """trigger_code 타입 �리 → category. 예: WORK:CONFINED_SPACE → '점검'."""
+    """trigger_code 타입 머리 → category. 예: WORK:CONFINED_SPACE → '점검'."""
     family = trigger_code.split(":", 1)[0] if ":" in trigger_code else ""
     return _TRIGGER_TO_CATEGORY.get(family, "서류")
 
@@ -104,6 +107,8 @@ def _build_obligation_from_candidate(candidate: Dict[str, Any]) -> Dict[str, Any
 
     semantic_clause 후보를 정제레이어 호환 포맷으로 변환.
     새 판단 없음. candidate에 있는 데이터만 사용.
+    law_name/law_article/evidence는 Glue(_resolve_law_for_candidates)가 채운
+    값을 그대로 사용 — 새 법령 생성 아님, 조합만.
     """
     trigger_code = candidate.get("trigger_code") or ""
     action_text = str(candidate.get("action_text") or "").strip()
@@ -113,12 +118,17 @@ def _build_obligation_from_candidate(candidate: Dict[str, Any]) -> Dict[str, Any
     # 제목: action_text 앞 50자
     title = action_text[:50] if action_text else "의무사항"
 
+    # 법령정보 (Glue가 보강한 값. 없으면 빈 값 — 새 생성 아님)
+    law_name = str(candidate.get("law_name") or "").strip()
+    law_article = str(candidate.get("law_article") or "").strip()
+    legal_basis = " ".join(p for p in (law_name, law_article) if p)
+
     return {
         "id": candidate.get("clause_id") or candidate.get("source_article_id") or "",
         "category": category,
         "title": title,
-        "law_name": "",           # semantic_clause에 법령명 없음 → 빈 문자열
-        "law_article": "",        # 이후 JOIN으로 보강 가능
+        "law_name": law_name,          # Glue 보강
+        "law_article": law_article,    # Glue 보강
         "rule_type": _CONTENT_TYPE_TO_RULE_TYPE.get(
             candidate.get("content_type") or "", "OBLIGATION"
         ),
@@ -127,7 +137,7 @@ def _build_obligation_from_candidate(candidate: Dict[str, Any]) -> Dict[str, Any
         "condition": condition_text or None,
         "trigger_code": trigger_code,
         "confidence": candidate.get("confidence") or "MEDIUM",
-        "evidence": [],
+        "evidence": [legal_basis] if legal_basis else [],   # Glue 보강
         "required_count": None,
         "auto_schedulable": False,
     }

--- a/services/obligation_instance_adapter.py
+++ b/services/obligation_instance_adapter.py
@@ -5,6 +5,11 @@
   - FastAPI import 없음 (순수 서비스).
   - obligation_adapter_service 무수정 호출.
   - status='ACTIVE'는 Engine이 이미 정한 것 (새 판단 아님).
+
+v1.1.0 (WO-ADAPTER-LAW-ENRICHMENT-001):
+  - 누락 law_name/law_article 보강 추가 (source_article_id → law_article → law_master JOIN).
+  - 새 판단/법령 생성 아님. DB에 이미 있는 법령식별 값을 후보에 채울 뿐.
+  - 실패 시 빈 값 유지(graceful) — 파이프라인 무중단.
 """
 from __future__ import annotations
 
@@ -33,6 +38,19 @@ def _confidence_band(value: Any) -> str:
     return "LOW"
 
 
+def _format_law_article(article_no: Any, article_sub_no: Any) -> str:
+    """law_article 표기 문자열. 예: 139 → '제139조', (24, 2) → '제24조의2'.
+
+    새 데이터 생성 아님 — law_article의 표준 표기일 뿐.
+    """
+    if article_no in (None, ""):
+        return ""
+    base = f"제{article_no}조"
+    if article_sub_no not in (None, "", 0):
+        return f"{base}의{article_sub_no}"
+    return base
+
+
 def obligation_instances_to_candidates(
     rows: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
@@ -43,6 +61,8 @@ def obligation_instances_to_candidates(
       trigger_type, trigger_l2, executor_text,
       condition_text, action_text, content_type,
       applicable_sectors, confidence
+
+    law_name/law_article는 빈 값으로 두고 _resolve_law_for_candidates()가 보강.
     """
     candidates: List[Dict[str, Any]] = []
     for r in rows:
@@ -59,8 +79,76 @@ def obligation_instances_to_candidates(
             "content_type": r.get("content_type"),
             "sector": sectors[0] if sectors else None,
             "confidence": _confidence_band(r.get("confidence")),
+            "law_name": "",      # _resolve_law_for_candidates()가 보강
+            "law_article": "",   # _resolve_law_for_candidates()가 보강
         })
     return candidates
+
+
+def _resolve_law_for_candidates(
+    supabase,
+    candidates: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """source_article_id → law_article → law_master JOIN으로 law_name/law_article 보강.
+
+    원칙:
+      - 새 판단/법령 생성 없음. DB에 이미 있는 식별값을 후보에 채울 뿐.
+      - 실패 시 후보를 그대로 반환(빈 값 유지) — 파이프라인 무중단.
+    """
+    try:
+        article_ids = list({
+            str(c["source_article_id"])
+            for c in candidates
+            if c.get("source_article_id")
+        })
+        if not article_ids:
+            return candidates
+
+        # source_article_id → law_article
+        article_map: Dict[str, Dict[str, Any]] = {}
+        for i in range(0, len(article_ids), 200):
+            chunk = article_ids[i:i + 200]
+            res = (
+                supabase.table("law_article")
+                .select("id, law_id, article_no, article_sub_no")
+                .in_("id", chunk)
+                .execute()
+            )
+            for a in res.data or []:
+                article_map[str(a["id"])] = a
+
+        # law_id → law_master
+        law_ids = list({
+            str(a["law_id"])
+            for a in article_map.values()
+            if a.get("law_id")
+        })
+        law_map: Dict[str, Dict[str, Any]] = {}
+        for i in range(0, len(law_ids), 200):
+            chunk = law_ids[i:i + 200]
+            res = (
+                supabase.table("law_master")
+                .select("id, law_name")
+                .in_("id", chunk)
+                .execute()
+            )
+            for lm in res.data or []:
+                law_map[str(lm["id"])] = lm
+
+        # 후보 보강
+        for c in candidates:
+            art = article_map.get(str(c.get("source_article_id") or ""))
+            if not art:
+                continue
+            law = law_map.get(str(art.get("law_id") or ""))
+            c["law_name"] = str((law or {}).get("law_name") or "")
+            c["law_article"] = _format_law_article(
+                art.get("article_no"), art.get("article_sub_no")
+            )
+        return candidates
+    except Exception as exc:
+        log.warning("law enrichment failed, keep empty: %s", exc)
+        return candidates
 
 
 def _flatten_embedded_join(row: Dict[str, Any]) -> Dict[str, Any]:
@@ -183,9 +271,12 @@ def obligation_instances_to_trigger_candidates(
     """obligation_instance → build_obligations_from_trigger_candidates() 입력.
 
     변환만 수행. 새 판단/필터/법령/Trigger 없음.
+    law_name/law_article는 _resolve_law_for_candidates()가 DB JOIN으로 보강.
     """
     if supabase is None:
         from db.supabase_client import get_supabase
         supabase = get_supabase()
     rows = fetch_obligation_instance_rows(supabase, factory_id)
-    return obligation_instances_to_candidates(rows)
+    candidates = obligation_instances_to_candidates(rows)
+    candidates = _resolve_law_for_candidates(supabase, candidates)
+    return candidates


### PR DESCRIPTION
## 목적
Trigger 경로(`POST /obligation-adapter/from-instances/{factory_id}`) 출력 obligations의 비어있던 `law_name`·`law_article`·`evidence`를 채운다.

## 배경 (규명 결과)
WO-CHECKENGINE-INTERNAL-ANALYSIS-001에서 확인: Trigger 경로 Adapter는 `law_name=""`, `law_article=""`, `evidence=[]`로 내보내고 있었음(주석 "이후 JOIN으로 보강 가능"이 미수행 상태). 기존 HTML/SaaS 출력이 가장 먼저 요구하는 법령명·조문이 운영 response에 비어 있던 병목.

## 변경
**`services/obligation_instance_adapter.py` (Glue, DB 레이어)**
- `_format_law_article()` 추가 — article_no/sub → "제139조"/"제24조의2" 표기.
- `_resolve_law_for_candidates(supabase, candidates)` 추가 — `source_article_id → law_article → law_master` 배치 JOIN으로 후보에 law_name/law_article 보강. **try/except로 실패 시 빈 값 유지(graceful, 파이프라인 무중단).**
- `obligation_instances_to_candidates()` — law_name/law_article 빈 키 기본 추가.
- `obligation_instances_to_trigger_candidates()` — 보강 호출 추가.

**`services/obligation_adapter_service.py` (Adapter, 순수)**
- `_build_obligation_from_candidate()` — Glue가 채운 law_name/law_article로 `evidence=[법령근거]` 조립.

## 경계 / 금지 준수
- ✅ Check Engine / Applicability / 정제레이어 무수정
- ✅ 새 Trace Engine 미구현 · 6W 미생성 · Evidence 추론 없음 · 법령 분석 없음
- ✅ obligation 수 / verdict / category / description 무변경
- ✅ 새 판단·새 법령 생성 0 — DB에 이미 있는 식별값을 채울 뿐
- Adapter는 순수 유지(DB 호출은 Glue에서만)

## 검증 (실데이터)
factory `e9c56af6` batch `WO-MVP-001-LIVE` 171건: `source_article_id → law_article → law_master` = **171/171 (100%) 해결**. 표본 포맷:
```
제139조  | 산업안전보건기준에 관한 규칙 제139조
제24조   | 산업안전보건법 시행령 제24조
제197조  | 산업안전보건법 시행규칙 제197조
```

## 배포 주의
main 머지 시 Railway 자동배포. 머지 전 리뷰 권장. 보강 실패는 graceful(빈 값)이라 진단 파이프라인은 무중단.

🤖 Generated with Claude
